### PR TITLE
feat(cli): judge worker completion from result.md and exit code

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -74,6 +74,10 @@ path = "tests-rs/session_contract_test.rs"
 name = "workspace_migrate_gallery"
 path = "tests-rs/workspace_migrate_gallery.rs"
 
+[[test]]
+name = "team_profile_contract"
+path = "tests-rs/team_profile_contract.rs"
+
 # Windows only
 [target.'cfg(not(windows))'.dependencies]
 [target.'cfg(windows)'.dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -86,6 +86,10 @@ path = "tests-rs/instruction_pack_contract.rs"
 name = "prompt_bundle_contract"
 path = "tests-rs/prompt_bundle_contract.rs"
 
+[[test]]
+name = "worker_artifact_contract"
+path = "tests-rs/worker_artifact_contract.rs"
+
 # Windows only
 [target.'cfg(not(windows))'.dependencies]
 [target.'cfg(windows)'.dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -78,6 +78,10 @@ path = "tests-rs/workspace_migrate_gallery.rs"
 name = "team_profile_contract"
 path = "tests-rs/team_profile_contract.rs"
 
+[[test]]
+name = "instruction_pack_contract"
+path = "tests-rs/instruction_pack_contract.rs"
+
 # Windows only
 [target.'cfg(not(windows))'.dependencies]
 [target.'cfg(windows)'.dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -82,6 +82,10 @@ path = "tests-rs/team_profile_contract.rs"
 name = "instruction_pack_contract"
 path = "tests-rs/instruction_pack_contract.rs"
 
+[[test]]
+name = "prompt_bundle_contract"
+path = "tests-rs/prompt_bundle_contract.rs"
+
 # Windows only
 [target.'cfg(not(windows))'.dependencies]
 [target.'cfg(windows)'.dependencies]

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,0 +1,62 @@
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let profiles = manifest_dir
+        .join("..")
+        .join("winsmux-core")
+        .join("agents")
+        .join("profiles");
+    println!("cargo:rerun-if-changed={}", profiles.display());
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let dest = out_dir.join("embedded_profiles.rs");
+    let mut files = Vec::new();
+    collect_files(&profiles, &profiles, &mut files);
+    files.sort();
+    let mut out = fs::File::create(&dest).expect("create embedded_profiles.rs");
+    writeln!(
+        out,
+        "fn embedded_profile(rel: &str) -> Option<&'static str> {{"
+    )
+    .unwrap();
+    writeln!(out, "    let normalized = rel.replace('\\\\', \"/\");").unwrap();
+    writeln!(out, "    match normalized.as_str() {{").unwrap();
+    for rel in &files {
+        let abs = profiles
+            .join(rel)
+            .canonicalize()
+            .expect("canonicalize profile");
+        let rel_lit = rel.replace('\\', "/");
+        writeln!(
+            out,
+            "        \"{}\" => Some(include_str!(r\"{}\")),",
+            rel_lit,
+            abs.display()
+        )
+        .unwrap();
+        println!("cargo:rerun-if-changed={}", abs.display());
+    }
+    writeln!(out, "        _ => None,").unwrap();
+    writeln!(out, "    }}").unwrap();
+    writeln!(out, "}}").unwrap();
+}
+
+fn collect_files(root: &Path, dir: &Path, files: &mut Vec<String>) {
+    for entry in fs::read_dir(dir).expect("read profiles") {
+        let entry = entry.expect("profile entry");
+        let path = entry.path();
+        if path.is_dir() {
+            collect_files(root, &path, files);
+            continue;
+        }
+        let rel = path
+            .strip_prefix(root)
+            .expect("profile prefix")
+            .to_string_lossy()
+            .replace('\\', "/");
+        files.push(rel);
+    }
+}

--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -136,6 +136,7 @@ OPERATOR COMMANDS:
     meta-plan               Draft a read-only multi-role planning packet
     workspace-plan          Validate and print a declarative workspace plan
     workspace-migrate       List, preview, apply, or roll back shipped workspace presets as JSON
+    team-profile            Validate, resolve, save, or classify Team Profile slot assignments as JSON
     provider-capabilities   Inspect the provider capability registry contract
     skills                  Print agent-readable command skill contracts
     machine-contract        Print the hook and agent machine contract JSON
@@ -457,6 +458,7 @@ fn commands_text() -> &'static str {
   meta-plan                 - Draft a read-only multi-role planning packet
   workspace-plan            - Validate and print a declarative workspace plan
   workspace-migrate         - List, preview, apply, or roll back shipped workspace presets as JSON
+  team-profile              - Validate, resolve, save, or classify Team Profile slot assignments as JSON
   rust-canary               - Print the Rust default-on canary gate JSON
   manual-checklist          - Print the versioned manual validation checklist gate
   legacy-compat-gate        - Print the legacy compatibility removal inventory gate

--- a/core/src/cli.rs
+++ b/core/src/cli.rs
@@ -137,6 +137,7 @@ OPERATOR COMMANDS:
     workspace-plan          Validate and print a declarative workspace plan
     workspace-migrate       List, preview, apply, or roll back shipped workspace presets as JSON
     team-profile            Validate, resolve, save, or classify Team Profile slot assignments as JSON
+    worker-artifact          Judge worker completion from a dispatch output file and exit code as JSON
     provider-capabilities   Inspect the provider capability registry contract
     skills                  Print agent-readable command skill contracts
     machine-contract        Print the hook and agent machine contract JSON
@@ -459,6 +460,7 @@ fn commands_text() -> &'static str {
   workspace-plan            - Validate and print a declarative workspace plan
   workspace-migrate         - List, preview, apply, or roll back shipped workspace presets as JSON
   team-profile              - Validate, resolve, save, or classify Team Profile slot assignments as JSON
+  worker-artifact            - Judge worker completion from a dispatch output file and exit code as JSON
   rust-canary               - Print the Rust default-on canary gate JSON
   manual-checklist          - Print the versioned manual validation checklist gate
   legacy-compat-gate        - Print the legacy compatibility removal inventory gate

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -2207,7 +2207,10 @@ pub fn run_remote(terminal: &mut Terminal<CrosstermBackend<crate::platform::Psmu
                                     selection_changed = true;
                                     // Suppress text key events that VS Code's ConPTY
                                     // injects after a right-click copy action.
-                                    paste_suppress_until = Some(Instant::now() + Duration::from_secs(2));
+                                    #[cfg(windows)]
+                                    {
+                                        paste_suppress_until = Some(Instant::now() + Duration::from_secs(2));
+                                    }
                                 } else {
                                     // No selection, no TUI — paste from clipboard (pwsh-style)
                                     rsel_start = None;

--- a/core/src/instruction_pack.rs
+++ b/core/src/instruction_pack.rs
@@ -341,7 +341,8 @@ pub(crate) fn tracked_instruction_hashes() -> Result<Vec<(String, String, String
                 format!("Tracked instruction file '{rel}' is missing."),
             )]
         })?;
-        let actual = format!("{:x}", Sha256::digest(&bytes));
+        let normalized = String::from_utf8_lossy(&bytes).replace("\r\n", "\n");
+        let actual = format!("{:x}", Sha256::digest(normalized.as_bytes()));
         rows.push((rel.to_string(), expected.to_string(), actual));
     }
     Ok(rows)

--- a/core/src/instruction_pack.rs
+++ b/core/src/instruction_pack.rs
@@ -1,0 +1,696 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env, fs,
+    io::{self, ErrorKind},
+    path::{Path, PathBuf},
+};
+
+use serde::Serialize;
+use serde_json::{json, Value as JsonValue};
+use serde_yaml::Value;
+use sha2::{Digest, Sha256};
+
+use crate::workspace_recipe::parse_workspace_yaml;
+
+const REGISTRY_REL: &str = "winsmux-core/agents/profiles";
+const REGISTRY_FILE: &str = "registry.yaml";
+const INSTRUCTION_FILES: [&str; 3] = [
+    "winsmux-core/agents/AGENTS.md",
+    ".claude/CLAUDE.md",
+    "GEMINI.md",
+];
+const TRACKED_INSTRUCTION_SHA256: [(&str, &str); 3] = [
+    (
+        "winsmux-core/agents/AGENTS.md",
+        "ebc5696f845388b5dc3c275537161e52db0a85cf5761f98dd851da8125c1a4a3",
+    ),
+    (
+        ".claude/CLAUDE.md",
+        "b12b74fc890a6ab468fe458f2f40c39d3e44d3e5921b216b25de711d8e9ded90",
+    ),
+    (
+        "GEMINI.md",
+        "f2037a0e37b9557b756865827734ee2af40a8bc2187eb73a67bf5b9e730edffa",
+    ),
+];
+const SECRET_PATTERN: &str = r"(?i)\b(gho_[A-Za-z0-9_]+|ghp_[A-Za-z0-9_]+|sk-[A-Za-z0-9_-]+)\b|(?:^|\s)(?:GITHUB_TOKEN|GH_TOKEN|API_KEY)\s*=|/Users/|/home/[A-Za-z]|[A-Za-z]:\\Users\\";
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct InstructionIssue {
+    pub field: String,
+    pub code: String,
+    pub severity: String,
+    pub remediation: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct ComposedPack {
+    #[serde(rename = "template-ids")]
+    pub template_ids: Vec<String>,
+    pub digest_sha256: String,
+    pub body: String,
+    pub a1: A1Criteria,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct A1Criteria {
+    pub worker: Vec<String>,
+    pub operator: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+struct Registry {
+    a1: A1Criteria,
+    base: String,
+    providers: BTreeMap<String, String>,
+    roles: BTreeMap<String, String>,
+    lifecycles: BTreeMap<String, String>,
+    task_classes: BTreeMap<String, String>,
+    models: BTreeMap<String, ModelTemplate>,
+    dynamic_providers: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug)]
+struct ModelTemplate {
+    provider: String,
+    template: String,
+}
+
+pub(crate) fn profiles_root() -> io::Result<PathBuf> {
+    if let Ok(configured) = env::var("WINSMUX_PROFILES_DIR") {
+        let path = PathBuf::from(configured);
+        if path.join(REGISTRY_FILE).is_file() {
+            return Ok(path);
+        }
+    }
+    if let Ok(manifest) = env::var("CARGO_MANIFEST_DIR") {
+        let path = Path::new(&manifest).join("..").join(REGISTRY_REL);
+        if path.join(REGISTRY_FILE).is_file() {
+            return Ok(path);
+        }
+    }
+    if let Ok(exe) = env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            for ancestor in dir.ancestors() {
+                let path = ancestor.join(REGISTRY_REL);
+                if path.join(REGISTRY_FILE).is_file() {
+                    return Ok(path);
+                }
+            }
+        }
+    }
+    let cwd = env::current_dir()?;
+    for ancestor in cwd.ancestors() {
+        let path = ancestor.join(REGISTRY_REL);
+        if path.join(REGISTRY_FILE).is_file() {
+            return Ok(path);
+        }
+    }
+    Err(io::Error::new(
+        ErrorKind::NotFound,
+        "instruction-pack registry.yaml was not found.",
+    ))
+}
+
+pub(crate) fn lint_registry() -> Result<JsonValue, Vec<InstructionIssue>> {
+    let root = profiles_root().map_err(|error| {
+        vec![issue(
+            "registry",
+            "missing_registry",
+            error.to_string(),
+        )]
+    })?;
+    let registry = load_registry(&root)?;
+    let mut issues = Vec::new();
+    lint_path(&root, &registry.base, "base", &mut issues);
+    for (id, template) in &registry.providers {
+        lint_path(&root, template, &format!("provider/{id}"), &mut issues);
+    }
+    for (id, template) in &registry.roles {
+        lint_path(&root, template, &format!("role/{id}"), &mut issues);
+    }
+    for (id, template) in &registry.lifecycles {
+        lint_path(&root, template, &format!("lifecycle/{id}"), &mut issues);
+    }
+    for (id, template) in &registry.task_classes {
+        lint_path(&root, template, &format!("task-class/{id}"), &mut issues);
+    }
+    let mut templates = BTreeSet::new();
+    for (id, model) in &registry.models {
+        if !templates.insert((model.provider.clone(), model.template.clone()))
+            && registry
+                .models
+                .values()
+                .filter(|other| other.template == model.template)
+                .count()
+                > 1
+            && model.provider != "openrouter"
+        {
+            // Duplicate exact paths are allowed only when intentional; unique IDs are the hard rule.
+        }
+        let _ = id;
+        lint_path(&root, &model.template, &format!("model/{}", id), &mut issues);
+        if model.provider.is_empty() || !registry.providers.contains_key(&model.provider) {
+            issues.push(issue(
+                &format!("model/{id}"),
+                "unknown_provider_mapping",
+                format!("Model '{id}' maps to unknown provider '{}'.", model.provider),
+            ));
+        }
+    }
+    for (provider, template) in &registry.dynamic_providers {
+        lint_path(
+            &root,
+            template,
+            &format!("dynamic/{provider}"),
+            &mut issues,
+        );
+    }
+    if registry.a1.worker.is_empty() || registry.a1.operator.is_empty() {
+        issues.push(issue(
+            "a1",
+            "missing_a1",
+            "Registry A1 worker and operator lists are required.",
+        ));
+    }
+    if issues.is_empty() {
+        Ok(json!({
+            "schema_version": 1,
+            "ok": true,
+            "registry_id": "official-instruction-packs-v1",
+            "models": registry.models.len(),
+        }))
+    } else {
+        Err(issues)
+    }
+}
+
+pub(crate) fn compose_pack(
+    provider: &str,
+    model: &str,
+    role: &str,
+    lifecycle: &str,
+    task_classes: &[String],
+) -> Result<ComposedPack, Vec<InstructionIssue>> {
+    let root = profiles_root().map_err(|error| {
+        vec![issue("registry", "missing_registry", error.to_string())]
+    })?;
+    let registry = load_registry(&root)?;
+    let mut template_ids = Vec::new();
+    let mut parts = Vec::new();
+    push_layer(&root, &registry.base, "base", &mut template_ids, &mut parts)?;
+    let provider_template = registry.providers.get(provider).ok_or_else(|| {
+        vec![issue(
+            "provider",
+            "missing_instruction_pack",
+            format!("No provider template for '{provider}'."),
+        )]
+    })?;
+    push_layer(
+        &root,
+        provider_template,
+        &format!("provider/{provider}"),
+        &mut template_ids,
+        &mut parts,
+    )?;
+    let (model_template, model_template_id) = resolve_model_template(&registry, provider, model)?;
+    push_layer(
+        &root,
+        &model_template,
+        &model_template_id,
+        &mut template_ids,
+        &mut parts,
+    )?;
+    let role_template = registry.roles.get(role).ok_or_else(|| {
+        vec![issue(
+            "role-profile",
+            "missing_instruction_pack",
+            format!("No role template for '{role}'."),
+        )]
+    })?;
+    push_layer(
+        &root,
+        role_template,
+        &format!("role/{role}"),
+        &mut template_ids,
+        &mut parts,
+    )?;
+    let lifecycle_template = registry.lifecycles.get(lifecycle).ok_or_else(|| {
+        vec![issue(
+            "lifecycle",
+            "missing_instruction_pack",
+            format!("No lifecycle template for '{lifecycle}'."),
+        )]
+    })?;
+    push_layer(
+        &root,
+        lifecycle_template,
+        &format!("lifecycle/{lifecycle}"),
+        &mut template_ids,
+        &mut parts,
+    )?;
+    if task_classes.is_empty() {
+        return Err(vec![issue(
+            "task-classes",
+            "missing_instruction_pack",
+            "task-classes must be a non-empty list of registered templates.",
+        )]);
+    }
+    for class in task_classes {
+        let template = registry.task_classes.get(class).ok_or_else(|| {
+            vec![issue(
+                "task-classes",
+                "missing_instruction_pack",
+                format!("No task-class template for '{class}'."),
+            )]
+        })?;
+        push_layer(
+            &root,
+            template,
+            &format!("task/{class}"),
+            &mut template_ids,
+            &mut parts,
+        )?;
+    }
+    let body = format!("{}\n", parts.join("\n\n"));
+    let digest = format!("{:x}", Sha256::digest(body.as_bytes()));
+    Ok(ComposedPack {
+        template_ids,
+        digest_sha256: digest,
+        body,
+        a1: registry.a1,
+    })
+}
+
+pub(crate) fn compose_json(
+    provider: &str,
+    model: &str,
+    role: &str,
+    lifecycle: &str,
+    task_classes: &[String],
+) -> Result<JsonValue, Vec<InstructionIssue>> {
+    let pack = compose_pack(provider, model, role, lifecycle, task_classes)?;
+    Ok(json!({
+        "schema_version": 1,
+        "template_ids": pack.template_ids,
+        "digest_sha256": pack.digest_sha256,
+        "a1": pack.a1,
+    }))
+}
+
+pub(crate) fn tracked_instruction_hashes() -> Result<Vec<(String, String, String)>, Vec<InstructionIssue>> {
+    let root = repo_root().map_err(|error| {
+        vec![issue("instruction-files", "missing_repo", error.to_string())]
+    })?;
+    let mut rows = Vec::new();
+    for (rel, expected) in TRACKED_INSTRUCTION_SHA256 {
+        let path = root.join(rel);
+        let bytes = fs::read(&path).map_err(|_| {
+            vec![issue(
+                rel,
+                "missing_instruction_file",
+                format!("Tracked instruction file '{rel}' is missing."),
+            )]
+        })?;
+        let actual = format!("{:x}", Sha256::digest(&bytes));
+        rows.push((rel.to_string(), expected.to_string(), actual));
+    }
+    Ok(rows)
+}
+
+fn repo_root() -> io::Result<PathBuf> {
+    let profiles = profiles_root()?;
+    profiles
+        .ancestors()
+        .nth(3)
+        .map(Path::to_path_buf)
+        .ok_or_else(|| io::Error::new(ErrorKind::NotFound, "repository root was not found."))
+}
+
+fn load_registry(root: &Path) -> Result<Registry, Vec<InstructionIssue>> {
+    let yaml = fs::read_to_string(root.join(REGISTRY_FILE)).map_err(|_| {
+        vec![issue(
+            "registry",
+            "missing_registry",
+            "registry.yaml is missing.",
+        )]
+    })?;
+    if yaml.starts_with('\u{feff}') {
+        return Err(vec![issue(
+            "registry",
+            "utf8_bom",
+            "registry.yaml must be UTF-8 without BOM.",
+        )]);
+    }
+    let root_value = parse_workspace_yaml(&yaml).map_err(|error| {
+        vec![issue("registry", "invalid_registry", error.to_string())]
+    })?;
+    let mapping = root_value.as_mapping().ok_or_else(|| {
+        vec![issue(
+            "registry",
+            "invalid_registry",
+            "registry.yaml must be a mapping.",
+        )]
+    })?;
+    let schema = mapping
+        .get(&Value::String("schema-version".into()))
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+    if schema != 1 {
+        return Err(vec![issue(
+            "registry",
+            "unsupported_schema_version",
+            "instruction-pack schema-version must be 1.",
+        )]);
+    }
+    Ok(Registry {
+        a1: parse_a1(mapping)?,
+        base: required_text(mapping, "base")?,
+        providers: id_templates(mapping, "providers")?,
+        roles: id_templates(mapping, "roles")?,
+        lifecycles: id_templates(mapping, "lifecycles")?,
+        task_classes: id_templates(mapping, "task-classes")?,
+        models: parse_models(mapping)?,
+        dynamic_providers: parse_dynamic(mapping)?,
+    })
+}
+
+fn parse_a1(mapping: &serde_yaml::Mapping) -> Result<A1Criteria, Vec<InstructionIssue>> {
+    let Some(Value::Mapping(a1)) = mapping.get(&Value::String("a1".into())) else {
+        return Err(vec![issue("a1", "missing_a1", "Registry A1 block is required.")]);
+    };
+    Ok(A1Criteria {
+        worker: string_list(a1, "worker")?,
+        operator: string_list(a1, "operator")?,
+    })
+}
+
+fn string_list(
+    mapping: &serde_yaml::Mapping,
+    key: &str,
+) -> Result<Vec<String>, Vec<InstructionIssue>> {
+    let Some(Value::Sequence(items)) = mapping.get(&Value::String(key.into())) else {
+        return Err(vec![issue(
+            key,
+            "invalid_list",
+            format!("{key} must be a sequence."),
+        )]);
+    };
+    let mut values = Vec::new();
+    for item in items {
+        let Some(text) = item.as_str() else {
+            return Err(vec![issue(key, "invalid_list_item", "List values must be strings.")]);
+        };
+        values.push(text.to_string());
+    }
+    Ok(values)
+}
+
+fn required_text(
+    mapping: &serde_yaml::Mapping,
+    key: &str,
+) -> Result<String, Vec<InstructionIssue>> {
+    mapping
+        .get(&Value::String(key.into()))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| vec![issue(key, "missing_field", format!("{key} is required."))])
+}
+
+fn id_templates(
+    mapping: &serde_yaml::Mapping,
+    key: &str,
+) -> Result<BTreeMap<String, String>, Vec<InstructionIssue>> {
+    let Some(Value::Sequence(items)) = mapping.get(&Value::String(key.into())) else {
+        return Err(vec![issue(
+            key,
+            "invalid_list",
+            format!("{key} must be a sequence."),
+        )]);
+    };
+    let mut out = BTreeMap::new();
+    for item in items {
+        let Some(entry) = item.as_mapping() else {
+            return Err(vec![issue(key, "invalid_entry", "Each entry must be a mapping.")]);
+        };
+        let id = required_text(entry, "id")?;
+        let template = required_text(entry, "template")?;
+        if out.insert(id.clone(), template).is_some() {
+            return Err(vec![issue(
+                key,
+                "duplicate_id",
+                format!("Duplicate '{key}' id '{id}'."),
+            )]);
+        }
+    }
+    Ok(out)
+}
+
+fn parse_models(
+    mapping: &serde_yaml::Mapping,
+) -> Result<BTreeMap<String, ModelTemplate>, Vec<InstructionIssue>> {
+    let Some(Value::Sequence(items)) = mapping.get(&Value::String("models".into())) else {
+        return Err(vec![issue(
+            "models",
+            "invalid_list",
+            "models must be a sequence.",
+        )]);
+    };
+    let mut out = BTreeMap::new();
+    for item in items {
+        let Some(entry) = item.as_mapping() else {
+            return Err(vec![issue("models", "invalid_entry", "Each model must be a mapping.")]);
+        };
+        let id = required_text(entry, "id")?;
+        let model = ModelTemplate {
+            provider: required_text(entry, "provider")?,
+            template: required_text(entry, "template")?,
+        };
+        if out.insert(id.clone(), model).is_some() {
+            return Err(vec![issue(
+                "models",
+                "duplicate_id",
+                format!("Duplicate model id '{id}'."),
+            )]);
+        }
+    }
+    Ok(out)
+}
+
+fn parse_dynamic(
+    mapping: &serde_yaml::Mapping,
+) -> Result<BTreeMap<String, String>, Vec<InstructionIssue>> {
+    let Some(Value::Sequence(items)) = mapping.get(&Value::String("dynamic-providers".into())) else {
+        return Ok(BTreeMap::new());
+    };
+    let mut out = BTreeMap::new();
+    for item in items {
+        let Some(entry) = item.as_mapping() else {
+            return Err(vec![issue(
+                "dynamic-providers",
+                "invalid_entry",
+                "Each dynamic provider must be a mapping.",
+            )]);
+        };
+        let provider = required_text(entry, "provider")?;
+        let template = required_text(entry, "template")?;
+        if out.insert(provider.clone(), template).is_some() {
+            return Err(vec![issue(
+                "dynamic-providers",
+                "duplicate_id",
+                format!("Duplicate dynamic provider '{provider}'."),
+            )]);
+        }
+    }
+    Ok(out)
+}
+
+fn resolve_model_template(
+    registry: &Registry,
+    provider: &str,
+    model: &str,
+) -> Result<(String, String), Vec<InstructionIssue>> {
+    if let Some(entry) = registry.models.get(model) {
+        if entry.provider != provider {
+            return Err(vec![issue(
+                "model",
+                "model_provider_mismatch",
+                format!("Instruction pack for '{model}' belongs to '{}'.", entry.provider),
+            )]);
+        }
+        return Ok((
+            entry.template.clone(),
+            format!("model/{provider}/{model}"),
+        ));
+    }
+    if let Some(template) = registry.dynamic_providers.get(provider) {
+        let stem = Path::new(template)
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .unwrap_or("_dynamic");
+        return Ok((template.clone(), format!("model/{provider}/{stem}")));
+    }
+    Err(vec![issue(
+        "model",
+        "missing_instruction_pack",
+        format!("No instruction pack mapping for model '{model}'."),
+    )])
+}
+
+fn push_layer(
+    root: &Path,
+    rel: &str,
+    id: &str,
+    ids: &mut Vec<String>,
+    parts: &mut Vec<String>,
+) -> Result<(), Vec<InstructionIssue>> {
+    let text = read_template(root, rel, id)?;
+    ids.push(id.to_string());
+    parts.push(text);
+    Ok(())
+}
+
+fn lint_path(root: &Path, rel: &str, field: &str, issues: &mut Vec<InstructionIssue>) {
+    if let Err(mut found) = read_template(root, rel, field) {
+        issues.append(&mut found);
+    }
+}
+
+fn read_template(root: &Path, rel: &str, field: &str) -> Result<String, Vec<InstructionIssue>> {
+    if rel.is_empty()
+        || Path::new(rel).is_absolute()
+        || rel.contains('\0')
+        || rel.split(['/', '\\']).any(|part| part == "..")
+    {
+        return Err(vec![issue(
+            field,
+            "unsafe_template_path",
+            format!("Template path '{rel}' must be a relative path without '..'."),
+        )]);
+    }
+    let path = root.join(rel);
+    let bytes = fs::read(&path).map_err(|_| {
+        vec![issue(
+            field,
+            "missing_instruction_pack",
+            format!("Template '{rel}' is missing."),
+        )]
+    })?;
+    if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        return Err(vec![issue(
+            field,
+            "utf8_bom",
+            format!("Template '{rel}' must be UTF-8 without BOM."),
+        )]);
+    }
+    let text = String::from_utf8(bytes).map_err(|_| {
+        vec![issue(
+            field,
+            "invalid_utf8",
+            format!("Template '{rel}' is not valid UTF-8."),
+        )]
+    })?;
+    if regex_is_match(SECRET_PATTERN, &text) {
+        return Err(vec![issue(
+            field,
+            "secret_or_private_path",
+            format!("Template '{rel}' contains a secret or private path."),
+        )]);
+    }
+    Ok(text.trim().to_string())
+}
+
+fn regex_is_match(pattern: &str, text: &str) -> bool {
+    regex::Regex::new(pattern)
+        .map(|re| re.is_match(text))
+        .unwrap_or(false)
+}
+
+fn issue(field: &str, code: &str, remediation: impl Into<String>) -> InstructionIssue {
+    InstructionIssue {
+        field: field.to_string(),
+        code: code.to_string(),
+        severity: "error".to_string(),
+        remediation: remediation.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_lint_accepts_official_tree() {
+        let report = lint_registry().expect("lint");
+        assert_eq!(report["ok"], true);
+        assert_eq!(report["models"], 28);
+    }
+
+    #[test]
+    fn compose_default_architect_slot_is_stable() {
+        let pack = compose_pack(
+            "codex",
+            "codex-gpt-5-6-sol",
+            "architect",
+            "session",
+            &["architecture".into(), "protocol".into(), "security".into()],
+        )
+        .expect("compose default");
+        assert_eq!(
+            pack.template_ids,
+            vec![
+                "base",
+                "provider/codex",
+                "model/codex/codex-gpt-5-6-sol",
+                "role/architect",
+                "lifecycle/session",
+                "task/architecture",
+                "task/protocol",
+                "task/security",
+            ]
+        );
+        assert!(pack.body.contains("A1 delegation"));
+        assert!(pack.body.contains("frozen-spec-implementation"));
+        assert!(!pack.body.contains("TASK-"));
+        assert_eq!(pack.digest_sha256.len(), 64);
+        assert_eq!(pack.a1.worker.len(), 3);
+    }
+
+    #[test]
+    fn compose_openrouter_dynamic_does_not_probe_filenames() {
+        let pack = compose_pack(
+            "openrouter",
+            "openrouter-not-in-seed-catalog",
+            "maintainer",
+            "task",
+            &["documentation".into(), "repository-operations".into()],
+        )
+        .expect("compose dynamic");
+        assert!(pack.template_ids.iter().any(|id| id == "model/openrouter/_dynamic"));
+        assert!(!pack.template_ids.iter().any(|id| id.contains("not-in-seed")));
+        assert!(pack.body.contains("Do not probe sibling filenames"));
+        assert!(!pack.body.contains("openrouter-glm-5-2"));
+    }
+
+    #[test]
+    fn missing_role_fails_closed() {
+        let error = compose_pack(
+            "codex",
+            "codex-gpt-5-6-sol",
+            "wizard",
+            "session",
+            &["architecture".into()],
+        )
+        .unwrap_err();
+        assert!(error.iter().any(|issue| issue.code == "missing_instruction_pack"));
+    }
+
+    #[test]
+    fn tracked_instruction_files_are_unchanged() {
+        let rows = tracked_instruction_hashes().expect("hashes");
+        for (rel, expected, actual) in rows {
+            assert_eq!(actual, expected, "{rel} hash changed");
+        }
+        assert_eq!(INSTRUCTION_FILES.len(), 3);
+    }
+}

--- a/core/src/instruction_pack.rs
+++ b/core/src/instruction_pack.rs
@@ -12,6 +12,8 @@ use sha2::{Digest, Sha256};
 
 use crate::workspace_recipe::parse_workspace_yaml;
 
+include!(concat!(::core::env!("OUT_DIR"), "/embedded_profiles.rs"));
+
 const REGISTRY_REL: &str = "winsmux-core/agents/profiles";
 const REGISTRY_FILE: &str = "registry.yaml";
 const INSTRUCTION_FILES: [&str; 3] = [
@@ -76,35 +78,28 @@ struct ModelTemplate {
     template: String,
 }
 
+#[derive(Clone, Debug)]
+enum ProfileSource {
+    Filesystem(PathBuf),
+    Embedded,
+}
+
 pub(crate) fn profiles_root() -> io::Result<PathBuf> {
-    if let Ok(configured) = env::var("WINSMUX_PROFILES_DIR") {
-        let path = PathBuf::from(configured);
-        if path.join(REGISTRY_FILE).is_file() {
-            return Ok(path);
-        }
+    match profile_source()? {
+        ProfileSource::Filesystem(path) => Ok(path),
+        ProfileSource::Embedded => Err(io::Error::new(
+            ErrorKind::NotFound,
+            "instruction-pack registry is embedded; no on-disk profiles root is required.",
+        )),
     }
-    if let Ok(manifest) = env::var("CARGO_MANIFEST_DIR") {
-        let path = Path::new(&manifest).join("..").join(REGISTRY_REL);
-        if path.join(REGISTRY_FILE).is_file() {
-            return Ok(path);
-        }
+}
+
+fn profile_source() -> io::Result<ProfileSource> {
+    if let Some(path) = filesystem_profiles_root() {
+        return Ok(ProfileSource::Filesystem(path));
     }
-    if let Ok(exe) = env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            for ancestor in dir.ancestors() {
-                let path = ancestor.join(REGISTRY_REL);
-                if path.join(REGISTRY_FILE).is_file() {
-                    return Ok(path);
-                }
-            }
-        }
-    }
-    let cwd = env::current_dir()?;
-    for ancestor in cwd.ancestors() {
-        let path = ancestor.join(REGISTRY_REL);
-        if path.join(REGISTRY_FILE).is_file() {
-            return Ok(path);
-        }
+    if embedded_profile(REGISTRY_FILE).is_some() {
+        return Ok(ProfileSource::Embedded);
     }
     Err(io::Error::new(
         ErrorKind::NotFound,
@@ -112,28 +107,62 @@ pub(crate) fn profiles_root() -> io::Result<PathBuf> {
     ))
 }
 
+fn filesystem_profiles_root() -> Option<PathBuf> {
+    if let Ok(configured) = env::var("WINSMUX_PROFILES_DIR") {
+        let path = PathBuf::from(configured);
+        if path.join(REGISTRY_FILE).is_file() {
+            return Some(path);
+        }
+    }
+    if let Ok(manifest) = env::var("CARGO_MANIFEST_DIR") {
+        let path = Path::new(&manifest).join("..").join(REGISTRY_REL);
+        if path.join(REGISTRY_FILE).is_file() {
+            return Some(path);
+        }
+    }
+    if let Ok(exe) = env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            for ancestor in dir.ancestors() {
+                let path = ancestor.join(REGISTRY_REL);
+                if path.join(REGISTRY_FILE).is_file() {
+                    return Some(path);
+                }
+            }
+        }
+    }
+    if let Ok(cwd) = env::current_dir() {
+        for ancestor in cwd.ancestors() {
+            let path = ancestor.join(REGISTRY_REL);
+            if path.join(REGISTRY_FILE).is_file() {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
 pub(crate) fn lint_registry() -> Result<JsonValue, Vec<InstructionIssue>> {
-    let root = profiles_root().map_err(|error| {
+    let source = profile_source().map_err(|error| {
         vec![issue(
             "registry",
             "missing_registry",
             error.to_string(),
         )]
     })?;
-    let registry = load_registry(&root)?;
+    let registry = load_registry(&source)?;
     let mut issues = Vec::new();
-    lint_path(&root, &registry.base, "base", &mut issues);
+    lint_path(&source, &registry.base, "base", &mut issues);
     for (id, template) in &registry.providers {
-        lint_path(&root, template, &format!("provider/{id}"), &mut issues);
+        lint_path(&source, template, &format!("provider/{id}"), &mut issues);
     }
     for (id, template) in &registry.roles {
-        lint_path(&root, template, &format!("role/{id}"), &mut issues);
+        lint_path(&source, template, &format!("role/{id}"), &mut issues);
     }
     for (id, template) in &registry.lifecycles {
-        lint_path(&root, template, &format!("lifecycle/{id}"), &mut issues);
+        lint_path(&source, template, &format!("lifecycle/{id}"), &mut issues);
     }
     for (id, template) in &registry.task_classes {
-        lint_path(&root, template, &format!("task-class/{id}"), &mut issues);
+        lint_path(&source, template, &format!("task-class/{id}"), &mut issues);
     }
     let mut templates = BTreeSet::new();
     for (id, model) in &registry.models {
@@ -149,7 +178,7 @@ pub(crate) fn lint_registry() -> Result<JsonValue, Vec<InstructionIssue>> {
             // Duplicate exact paths are allowed only when intentional; unique IDs are the hard rule.
         }
         let _ = id;
-        lint_path(&root, &model.template, &format!("model/{}", id), &mut issues);
+        lint_path(&source, &model.template, &format!("model/{}", id), &mut issues);
         if model.provider.is_empty() || !registry.providers.contains_key(&model.provider) {
             issues.push(issue(
                 &format!("model/{id}"),
@@ -160,7 +189,7 @@ pub(crate) fn lint_registry() -> Result<JsonValue, Vec<InstructionIssue>> {
     }
     for (provider, template) in &registry.dynamic_providers {
         lint_path(
-            &root,
+            &source,
             template,
             &format!("dynamic/{provider}"),
             &mut issues,
@@ -192,13 +221,13 @@ pub(crate) fn compose_pack(
     lifecycle: &str,
     task_classes: &[String],
 ) -> Result<ComposedPack, Vec<InstructionIssue>> {
-    let root = profiles_root().map_err(|error| {
+    let source = profile_source().map_err(|error| {
         vec![issue("registry", "missing_registry", error.to_string())]
     })?;
-    let registry = load_registry(&root)?;
+    let registry = load_registry(&source)?;
     let mut template_ids = Vec::new();
     let mut parts = Vec::new();
-    push_layer(&root, &registry.base, "base", &mut template_ids, &mut parts)?;
+    push_layer(&source, &registry.base, "base", &mut template_ids, &mut parts)?;
     let provider_template = registry.providers.get(provider).ok_or_else(|| {
         vec![issue(
             "provider",
@@ -207,7 +236,7 @@ pub(crate) fn compose_pack(
         )]
     })?;
     push_layer(
-        &root,
+        &source,
         provider_template,
         &format!("provider/{provider}"),
         &mut template_ids,
@@ -215,7 +244,7 @@ pub(crate) fn compose_pack(
     )?;
     let (model_template, model_template_id) = resolve_model_template(&registry, provider, model)?;
     push_layer(
-        &root,
+        &source,
         &model_template,
         &model_template_id,
         &mut template_ids,
@@ -229,7 +258,7 @@ pub(crate) fn compose_pack(
         )]
     })?;
     push_layer(
-        &root,
+        &source,
         role_template,
         &format!("role/{role}"),
         &mut template_ids,
@@ -243,7 +272,7 @@ pub(crate) fn compose_pack(
         )]
     })?;
     push_layer(
-        &root,
+        &source,
         lifecycle_template,
         &format!("lifecycle/{lifecycle}"),
         &mut template_ids,
@@ -265,7 +294,7 @@ pub(crate) fn compose_pack(
             )]
         })?;
         push_layer(
-            &root,
+            &source,
             template,
             &format!("task/{class}"),
             &mut template_ids,
@@ -319,16 +348,22 @@ pub(crate) fn tracked_instruction_hashes() -> Result<Vec<(String, String, String
 }
 
 fn repo_root() -> io::Result<PathBuf> {
-    let profiles = profiles_root()?;
-    profiles
-        .ancestors()
-        .nth(3)
-        .map(Path::to_path_buf)
-        .ok_or_else(|| io::Error::new(ErrorKind::NotFound, "repository root was not found."))
+    if let Some(profiles) = filesystem_profiles_root() {
+        if let Some(root) = profiles.ancestors().nth(3) {
+            return Ok(root.to_path_buf());
+        }
+    }
+    let cwd = env::current_dir()?;
+    for ancestor in cwd.ancestors() {
+        if ancestor.join("winsmux-core/agents/AGENTS.md").is_file() {
+            return Ok(ancestor.to_path_buf());
+        }
+    }
+    Err(io::Error::new(ErrorKind::NotFound, "repository root was not found."))
 }
 
-fn load_registry(root: &Path) -> Result<Registry, Vec<InstructionIssue>> {
-    let yaml = fs::read_to_string(root.join(REGISTRY_FILE)).map_err(|_| {
+fn load_registry(source: &ProfileSource) -> Result<Registry, Vec<InstructionIssue>> {
+    let yaml = read_profile_text(source, REGISTRY_FILE).map_err(|_| {
         vec![issue(
             "registry",
             "missing_registry",
@@ -538,25 +573,43 @@ fn resolve_model_template(
 }
 
 fn push_layer(
-    root: &Path,
+    source: &ProfileSource,
     rel: &str,
     id: &str,
     ids: &mut Vec<String>,
     parts: &mut Vec<String>,
 ) -> Result<(), Vec<InstructionIssue>> {
-    let text = read_template(root, rel, id)?;
+    let text = read_template(source, rel, id)?;
     ids.push(id.to_string());
     parts.push(text);
     Ok(())
 }
 
-fn lint_path(root: &Path, rel: &str, field: &str, issues: &mut Vec<InstructionIssue>) {
-    if let Err(mut found) = read_template(root, rel, field) {
+fn lint_path(source: &ProfileSource, rel: &str, field: &str, issues: &mut Vec<InstructionIssue>) {
+    if let Err(mut found) = read_template(source, rel, field) {
         issues.append(&mut found);
     }
 }
 
-fn read_template(root: &Path, rel: &str, field: &str) -> Result<String, Vec<InstructionIssue>> {
+fn read_profile_text(source: &ProfileSource, rel: &str) -> io::Result<String> {
+    match source {
+        ProfileSource::Filesystem(root) => fs::read_to_string(root.join(rel)),
+        ProfileSource::Embedded => embedded_profile(rel)
+            .map(str::to_string)
+            .ok_or_else(|| io::Error::new(ErrorKind::NotFound, format!("{rel} is not embedded."))),
+    }
+}
+
+fn read_profile_bytes(source: &ProfileSource, rel: &str) -> io::Result<Vec<u8>> {
+    match source {
+        ProfileSource::Filesystem(root) => fs::read(root.join(rel)),
+        ProfileSource::Embedded => embedded_profile(rel)
+            .map(|text| text.as_bytes().to_vec())
+            .ok_or_else(|| io::Error::new(ErrorKind::NotFound, format!("{rel} is not embedded."))),
+    }
+}
+
+fn read_template(source: &ProfileSource, rel: &str, field: &str) -> Result<String, Vec<InstructionIssue>> {
     if rel.is_empty()
         || Path::new(rel).is_absolute()
         || rel.contains('\0')
@@ -568,8 +621,7 @@ fn read_template(root: &Path, rel: &str, field: &str) -> Result<String, Vec<Inst
             format!("Template path '{rel}' must be a relative path without '..'."),
         )]);
     }
-    let path = root.join(rel);
-    let bytes = fs::read(&path).map_err(|_| {
+    let bytes = read_profile_bytes(source, rel).map_err(|_| {
         vec![issue(
             field,
             "missing_instruction_pack",
@@ -692,5 +744,21 @@ mod tests {
             assert_eq!(actual, expected, "{rel} hash changed");
         }
         assert_eq!(INSTRUCTION_FILES.len(), 3);
+    }
+
+    #[test]
+    fn embedded_registry_covers_official_tree() {
+        assert!(super::embedded_profile("registry.yaml").is_some());
+        assert!(super::embedded_profile("base.md").is_some());
+        assert!(super::embedded_profile("providers/codex.md").is_some());
+        let pack = compose_pack(
+            "codex",
+            "codex-gpt-5-6-sol",
+            "architect",
+            "session",
+            &["architecture".into(), "protocol".into(), "security".into()],
+        )
+        .expect("compose from available source");
+        assert_eq!(pack.digest_sha256.len(), 64);
     }
 }

--- a/core/src/instruction_pack.rs
+++ b/core/src/instruction_pack.rs
@@ -94,6 +94,12 @@ pub(crate) fn profiles_root() -> io::Result<PathBuf> {
     }
 }
 
+pub(crate) fn registry_sha256() -> io::Result<String> {
+    let source = profile_source()?;
+    let bytes = read_profile_bytes(&source, REGISTRY_FILE)?;
+    Ok(format!("{:x}", Sha256::digest(&bytes)))
+}
+
 fn profile_source() -> io::Result<ProfileSource> {
     if let Some(path) = filesystem_profiles_root() {
         return Ok(ProfileSource::Filesystem(path));

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -912,19 +912,33 @@ fn run_main() -> io::Result<()> {
     }
 
     if is_winsmux_core_bridge_command(cmd) {
+        let mut owned_dispatch_args = None;
         if cmd == "dispatch-task" {
-            if let Some(payload) = team_profile::refuse_unclassifiable_dispatch(&cmd_args[1..])? {
-                println!("{payload}");
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "dispatch-task refused unclassifiable or operator-owned work.",
-                ));
+            match team_profile::gate_dispatch(&cmd_args[1..])? {
+                team_profile::DispatchGate::Refused(payload) => {
+                    println!("{payload}");
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "dispatch-task refused unclassifiable or operator-owned work.",
+                    ));
+                }
+                team_profile::DispatchGate::Classified { slot_id } => {
+                    owned_dispatch_args =
+                        Some(team_profile::with_classified_slot(&cmd_args, &slot_id));
+                }
+                team_profile::DispatchGate::Passthrough => {}
             }
         }
+        let forwarded_owned = owned_dispatch_args;
+        let forwarded: Vec<&String> = if let Some(ref owned) = forwarded_owned {
+            owned.iter().collect()
+        } else {
+            cmd_args.clone()
+        };
         if let Some(script_path) = find_winsmux_core_script() {
             return run_winsmux_core_script(
                 script_path,
-                &cmd_args,
+                &forwarded,
                 l_socket_name.as_deref(),
                 s_socket_selector.as_deref(),
                 session_namespace.as_deref(),

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -37,6 +37,7 @@ mod workspace_migrate;
 mod team_profile;
 mod instruction_pack;
 mod prompt_bundle;
+mod worker_artifact;
 mod project_settings_render;
 mod client;
 mod app;
@@ -953,6 +954,7 @@ fn run_main() -> io::Result<()> {
             return workspace_migrate::run_workspace_migrate_command(&cmd_args[1..])
         }
         "team-profile" => return team_profile::run_team_profile_command(&cmd_args[1..]),
+        "worker-artifact" => return worker_artifact::run_worker_artifact_command(&cmd_args[1..]),
         "provider-capabilities" => return operator_cli::run_provider_capabilities_command(&cmd_args[1..]),
         "operator-jobs" => return operator_cli::run_operator_jobs_command(&cmd_args[1..]),
         "skills" => return operator_cli::run_skills_command(&cmd_args[1..]),

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -35,6 +35,7 @@ mod context_pack;
 mod operator_cli;
 mod workspace_migrate;
 mod team_profile;
+mod instruction_pack;
 mod project_settings_render;
 mod client;
 mod app;

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -36,6 +36,7 @@ mod operator_cli;
 mod workspace_migrate;
 mod team_profile;
 mod instruction_pack;
+mod prompt_bundle;
 mod project_settings_render;
 mod client;
 mod app;

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -34,6 +34,7 @@ mod machine_contract;
 mod context_pack;
 mod operator_cli;
 mod workspace_migrate;
+mod team_profile;
 mod project_settings_render;
 mod client;
 mod app;
@@ -911,6 +912,15 @@ fn run_main() -> io::Result<()> {
     }
 
     if is_winsmux_core_bridge_command(cmd) {
+        if cmd == "dispatch-task" {
+            if let Some(payload) = team_profile::refuse_unclassifiable_dispatch(&cmd_args[1..])? {
+                println!("{payload}");
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "dispatch-task refused unclassifiable or operator-owned work.",
+                ));
+            }
+        }
         if let Some(script_path) = find_winsmux_core_script() {
             return run_winsmux_core_script(
                 script_path,
@@ -940,6 +950,7 @@ fn run_main() -> io::Result<()> {
         "workspace-migrate" => {
             return workspace_migrate::run_workspace_migrate_command(&cmd_args[1..])
         }
+        "team-profile" => return team_profile::run_team_profile_command(&cmd_args[1..]),
         "provider-capabilities" => return operator_cli::run_provider_capabilities_command(&cmd_args[1..]),
         "operator-jobs" => return operator_cli::run_operator_jobs_command(&cmd_args[1..]),
         "skills" => return operator_cli::run_skills_command(&cmd_args[1..]),

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -6988,6 +6988,7 @@ fn usage_for(command: &str) -> &'static str {
         }
         "workspace-migrate" => crate::workspace_migrate::USAGE,
         "team-profile" => crate::team_profile::USAGE,
+        "worker-artifact" => crate::worker_artifact::USAGE,
         "provider-capabilities" => {
             "usage: winsmux provider-capabilities [provider] [--json] [--project-dir <path>]"
         }

--- a/core/src/operator_cli.rs
+++ b/core/src/operator_cli.rs
@@ -6987,6 +6987,7 @@ fn usage_for(command: &str) -> &'static str {
             "usage: winsmux workspace-plan --recipe-id <id> [--workflow-id <id>] [--run-id <id>] [--context-pack-id <id> --context-pack-input -] --json [--project-dir <path>]"
         }
         "workspace-migrate" => crate::workspace_migrate::USAGE,
+        "team-profile" => crate::team_profile::USAGE,
         "provider-capabilities" => {
             "usage: winsmux provider-capabilities [provider] [--json] [--project-dir <path>]"
         }

--- a/core/src/platform.rs
+++ b/core/src/platform.rs
@@ -1308,6 +1308,12 @@ pub mod mouse_inject {
 
 #[cfg(not(windows))]
 pub mod mouse_inject {
+    pub const FROM_LEFT_1ST_BUTTON_PRESSED: u32 = 0x0001;
+    pub const RIGHTMOST_BUTTON_PRESSED: u32 = 0x0002;
+    pub const FROM_LEFT_2ND_BUTTON_PRESSED: u32 = 0x0004;
+    pub const MOUSE_MOVED: u32 = 0x0001;
+    pub const MOUSE_WHEELED: u32 = 0x0004;
+
     pub fn get_child_pid(_child: &dyn portable_pty::Child) -> Option<u32> { None }
     pub fn send_mouse_event(_pid: u32, _col: i16, _row: i16, _btn: u32, _flags: u32, _reattach: bool) -> bool { false }
     pub fn send_vt_sequence(_pid: u32, _sequence: &[u8]) -> bool { false }

--- a/core/src/project_settings_render.rs
+++ b/core/src/project_settings_render.rs
@@ -132,6 +132,53 @@ pub(crate) fn render_owned_workspace_recipes(
     .map_err(|_| generic_error())
 }
 
+pub(crate) fn render_owned_lane_b(
+    original_yaml: &str,
+    team_profile: Option<serde_json::Value>,
+    agent_slots: Option<serde_json::Value>,
+) -> io::Result<String> {
+    let mut desired_settings = serde_json::Map::new();
+    let mut owned_keys = Vec::new();
+    if let Some(profile) = team_profile {
+        desired_settings.insert("team-profile".to_string(), profile);
+        owned_keys.push("team-profile".to_string());
+    }
+    if let Some(slots) = agent_slots {
+        desired_settings.insert("agent-slots".to_string(), slots);
+        owned_keys.push("agent-slots".to_string());
+    }
+    if owned_keys.is_empty() {
+        return Err(generic_error());
+    }
+    let mut aliases = BTreeMap::new();
+    aliases.insert("agent".to_string(), "provider".to_string());
+    render(RenderRequest {
+        original_yaml: original_yaml.to_string(),
+        desired_settings,
+        owned_keys,
+        nested_contract: NestedContractRequest {
+            agent_slots: KeyedSequenceContractRequest {
+                identity_key: "slot-id".to_string(),
+                owned_keys: vec![
+                    "slot-id".to_string(),
+                    "provider".to_string(),
+                    "model".to_string(),
+                    "reasoning-effort".to_string(),
+                    "role-profile".to_string(),
+                    "lifecycle".to_string(),
+                    "task-classes".to_string(),
+                    "delegation".to_string(),
+                ],
+                aliases,
+            },
+            roles: MappingValuesContractRequest {
+                owned_keys: Vec::new(),
+            },
+        },
+    })
+    .map_err(|_| generic_error())
+}
+
 fn render_from_stdin(args: &[String]) -> Result<String, ()> {
     if !args.is_empty() {
         return Err(());

--- a/core/src/prompt_bundle.rs
+++ b/core/src/prompt_bundle.rs
@@ -68,37 +68,36 @@ pub(crate) fn project_launch(
         &pack.template_ids,
     )?;
     let merged_manifest = match original_manifest.as_deref() {
-        Some(original) => Some(merge_manifest(original, &projection, &slot.slot_id)?),
-        None => None,
+        Some(original) => merge_manifest(original, &projection, &slot.slot_id)?,
+        None => merge_manifest(
+            "version: 2\nsession: {}\npanes: {}\n",
+            &projection,
+            &slot.slot_id,
+        )?,
     };
 
     fs::create_dir_all(bundle_path.parent().ok_or_else(|| {
         invalid_input("prompt-bundle path has no parent directory.")
     })?)?;
+    fs::create_dir_all(manifest_path.parent().ok_or_else(|| {
+        invalid_input("manifest path has no parent directory.")
+    })?)?;
     let tmp_bundle = bundle_path.with_extension("md.tmp-prompt-bundle");
     fs::write(&tmp_bundle, &body)?;
-    let mut tmp_manifest = None;
-    if let Some(merged) = merged_manifest.as_ref() {
-        let tmp = manifest_path.with_extension("yaml.tmp-prompt-bundle");
-        fs::write(&tmp, merged)?;
-        tmp_manifest = Some(tmp);
-    }
-    if let Err(error) = fs::rename(&tmp_bundle, &bundle_path) {
+    let tmp_manifest = manifest_path.with_extension("yaml.tmp-prompt-bundle");
+    fs::write(&tmp_manifest, &merged_manifest)?;
+    if let Err(error) = replace_existing_file(&tmp_bundle, &bundle_path) {
         let _ = fs::remove_file(&tmp_bundle);
-        if let Some(tmp) = &tmp_manifest {
-            let _ = fs::remove_file(tmp);
-        }
+        let _ = fs::remove_file(&tmp_manifest);
         return Err(error);
     }
-    if let Some(tmp) = tmp_manifest {
-        if let Err(error) = fs::rename(&tmp, &manifest_path) {
-            let _ = fs::remove_file(&tmp);
-            let _ = fs::remove_file(&bundle_path);
-            if let Some(original) = original_manifest {
-                let _ = fs::write(&manifest_path, original);
-            }
-            return Err(error);
+    if let Err(error) = replace_existing_file(&tmp_manifest, &manifest_path) {
+        let _ = fs::remove_file(&tmp_manifest);
+        let _ = fs::remove_file(&bundle_path);
+        if let Some(original) = original_manifest {
+            let _ = fs::write(&manifest_path, original);
         }
+        return Err(error);
     }
     Ok(json!({
         "schema_version": 1,
@@ -136,9 +135,7 @@ fn projection_value(
 ) -> io::Result<JsonValue> {
     let source = fs::read(project_dir.join(".winsmux.yaml"))?;
     let source_config_sha256 = format!("{:x}", Sha256::digest(&source));
-    let registry = instruction_pack::profiles_root()?.join("registry.yaml");
-    let registry_bytes = fs::read(registry)?;
-    let instruction_registry_sha256 = format!("{:x}", Sha256::digest(&registry_bytes));
+    let instruction_registry_sha256 = instruction_pack::registry_sha256()?;
     let meta = team.team_profile.as_ref();
     Ok(json!({
         "session": {
@@ -268,6 +265,41 @@ fn invalid_data(message: impl Into<String>) -> io::Error {
     io::Error::new(ErrorKind::InvalidData, message.into())
 }
 
+#[cfg(windows)]
+fn replace_existing_file(tmp_path: &Path, path: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    fn wide(value: &Path) -> Vec<u16> {
+        value
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    let tmp = wide(tmp_path);
+    let target = wide(path);
+    let moved = unsafe {
+        MoveFileExW(
+            tmp.as_ptr(),
+            target.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if moved == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn replace_existing_file(tmp_path: &Path, path: &Path) -> io::Result<()> {
+    fs::rename(tmp_path, path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -298,6 +330,20 @@ mod tests {
         assert_eq!(payload["projection"]["pane"]["status"], "ready");
         assert!(payload["projection"]["pane"]["prompt_bundle"]["sha256"].as_str().unwrap().len() == 64);
         assert!(payload["projection"]["pane"].get("task_id").is_none());
+        let saved = fs::read_to_string(dir.path().join(".winsmux/manifest.yaml")).unwrap();
+        assert!(saved.contains("team_profile:"));
+        assert!(saved.contains("prompt_bundle:"));
+    }
+
+    #[test]
+    fn project_launch_writes_manifest_when_missing() {
+        let dir = seed_project();
+        assert!(!dir.path().join(".winsmux/manifest.yaml").exists());
+        project_launch(dir.path(), "sess-1", "worker-1", None, None).unwrap();
+        let saved = fs::read_to_string(dir.path().join(".winsmux/manifest.yaml")).unwrap();
+        assert!(saved.contains("team_profile:"));
+        assert!(saved.contains("prompt_bundle:"));
+        assert!(saved.contains("worker-1"));
     }
 
     #[test]

--- a/core/src/prompt_bundle.rs
+++ b/core/src/prompt_bundle.rs
@@ -1,0 +1,343 @@
+use std::{
+    fs,
+    io::{self, ErrorKind},
+    path::Path,
+};
+
+use serde_json::{json, Value as JsonValue};
+use serde_yaml::{Mapping, Value};
+use sha2::{Digest, Sha256};
+
+use crate::instruction_pack::{self, compose_pack};
+use crate::team_profile::{self, ResolvedSlot, ResolvedTeam};
+use crate::workspace_recipe::parse_workspace_yaml;
+
+pub(crate) fn project_launch(
+    project_dir: &Path,
+    session_id: &str,
+    slot_id: &str,
+    worktree: Option<&str>,
+    read_write_scope: Option<&str>,
+) -> io::Result<JsonValue> {
+    let session_id = require_token(session_id, "session-id")?;
+    let slot_id = require_token(slot_id, "slot-id")?;
+    let team = team_profile::resolve_project(project_dir).map_err(issues_error)?;
+    if !team.opted_in {
+        return Err(invalid_input(
+            "prompt-bundle projection requires an opted-in team-profile.",
+        ));
+    }
+    let slot = team
+        .slots
+        .iter()
+        .find(|slot| slot.slot_id == slot_id)
+        .ok_or_else(|| invalid_input(format!("unknown slot-id '{slot_id}'.")))?
+        .clone();
+    let pack = compose_pack(
+        &slot.provider,
+        &slot.model,
+        &slot.role_profile,
+        &slot.lifecycle,
+        &slot.task_classes,
+    )
+    .map_err(pack_error)?;
+    let metadata = launch_metadata(&slot, worktree, read_write_scope);
+    if metadata.contains("task-id") || metadata.contains("task_id") {
+        return Err(invalid_data("launch metadata must not include a task ID."));
+    }
+    let body = format!("{}\n\n{}\n", pack.body.trim_end(), metadata.trim_end());
+    if body.to_ascii_lowercase().contains("task-id:") || body.contains("{{task") {
+        return Err(invalid_data("launch bundle must not include a task identity."));
+    }
+    let digest = format!("{:x}", Sha256::digest(body.as_bytes()));
+    let rel_path = format!(".winsmux/runtime/prompt-bundles/{session_id}/{slot_id}.md");
+    let bundle_path = project_dir.join(&rel_path);
+    let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
+    let original_manifest = if manifest_path.is_file() {
+        Some(fs::read_to_string(&manifest_path)?)
+    } else {
+        None
+    };
+    let projection = projection_value(
+        &team,
+        &slot,
+        project_dir,
+        &session_id,
+        &rel_path,
+        &digest,
+        &pack.template_ids,
+    )?;
+    let merged_manifest = match original_manifest.as_deref() {
+        Some(original) => Some(merge_manifest(original, &projection, &slot.slot_id)?),
+        None => None,
+    };
+
+    fs::create_dir_all(bundle_path.parent().ok_or_else(|| {
+        invalid_input("prompt-bundle path has no parent directory.")
+    })?)?;
+    let tmp_bundle = bundle_path.with_extension("md.tmp-prompt-bundle");
+    fs::write(&tmp_bundle, &body)?;
+    let mut tmp_manifest = None;
+    if let Some(merged) = merged_manifest.as_ref() {
+        let tmp = manifest_path.with_extension("yaml.tmp-prompt-bundle");
+        fs::write(&tmp, merged)?;
+        tmp_manifest = Some(tmp);
+    }
+    if let Err(error) = fs::rename(&tmp_bundle, &bundle_path) {
+        let _ = fs::remove_file(&tmp_bundle);
+        if let Some(tmp) = &tmp_manifest {
+            let _ = fs::remove_file(tmp);
+        }
+        return Err(error);
+    }
+    if let Some(tmp) = tmp_manifest {
+        if let Err(error) = fs::rename(&tmp, &manifest_path) {
+            let _ = fs::remove_file(&tmp);
+            let _ = fs::remove_file(&bundle_path);
+            if let Some(original) = original_manifest {
+                let _ = fs::write(&manifest_path, original);
+            }
+            return Err(error);
+        }
+    }
+    Ok(json!({
+        "schema_version": 1,
+        "ok": true,
+        "action": "project-launch",
+        "bundle_path": rel_path,
+        "digest_sha256": digest,
+        "template_ids": pack.template_ids,
+        "projection": projection,
+    }))
+}
+
+fn launch_metadata(
+    slot: &ResolvedSlot,
+    worktree: Option<&str>,
+    read_write_scope: Option<&str>,
+) -> String {
+    let worktree = worktree.unwrap_or("(unset)");
+    let scope = read_write_scope.unwrap_or("session");
+    let evidence = slot.task_classes.join(",");
+    format!(
+        "# Launch metadata\n\n- slot-id: {}\n- worktree: {}\n- read-write-scope: {}\n- evidence-class: {}\n",
+        slot.slot_id, worktree, scope, evidence
+    )
+}
+
+fn projection_value(
+    team: &ResolvedTeam,
+    slot: &ResolvedSlot,
+    project_dir: &Path,
+    session_id: &str,
+    rel_path: &str,
+    digest: &str,
+    template_ids: &[String],
+) -> io::Result<JsonValue> {
+    let source = fs::read(project_dir.join(".winsmux.yaml"))?;
+    let source_config_sha256 = format!("{:x}", Sha256::digest(&source));
+    let registry = instruction_pack::profiles_root()?.join("registry.yaml");
+    let registry_bytes = fs::read(registry)?;
+    let instruction_registry_sha256 = format!("{:x}", Sha256::digest(&registry_bytes));
+    let meta = team.team_profile.as_ref();
+    Ok(json!({
+        "session": {
+            "team_profile": {
+                "preset": meta.map(|item| item.preset.clone()),
+                "preset_revision": meta.map(|item| item.preset_revision),
+                "source_config_sha256": source_config_sha256,
+                "instruction_registry_sha256": instruction_registry_sha256,
+                "session_id": session_id,
+            }
+        },
+        "pane": {
+            "slot_id": slot.slot_id,
+            "assignment": {
+                "provider": slot.provider,
+                "model": slot.model,
+                "launch_model": slot.launch_model,
+                "reasoning_effort": slot.reasoning_effort,
+                "role_profile": slot.role_profile,
+                "lifecycle": slot.lifecycle,
+                "task_classes": slot.task_classes,
+                "source": if slot.overrides.is_empty() { "preset" } else { "override" },
+            },
+            "prompt_bundle": {
+                "path": rel_path,
+                "sha256": digest,
+                "template_ids": template_ids,
+            },
+            "status": "ready"
+        }
+    }))
+}
+
+fn merge_manifest(original: &str, projection: &JsonValue, slot_id: &str) -> io::Result<String> {
+    let mut root = parse_workspace_yaml(original)?;
+    let mapping = root
+        .as_mapping_mut()
+        .ok_or_else(|| invalid_data("manifest.yaml must be a mapping."))?;
+    let session = mapping
+        .entry(Value::String("session".into()))
+        .or_insert(Value::Mapping(Mapping::new()));
+    let session_map = session
+        .as_mapping_mut()
+        .ok_or_else(|| invalid_data("manifest session must be a mapping."))?;
+    session_map.insert(
+        Value::String("team_profile".into()),
+        json_to_yaml(&projection["session"]["team_profile"]),
+    );
+    let panes = mapping
+        .entry(Value::String("panes".into()))
+        .or_insert(Value::Mapping(Mapping::new()));
+    match panes {
+        Value::Mapping(map) => {
+            let entry = map
+                .entry(Value::String(slot_id.into()))
+                .or_insert(Value::Mapping(Mapping::new()));
+            merge_pane(entry, &projection["pane"])?;
+        }
+        Value::Sequence(items) => {
+            let mut found = false;
+            for item in items.iter_mut() {
+                let Some(map) = item.as_mapping_mut() else {
+                    continue;
+                };
+                let id = map
+                    .get(&Value::String("slot_id".into()))
+                    .or_else(|| map.get(&Value::String("label".into())))
+                    .and_then(Value::as_str);
+                if id == Some(slot_id) {
+                    merge_pane(item, &projection["pane"])?;
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                items.push(json_to_yaml(&projection["pane"]));
+            }
+        }
+        _ => {
+            return Err(invalid_data("manifest panes must be a mapping or sequence."));
+        }
+    }
+    serde_yaml::to_string(&root).map_err(|error| invalid_data(error.to_string()))
+}
+
+fn merge_pane(pane: &mut Value, projection: &JsonValue) -> io::Result<()> {
+    let map = pane
+        .as_mapping_mut()
+        .ok_or_else(|| invalid_data("manifest pane must be a mapping."))?;
+    for key in ["slot_id", "assignment", "prompt_bundle", "status"] {
+        map.insert(
+            Value::String(key.into()),
+            json_to_yaml(&projection[key]),
+        );
+    }
+    Ok(())
+}
+
+fn json_to_yaml(value: &JsonValue) -> Value {
+    serde_yaml::to_value(value).unwrap_or(Value::Null)
+}
+
+fn require_token(value: &str, name: &str) -> io::Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || trimmed.contains(['/', '\\', '\0', '\n', '\r'])
+        || trimmed.contains("..")
+    {
+        return Err(invalid_input(format!("invalid {name}.")));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn issues_error(issues: Vec<team_profile::ValidationIssue>) -> io::Error {
+    invalid_data(serde_json::to_string(&issues).unwrap_or_else(|_| "team-profile validation failed.".into()))
+}
+
+fn pack_error(issues: Vec<instruction_pack::InstructionIssue>) -> io::Error {
+    invalid_data(serde_json::to_string(&issues).unwrap_or_else(|_| "instruction-pack projection failed.".into()))
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(ErrorKind::InvalidInput, message.into())
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(ErrorKind::InvalidData, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn opted_in_empty() -> &'static str {
+        "config-version: 1\nteam-profile:\n  schema-version: 1\n  preset: official-balanced-v1\n  preset-revision: 1\n  update-policy: retain-overrides\nagent-slots: []\n"
+    }
+
+    fn seed_project() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".winsmux.yaml"), opted_in_empty()).unwrap();
+        dir
+    }
+
+    #[test]
+    fn project_launch_writes_bundle_without_task_id() {
+        let dir = seed_project();
+        let payload = project_launch(dir.path(), "sess-1", "worker-1", Some("wt"), Some("session"))
+            .expect("project");
+        let rel = payload["bundle_path"].as_str().unwrap();
+        let body = fs::read_to_string(dir.path().join(rel)).unwrap();
+        assert!(body.contains("# Launch metadata"));
+        assert!(body.contains("slot-id: worker-1"));
+        assert!(body.contains("A1 delegation"));
+        assert!(!body.to_ascii_lowercase().contains("task-id"));
+        assert!(!body.contains("TASK-"));
+        assert_eq!(payload["projection"]["pane"]["status"], "ready");
+        assert!(payload["projection"]["pane"]["prompt_bundle"]["sha256"].as_str().unwrap().len() == 64);
+        assert!(payload["projection"]["pane"].get("task_id").is_none());
+    }
+
+    #[test]
+    fn project_launch_merges_existing_manifest_and_preserves_other_panes() {
+        let dir = seed_project();
+        let winsmux = dir.path().join(".winsmux");
+        fs::create_dir_all(&winsmux).unwrap();
+        fs::write(
+            winsmux.join("manifest.yaml"),
+            "version: 1\nsession:\n  name: existing\npanes:\n  worker-1:\n    pane_id: '%1'\n    role: Worker\n    label: worker-1\n  operator:\n    pane_id: '%0'\n    role: Operator\n",
+        )
+        .unwrap();
+        project_launch(dir.path(), "sess-1", "worker-1", None, None).unwrap();
+        let saved = fs::read_to_string(winsmux.join("manifest.yaml")).unwrap();
+        assert!(saved.contains("name: existing"));
+        assert!(saved.contains("team_profile:"));
+        assert!(saved.contains("prompt_bundle:"));
+        assert!(saved.contains("role: Operator"));
+        assert!(!saved.contains("A1 delegation"));
+    }
+
+    #[test]
+    fn failed_projection_does_not_write_partial_manifest() {
+        let dir = seed_project();
+        let winsmux = dir.path().join(".winsmux");
+        fs::create_dir_all(&winsmux).unwrap();
+        let original = "version: 1\nsession:\n  name: keep\npanes: {}\n";
+        fs::write(winsmux.join("manifest.yaml"), original).unwrap();
+        let err = project_launch(dir.path(), "sess-1", "worker-9", None, None).unwrap_err();
+        assert!(!err.to_string().is_empty());
+        assert_eq!(fs::read_to_string(winsmux.join("manifest.yaml")).unwrap(), original);
+        let runtime = dir.path().join(".winsmux/runtime/prompt-bundles");
+        assert!(!runtime.exists() || fs::read_dir(runtime).map(|entries| entries.count()).unwrap_or(0) == 0);
+    }
+
+    #[test]
+    fn legacy_without_team_profile_is_not_projected() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".winsmux.yaml"), "agent-slots:\n  - slot-id: worker-1\n").unwrap();
+        let err = project_launch(dir.path(), "sess-1", "worker-1", None, None).unwrap_err();
+        assert!(err.to_string().contains("opted-in"));
+    }
+}

--- a/core/src/team_profile.rs
+++ b/core/src/team_profile.rs
@@ -1,0 +1,2065 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env, fs, io,
+    path::{Path, PathBuf},
+};
+
+use serde::Serialize;
+use serde_json::{json, Map, Value as JsonValue};
+use serde_yaml::{Mapping, Value};
+use sha2::{Digest, Sha256};
+
+use crate::project_settings_render;
+use crate::workspace_recipe::parse_workspace_yaml;
+
+pub(crate) const USAGE: &str = "usage: winsmux team-profile --action <validate|resolve|save|reset-field|classify> --json [--project-dir <path>] [--slot-id <id>] [--field <name>] [--value <value>] [--task-class <id>] [--delegation <id>] [--text <text>]";
+
+const OFFICIAL_PRESET_ID: &str = "official-balanced-v1";
+const OFFICIAL_PRESET_YAML: &str =
+    include_str!("../../winsmux-core/agents/team-profiles/official-balanced-v1.yaml");
+const MODEL_CAPABILITIES_TS: &str = include_str!("../../winsmux-app/src/modelCapabilities.ts");
+const SLOT_IDS: [&str; 6] = [
+    "worker-1", "worker-2", "worker-3", "worker-4", "worker-5", "worker-6",
+];
+const ROLE_PROFILES: [&str; 5] = [
+    "architect", "builder", "reviewer", "researcher", "maintainer",
+];
+const LIFECYCLES: [&str; 3] = ["session", "task", "one-shot"];
+const TASK_CLASSES: [&str; 9] = [
+    "architecture",
+    "protocol",
+    "security",
+    "implementation",
+    "test",
+    "review",
+    "research",
+    "documentation",
+    "repository-operations",
+];
+const WORKER_DELEGATION: [&str; 3] = [
+    "frozen-spec-implementation",
+    "repro-fix",
+    "mechanical-migration",
+];
+const OPERATOR_DELEGATION: [&str; 5] = [
+    "design-judgment",
+    "api-judgment",
+    "small-tweak",
+    "secrets-mcp",
+    "destructive-ops",
+];
+const LANE_B_SLOT_FIELDS: [&str; 7] = [
+    "provider",
+    "model",
+    "reasoning-effort",
+    "role-profile",
+    "lifecycle",
+    "task-classes",
+    "delegation",
+];
+const TEAM_PROFILE_FIELDS: [&str; 4] = [
+    "schema-version",
+    "preset",
+    "preset-revision",
+    "update-policy",
+];
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct ValidationIssue {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slot_id: Option<String>,
+    pub field: String,
+    pub code: String,
+    pub severity: String,
+    pub remediation: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct ResolvedSlot {
+    #[serde(rename = "slot-id")]
+    pub slot_id: String,
+    pub provider: String,
+    pub model: String,
+    #[serde(rename = "launch-model")]
+    pub launch_model: String,
+    #[serde(rename = "reasoning-effort")]
+    pub reasoning_effort: String,
+    #[serde(rename = "role-profile")]
+    pub role_profile: String,
+    pub lifecycle: String,
+    #[serde(rename = "task-classes")]
+    pub task_classes: Vec<String>,
+    pub delegation: Vec<String>,
+    pub overrides: Vec<String>,
+    #[serde(rename = "worker-backend", skip_serializing_if = "Option::is_none")]
+    pub worker_backend: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct ResolvedTeam {
+    pub opted_in: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub team_profile: Option<TeamProfileMeta>,
+    pub slots: Vec<ResolvedSlot>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct TeamProfileMeta {
+    #[serde(rename = "schema-version")]
+    pub schema_version: i64,
+    pub preset: String,
+    #[serde(rename = "preset-revision")]
+    pub preset_revision: i64,
+    #[serde(rename = "update-policy")]
+    pub update_policy: String,
+}
+
+#[derive(Clone, Debug)]
+struct SlotRecord {
+    slot_id: String,
+    provider: String,
+    model: String,
+    reasoning_effort: String,
+    role_profile: String,
+    lifecycle: String,
+    task_classes: Vec<String>,
+    delegation: Vec<String>,
+    worker_backend: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct ModelEntry {
+    id: String,
+    provider_id: String,
+    launch_model: String,
+    supported_effort_ids: Vec<String>,
+    required_backend: String,
+    readiness_state: String,
+}
+
+#[derive(Clone, Debug)]
+struct Catalog {
+    providers: BTreeSet<String>,
+    models: BTreeMap<String, ModelEntry>,
+    backends: BTreeMap<String, Vec<String>>,
+}
+
+#[derive(Clone, Debug)]
+struct OverlaySlot {
+    slot_id: String,
+    fields: BTreeMap<String, Value>,
+    extras: Mapping,
+}
+
+#[derive(Default)]
+struct DispatchOptions {
+    task_class: Option<String>,
+    delegation: Option<String>,
+    slot_id: Option<String>,
+    project_dir: Option<PathBuf>,
+    text: String,
+}
+
+pub(crate) fn run_team_profile_command(args: &[&String]) -> io::Result<()> {
+    if args.iter().any(|arg| *arg == "-h" || *arg == "--help") {
+        println!("{USAGE}");
+        return Ok(());
+    }
+    let mut action = None;
+    let mut project_dir = None;
+    let mut json = false;
+    let mut slot_id = None;
+    let mut field = None;
+    let mut value = None;
+    let mut task_class = None;
+    let mut delegation = None;
+    let mut text = None;
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--action" => {
+                action = Some(required_option(args, index, "--action")?);
+                index += 2;
+            }
+            "--project-dir" => {
+                project_dir = Some(PathBuf::from(required_option(args, index, "--project-dir")?));
+                index += 2;
+            }
+            "--slot-id" => {
+                slot_id = Some(required_option(args, index, "--slot-id")?);
+                index += 2;
+            }
+            "--field" => {
+                field = Some(required_option(args, index, "--field")?);
+                index += 2;
+            }
+            "--value" => {
+                value = Some(required_option(args, index, "--value")?);
+                index += 2;
+            }
+            "--task-class" => {
+                task_class = Some(required_option(args, index, "--task-class")?);
+                index += 2;
+            }
+            "--delegation" => {
+                delegation = Some(required_option(args, index, "--delegation")?);
+                index += 2;
+            }
+            "--text" => {
+                text = Some(required_option(args, index, "--text")?);
+                index += 2;
+            }
+            "--json" => {
+                json = true;
+                index += 1;
+            }
+            _ => {
+                return Err(invalid_input("unknown team-profile argument."));
+            }
+        }
+    }
+    if !json {
+        return Err(invalid_input("team-profile requires --json."));
+    }
+    let action = action.ok_or_else(|| {
+        invalid_input("team-profile requires --action validate, resolve, save, reset-field, or classify.")
+    })?;
+    let project_dir = project_dir.unwrap_or(env::current_dir()?);
+    match action.as_str() {
+        "validate" => print_json(validate_project(&project_dir)?),
+        "resolve" => match resolve_project(&project_dir) {
+            Ok(team) => print_json(json!({"schema_version":1,"ok":true,"team":team})),
+            Err(issues) => print_issues(issues),
+        },
+        "save" => {
+            let slot_id = slot_id.ok_or_else(|| invalid_input("save requires --slot-id."))?;
+            let field = field.ok_or_else(|| invalid_input("save requires --field."))?;
+            let value = value.ok_or_else(|| invalid_input("save requires --value."))?;
+            save_slot_field(&project_dir, &slot_id, &field, &value)?;
+            print_json(json!({"schema_version":1,"ok":true,"action":"save"}))
+        }
+        "reset-field" => {
+            let slot_id = slot_id.ok_or_else(|| invalid_input("reset-field requires --slot-id."))?;
+            let field = field.ok_or_else(|| invalid_input("reset-field requires --field."))?;
+            reset_slot_field(&project_dir, &slot_id, &field)?;
+            print_json(json!({"schema_version":1,"ok":true,"action":"reset-field"}))
+        }
+        "classify" => {
+            let payload = classify_project(
+                &project_dir,
+                task_class.as_deref(),
+                delegation.as_deref(),
+                slot_id.as_deref(),
+                text.as_deref().unwrap_or(""),
+            )?;
+            print_json(payload)
+        }
+        _ => Err(invalid_input(
+            "team-profile --action must be validate, resolve, save, reset-field, or classify.",
+        )),
+    }
+}
+
+pub(crate) fn refuse_unclassifiable_dispatch(args: &[&String]) -> io::Result<Option<String>> {
+    let options = parse_dispatch_options(args);
+    let project_dir = options
+        .project_dir
+        .clone()
+        .unwrap_or(env::current_dir()?);
+    let yaml_path = project_dir.join(".winsmux.yaml");
+    if !yaml_path.exists() {
+        return Ok(None);
+    }
+    let yaml = fs::read_to_string(&yaml_path)?;
+    if !document_has_team_profile(&yaml) {
+        return Ok(None);
+    }
+    let payload = classify_project(
+        &project_dir,
+        options.task_class.as_deref(),
+        options.delegation.as_deref(),
+        options.slot_id.as_deref(),
+        &options.text,
+    )?;
+    let status = payload
+        .get("status")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("refused");
+    if status == "dispatchable" {
+        Ok(None)
+    } else {
+        Ok(Some(payload.to_string()))
+    }
+}
+
+fn print_json(value: JsonValue) -> io::Result<()> {
+    println!("{}", value);
+    Ok(())
+}
+
+fn print_issues(issues: Vec<ValidationIssue>) -> io::Result<()> {
+    print_json(json!({"schema_version":1,"ok":false,"issues":issues}))?;
+    Err(invalid_data("team-profile validation failed."))
+}
+
+fn required_option(args: &[&String], index: usize, flag: &str) -> io::Result<String> {
+    args.get(index + 1)
+        .map(|value| (*value).clone())
+        .ok_or_else(|| invalid_input(format!("{flag} requires a value.")))
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+fn issue(
+    slot_id: Option<&str>,
+    field: &str,
+    code: &str,
+    remediation: impl Into<String>,
+) -> ValidationIssue {
+    ValidationIssue {
+        slot_id: slot_id.map(str::to_string),
+        field: field.to_string(),
+        code: code.to_string(),
+        severity: "error".to_string(),
+        remediation: remediation.into(),
+    }
+}
+
+fn document_has_team_profile(yaml: &str) -> bool {
+    yaml.lines().any(|line| {
+        let trimmed = line.trim();
+        trimmed.starts_with("team-profile:") || trimmed.starts_with("team_profile:")
+    })
+}
+
+fn parse_dispatch_options(args: &[&String]) -> DispatchOptions {
+    let mut options = DispatchOptions::default();
+    let mut index = 0;
+    let mut text = Vec::new();
+    while index < args.len() {
+        match args[index].as_str() {
+            "--task-class" if index + 1 < args.len() => {
+                options.task_class = Some(args[index + 1].to_string());
+                index += 2;
+            }
+            "--delegation" if index + 1 < args.len() => {
+                options.delegation = Some(args[index + 1].to_string());
+                index += 2;
+            }
+            "--slot-id" if index + 1 < args.len() => {
+                options.slot_id = Some(args[index + 1].to_string());
+                index += 2;
+            }
+            "--project-dir" if index + 1 < args.len() => {
+                options.project_dir = Some(PathBuf::from(args[index + 1].as_str()));
+                index += 2;
+            }
+            "--json" => index += 1,
+            "--" => {
+                text.extend(args[index + 1..].iter().map(|value| (*value).clone()));
+                break;
+            }
+            other => {
+                text.push(other.to_string());
+                index += 1;
+            }
+        }
+    }
+    options.text = text.join(" ");
+    options
+}
+
+fn catalog() -> Catalog {
+    parse_model_capabilities(MODEL_CAPABILITIES_TS)
+}
+
+fn parse_model_capabilities(source: &str) -> Catalog {
+    let providers = parse_ts_string_array(source, "providerCapabilityIds")
+        .into_iter()
+        .collect();
+    let mut backends = BTreeMap::new();
+    for object in extract_objects(array_body(source, "backendCapabilities")) {
+        if let Some(id) = ts_string_field(object, "id") {
+            backends.insert(id, ts_string_array_field(object, "assignableBackends"));
+        }
+    }
+    let mut models = BTreeMap::new();
+    for object in extract_objects(array_body(source, "modelCapabilities")) {
+        let Some(id) = ts_string_field(object, "id") else {
+            continue;
+        };
+        let Some(provider_id) = ts_string_field(object, "providerId") else {
+            continue;
+        };
+        models.insert(
+            id.clone(),
+            ModelEntry {
+                id,
+                provider_id,
+                launch_model: ts_string_field(object, "model").unwrap_or_default(),
+                supported_effort_ids: ts_string_array_field(object, "supportedEffortIds"),
+                required_backend: ts_string_field(object, "requiredBackend").unwrap_or_default(),
+                readiness_state: ts_readiness_state(object).unwrap_or_default(),
+            },
+        );
+    }
+    Catalog {
+        providers,
+        models,
+        backends,
+    }
+}
+
+fn array_body<'a>(source: &'a str, export_name: &str) -> &'a str {
+    let marker = format!("export const {export_name}");
+    let Some(start) = source.find(&marker) else {
+        return "";
+    };
+    let rest = &source[start..];
+    // Skip TypeScript type brackets such as `readonly ModelCapability[] = [`.
+    let Some(eq) = rest.find('=') else {
+        return "";
+    };
+    let assigned = &rest[eq..];
+    let Some(open) = assigned.find('[') else {
+        return "";
+    };
+    let absolute = start + eq + open;
+    let mut depth = 0;
+    let mut in_str = false;
+    let mut escape = false;
+    for (offset, ch) in source[absolute..].char_indices() {
+        if in_str {
+            if escape {
+                escape = false;
+            } else if ch == '\\' {
+                escape = true;
+            } else if ch == '"' {
+                in_str = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_str = true,
+            '[' => depth += 1,
+            ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &source[absolute + 1..absolute + offset];
+                }
+            }
+            _ => {}
+        }
+    }
+    ""
+}
+
+fn parse_ts_string_array(source: &str, export_name: &str) -> Vec<String> {
+    quoted_strings(array_body(source, export_name))
+}
+
+fn quoted_strings(body: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let mut in_str = false;
+    let mut escape = false;
+    let mut current = String::new();
+    for ch in body.chars() {
+        if in_str {
+            if escape {
+                current.push(ch);
+                escape = false;
+            } else if ch == '\\' {
+                escape = true;
+            } else if ch == '"' {
+                values.push(std::mem::take(&mut current));
+                in_str = false;
+            } else {
+                current.push(ch);
+            }
+        } else if ch == '"' {
+            in_str = true;
+        }
+    }
+    values
+}
+
+fn extract_objects(body: &str) -> Vec<&str> {
+    let mut objects = Vec::new();
+    let bytes = body.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'{' {
+            let start = i;
+            let mut depth = 0;
+            let mut in_str = false;
+            let mut escape = false;
+            while i < bytes.len() {
+                let c = bytes[i];
+                if in_str {
+                    if escape {
+                        escape = false;
+                    } else if c == b'\\' {
+                        escape = true;
+                    } else if c == b'"' {
+                        in_str = false;
+                    }
+                } else if c == b'"' {
+                    in_str = true;
+                } else if c == b'{' {
+                    depth += 1;
+                } else if c == b'}' {
+                    depth -= 1;
+                    if depth == 0 {
+                        objects.push(&body[start..=i]);
+                        break;
+                    }
+                }
+                i += 1;
+            }
+        }
+        i += 1;
+    }
+    objects
+}
+
+fn ts_field_rest<'a>(object: &'a str, field: &str) -> Option<&'a str> {
+    let pattern = format!("{field}:");
+    let mut search = object;
+    while let Some(idx) = search.find(&pattern) {
+        let before = if idx == 0 {
+            ' '
+        } else {
+            search[..idx].chars().next_back().unwrap_or(' ')
+        };
+        if !before.is_ascii_alphanumeric() {
+            return Some(search[idx + pattern.len()..].trim_start());
+        }
+        search = &search[idx + 1..];
+    }
+    None
+}
+
+fn ts_string_field(object: &str, field: &str) -> Option<String> {
+    quoted_strings(ts_field_rest(object, field)?).into_iter().next()
+}
+
+fn ts_string_array_field(object: &str, field: &str) -> Vec<String> {
+    let Some(rest) = ts_field_rest(object, field) else {
+        return Vec::new();
+    };
+    if !rest.starts_with('[') {
+        return Vec::new();
+    }
+    let Some(close) = rest.find(']') else {
+        return Vec::new();
+    };
+    quoted_strings(&rest[1..close])
+}
+
+fn ts_readiness_state(object: &str) -> Option<String> {
+    let idx = object.find("readiness:")?;
+    ts_string_field(&object[idx..], "state")
+}
+
+fn validate_project(project_dir: &Path) -> io::Result<JsonValue> {
+    match resolve_project(project_dir) {
+        Ok(team) => Ok(json!({"schema_version":1,"ok":true,"team":team})),
+        Err(issues) => Ok(json!({"schema_version":1,"ok":false,"issues":issues})),
+    }
+}
+
+fn resolve_project(project_dir: &Path) -> Result<ResolvedTeam, Vec<ValidationIssue>> {
+    let path = project_dir.join(".winsmux.yaml");
+    let yaml = fs::read_to_string(&path).map_err(|_| {
+        vec![issue(
+            None,
+            "document",
+            "missing_settings",
+            "Create .winsmux.yaml before resolving a Team Profile.",
+        )]
+    })?;
+    resolve_yaml(&yaml, OFFICIAL_PRESET_YAML, &catalog())
+}
+
+fn resolve_yaml(
+    yaml: &str,
+    preset_yaml: &str,
+    catalog: &Catalog,
+) -> Result<ResolvedTeam, Vec<ValidationIssue>> {
+    let root = parse_workspace_yaml(yaml).map_err(|error| {
+        vec![issue(
+            None,
+            "document",
+            if error.to_string() == "duplicate YAML mapping key." {
+                "duplicate_mapping_key"
+            } else {
+                "invalid_yaml"
+            },
+            error.to_string(),
+        )]
+    })?;
+    let mapping = root.as_mapping().ok_or_else(|| {
+        vec![issue(
+            None,
+            "document",
+            "root_not_mapping",
+            ".winsmux.yaml must be a mapping.",
+        )]
+    })?;
+    if let Some(version) = mapping_lookup(mapping, "config-version")? {
+        if yaml_i64(version) != Some(1) {
+            return Err(vec![issue(
+                None,
+                "config-version",
+                "unsupported_config_version",
+                "config-version must be 1.",
+            )]);
+        }
+    }
+    let team_profile_value = mapping_lookup(mapping, "team-profile")?;
+    let overlays = parse_overlay_slots(mapping)?;
+    if team_profile_value.is_none() {
+        return Ok(ResolvedTeam {
+            opted_in: false,
+            team_profile: None,
+            slots: overlays
+                .into_iter()
+                .map(|overlay| legacy_slot(overlay))
+                .collect(),
+        });
+    }
+    let meta = parse_team_profile_meta(team_profile_value.unwrap())?;
+    if meta.preset != OFFICIAL_PRESET_ID {
+        return Err(vec![issue(
+            None,
+            "preset",
+            "unknown_preset",
+            format!("Unknown Team Profile preset '{}'.", meta.preset),
+        )]);
+    }
+    let preset_slots = load_preset(preset_yaml)?;
+    let mut overlay_by_id = BTreeMap::new();
+    for overlay in overlays {
+        if !SLOT_IDS.contains(&overlay.slot_id.as_str()) {
+            return Err(vec![issue(
+                Some(&overlay.slot_id),
+                "slot-id",
+                "unknown_slot",
+                "Opted-in agent-slots may only override worker-1 through worker-6.",
+            )]);
+        }
+        if overlay_by_id
+            .insert(overlay.slot_id.clone(), overlay)
+            .is_some()
+        {
+            return Err(vec![issue(
+                None,
+                "slot-id",
+                "duplicate_slot",
+                "agent-slots slot-id values must be unique.",
+            )]);
+        }
+    }
+    let mut resolved = Vec::new();
+    let mut issues = Vec::new();
+    for preset in &preset_slots {
+        let overlay = overlay_by_id.remove(&preset.slot_id);
+        match resolve_slot(preset, overlay.as_ref(), catalog) {
+            Ok(slot) => resolved.push(slot),
+            Err(mut slot_issues) => issues.append(&mut slot_issues),
+        }
+    }
+    if !overlay_by_id.is_empty() {
+        for slot_id in overlay_by_id.keys() {
+            issues.push(issue(
+                Some(slot_id),
+                "slot-id",
+                "unknown_slot",
+                "Opted-in agent-slots may not introduce a slot that is not in the preset.",
+            ));
+        }
+    }
+    if !issues.is_empty() {
+        return Err(issues);
+    }
+    Ok(ResolvedTeam {
+        opted_in: true,
+        team_profile: Some(meta),
+        slots: resolved,
+    })
+}
+
+fn legacy_slot(overlay: OverlaySlot) -> ResolvedSlot {
+    ResolvedSlot {
+        slot_id: overlay.slot_id,
+        provider: overlay
+            .fields
+            .get("provider")
+            .and_then(yaml_text)
+            .or_else(|| overlay.fields.get("agent").and_then(yaml_text))
+            .unwrap_or_default(),
+        model: overlay
+            .fields
+            .get("model")
+            .and_then(yaml_text)
+            .unwrap_or_default(),
+        launch_model: String::new(),
+        reasoning_effort: overlay
+            .fields
+            .get("reasoning-effort")
+            .and_then(yaml_text)
+            .unwrap_or_default(),
+        role_profile: overlay
+            .fields
+            .get("role-profile")
+            .and_then(yaml_text)
+            .unwrap_or_default(),
+        lifecycle: overlay
+            .fields
+            .get("lifecycle")
+            .and_then(yaml_text)
+            .unwrap_or_default(),
+        task_classes: overlay
+            .fields
+            .get("task-classes")
+            .and_then(|value| yaml_string_list(value).ok())
+            .flatten()
+            .unwrap_or_default(),
+        delegation: overlay
+            .fields
+            .get("delegation")
+            .and_then(|value| yaml_string_list(value).ok())
+            .flatten()
+            .unwrap_or_default(),
+        overrides: Vec::new(),
+        worker_backend: overlay
+            .extras
+            .get(&Value::String("worker-backend".into()))
+            .and_then(yaml_text)
+            .or_else(|| {
+                overlay
+                    .extras
+                    .get(&Value::String("worker_backend".into()))
+                    .and_then(yaml_text)
+            }),
+    }
+}
+
+fn resolve_slot(
+    preset: &SlotRecord,
+    overlay: Option<&OverlaySlot>,
+    catalog: &Catalog,
+) -> Result<ResolvedSlot, Vec<ValidationIssue>> {
+    let mut overrides = Vec::new();
+    let mut record = preset.clone();
+    let mut worker_backend = preset.worker_backend.clone();
+    if let Some(overlay) = overlay {
+        for field in LANE_B_SLOT_FIELDS {
+            if overlay.fields.contains_key(field)
+                || (field == "provider" && overlay.fields.contains_key("agent"))
+            {
+                overrides.push(field.to_string());
+            }
+        }
+        if let Some(provider) = overlay_provider(overlay)? {
+            record.provider = provider;
+        }
+        if let Some(model) = overlay.fields.get("model").and_then(yaml_text) {
+            record.model = model;
+        }
+        if let Some(effort) = overlay.fields.get("reasoning-effort").and_then(yaml_text) {
+            record.reasoning_effort = effort;
+        }
+        if let Some(role) = overlay.fields.get("role-profile").and_then(yaml_text) {
+            record.role_profile = role;
+        }
+        if let Some(lifecycle) = overlay.fields.get("lifecycle").and_then(yaml_text) {
+            record.lifecycle = lifecycle;
+        }
+        if let Some(classes) = overlay.fields.get("task-classes") {
+            record.task_classes = yaml_string_list(classes)?.ok_or_else(|| {
+                vec![issue(
+                    Some(&record.slot_id),
+                    "task-classes",
+                    "invalid_task_classes",
+                    "task-classes must be a non-empty list of registered IDs.",
+                )]
+            })?;
+        }
+        if let Some(delegation) = overlay.fields.get("delegation") {
+            record.delegation = yaml_string_list(delegation)?.ok_or_else(|| {
+                vec![issue(
+                    Some(&record.slot_id),
+                    "delegation",
+                    "invalid_delegation",
+                    "delegation must be a non-empty list of worker ownership classes.",
+                )]
+            })?;
+        }
+        worker_backend = overlay
+            .extras
+            .get(&Value::String("worker-backend".into()))
+            .and_then(yaml_text)
+            .or_else(|| {
+                overlay
+                    .extras
+                    .get(&Value::String("worker_backend".into()))
+                    .and_then(yaml_text)
+            })
+            .or(worker_backend);
+    }
+    validate_resolved_slot(&record, worker_backend.as_deref(), catalog)?;
+    let model = catalog.models.get(&record.model).ok_or_else(|| {
+        vec![issue(
+            Some(&record.slot_id),
+            "model",
+            "unknown_model",
+            format!("Unknown model capability ID '{}'.", record.model),
+        )]
+    })?;
+    Ok(ResolvedSlot {
+        slot_id: record.slot_id,
+        provider: record.provider,
+        model: record.model,
+        launch_model: model.launch_model.clone(),
+        reasoning_effort: record.reasoning_effort,
+        role_profile: record.role_profile,
+        lifecycle: record.lifecycle,
+        task_classes: record.task_classes,
+        delegation: record.delegation,
+        overrides,
+        worker_backend,
+    })
+}
+
+fn overlay_provider(overlay: &OverlaySlot) -> Result<Option<String>, Vec<ValidationIssue>> {
+    let provider = overlay.fields.get("provider").and_then(yaml_text);
+    let agent = overlay.fields.get("agent").and_then(yaml_text);
+    match (provider, agent) {
+        (Some(provider), Some(agent)) if provider != agent => Err(vec![issue(
+            Some(&overlay.slot_id),
+            "provider",
+            "ambiguous_provider_alias",
+            "provider and agent disagree; keep provider as the canonical Team Profile field.",
+        )]),
+        (Some(provider), _) => Ok(Some(provider)),
+        (None, Some(agent)) => Ok(Some(agent)),
+        (None, None) => Ok(None),
+    }
+}
+
+fn validate_resolved_slot(
+    record: &SlotRecord,
+    worker_backend: Option<&str>,
+    catalog: &Catalog,
+) -> Result<(), Vec<ValidationIssue>> {
+    let slot_id = record.slot_id.as_str();
+    let mut issues = Vec::new();
+    if record.provider == "provider-default" || record.model == "provider-default" {
+        issues.push(issue(
+            Some(slot_id),
+            if record.provider == "provider-default" {
+                "provider"
+            } else {
+                "model"
+            },
+            "provider_default_forbidden",
+            "Resolved Team Profile slots must use a concrete provider and model capability ID.",
+        ));
+    }
+    if !catalog.providers.contains(&record.provider) || record.provider == "provider-default" {
+        issues.push(issue(
+            Some(slot_id),
+            "provider",
+            "unknown_provider",
+            format!("Unknown provider '{}'.", record.provider),
+        ));
+    }
+    match catalog.models.get(&record.model) {
+        None => issues.push(issue(
+            Some(slot_id),
+            "model",
+            "unknown_model",
+            format!(
+                "Unknown model capability ID '{}'. Use a catalog ID, not a raw CLI model argument.",
+                record.model
+            ),
+        )),
+        Some(model) => {
+            if model.provider_id != record.provider {
+                issues.push(issue(
+                    Some(slot_id),
+                    "model",
+                    "model_provider_mismatch",
+                    format!(
+                        "Model '{}' belongs to provider '{}'.",
+                        record.model, model.provider_id
+                    ),
+                ));
+            }
+            if !model
+                .supported_effort_ids
+                .iter()
+                .any(|effort| effort == &record.reasoning_effort)
+            {
+                issues.push(issue(
+                    Some(slot_id),
+                    "reasoning-effort",
+                    "unsupported_effort",
+                    format!(
+                        "Unsupported reasoning-effort '{}'. Supported values: {}.",
+                        record.reasoning_effort,
+                        model.supported_effort_ids.join(", ")
+                    ),
+                ));
+            }
+            if let Some(backend) = worker_backend {
+                let allowed = catalog
+                    .backends
+                    .get(&model.required_backend)
+                    .cloned()
+                    .unwrap_or_default();
+                let allowed = if allowed.iter().any(|value| value == "*") {
+                    vec![backend.to_string()]
+                } else {
+                    allowed
+                };
+                if !allowed.iter().any(|value| value == backend) {
+                    issues.push(issue(
+                        Some(slot_id),
+                        "worker-backend",
+                        "backend_capability_mismatch",
+                        format!(
+                            "worker-backend '{}' is not in assignableBackends for required backend '{}'.",
+                            backend, model.required_backend
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+    if !ROLE_PROFILES.contains(&record.role_profile.as_str()) {
+        issues.push(issue(
+            Some(slot_id),
+            "role-profile",
+            "unknown_role_profile",
+            format!("Unknown role-profile '{}'.", record.role_profile),
+        ));
+    }
+    if !LIFECYCLES.contains(&record.lifecycle.as_str()) {
+        issues.push(issue(
+            Some(slot_id),
+            "lifecycle",
+            "unknown_lifecycle",
+            format!("Unknown lifecycle '{}'.", record.lifecycle),
+        ));
+    }
+    if record.task_classes.is_empty() {
+        issues.push(issue(
+            Some(slot_id),
+            "task-classes",
+            "empty_task_classes",
+            "task-classes must be a non-empty duplicate-free list.",
+        ));
+    }
+    let mut seen = BTreeSet::new();
+    for class in &record.task_classes {
+        if !TASK_CLASSES.contains(&class.as_str()) {
+            issues.push(issue(
+                Some(slot_id),
+                "task-classes",
+                "unknown_task_class",
+                format!("Unknown task-class '{class}'."),
+            ));
+        }
+        if !seen.insert(class) {
+            issues.push(issue(
+                Some(slot_id),
+                "task-classes",
+                "duplicate_task_class",
+                "task-classes must not contain duplicates.",
+            ));
+        }
+    }
+    if record.delegation.is_empty() {
+        issues.push(issue(
+            Some(slot_id),
+            "delegation",
+            "empty_delegation",
+            "delegation must list the worker-owned classes this slot may accept.",
+        ));
+    }
+    let mut seen_delegation = BTreeSet::new();
+    for item in &record.delegation {
+        if !WORKER_DELEGATION.contains(&item.as_str()) {
+            issues.push(issue(
+                Some(slot_id),
+                "delegation",
+                "unknown_delegation",
+                format!("Unknown worker delegation class '{item}'."),
+            ));
+        }
+        if !seen_delegation.insert(item) {
+            issues.push(issue(
+                Some(slot_id),
+                "delegation",
+                "duplicate_delegation",
+                "delegation must not contain duplicates.",
+            ));
+        }
+    }
+    if issues.is_empty() {
+        Ok(())
+    } else {
+        Err(issues)
+    }
+}
+
+fn parse_team_profile_meta(value: &Value) -> Result<TeamProfileMeta, Vec<ValidationIssue>> {
+    let mapping = value.as_mapping().ok_or_else(|| {
+        vec![issue(
+            None,
+            "team-profile",
+            "invalid_team_profile",
+            "team-profile must be a mapping.",
+        )]
+    })?;
+    let schema_version = mapping_lookup(mapping, "schema-version")?
+        .and_then(yaml_i64)
+        .ok_or_else(|| {
+            vec![issue(
+                None,
+                "schema-version",
+                "missing_schema_version",
+                "team-profile.schema-version is required and must be 1.",
+            )]
+        })?;
+    if schema_version != 1 {
+        return Err(vec![issue(
+            None,
+            "schema-version",
+            "unsupported_schema_version",
+            "Unknown team-profile schema-version.",
+        )]);
+    }
+    let preset = mapping_lookup(mapping, "preset")?
+        .and_then(yaml_text)
+        .ok_or_else(|| {
+            vec![issue(
+                None,
+                "preset",
+                "missing_preset",
+                "team-profile.preset is required.",
+            )]
+        })?;
+    let preset_revision = mapping_lookup(mapping, "preset-revision")?
+        .and_then(yaml_i64)
+        .ok_or_else(|| {
+            vec![issue(
+                None,
+                "preset-revision",
+                "missing_preset_revision",
+                "team-profile.preset-revision is required.",
+            )]
+        })?;
+    let update_policy = mapping_lookup(mapping, "update-policy")?
+        .and_then(yaml_text)
+        .ok_or_else(|| {
+            vec![issue(
+                None,
+                "update-policy",
+                "missing_update_policy",
+                "team-profile.update-policy is required.",
+            )]
+        })?;
+    if update_policy != "retain-overrides" {
+        return Err(vec![issue(
+            None,
+            "update-policy",
+            "unsupported_update_policy",
+            "v1 update-policy must be retain-overrides.",
+        )]);
+    }
+    Ok(TeamProfileMeta {
+        schema_version,
+        preset,
+        preset_revision,
+        update_policy,
+    })
+}
+
+fn parse_overlay_slots(root: &Mapping) -> Result<Vec<OverlaySlot>, Vec<ValidationIssue>> {
+    let Some(value) = mapping_lookup(root, "agent-slots")? else {
+        return Ok(Vec::new());
+    };
+    let sequence = value.as_sequence().ok_or_else(|| {
+        vec![issue(
+            None,
+            "agent-slots",
+            "invalid_agent_slots",
+            "agent-slots must be a sequence of mappings.",
+        )]
+    })?;
+    let mut slots = Vec::new();
+    let mut seen = BTreeSet::new();
+    for item in sequence {
+        let mapping = item.as_mapping().ok_or_else(|| {
+            vec![issue(
+                None,
+                "agent-slots",
+                "invalid_slot_entry",
+                "Every agent-slots entry must be a mapping.",
+            )]
+        })?;
+        let slot_id = mapping_lookup(mapping, "slot-id")?
+            .and_then(yaml_text)
+            .ok_or_else(|| {
+                vec![issue(
+                    None,
+                    "slot-id",
+                    "missing_slot_id",
+                    "Every agent-slots entry must include slot-id.",
+                )]
+            })?;
+        if !seen.insert(slot_id.to_ascii_lowercase()) {
+            return Err(vec![issue(
+                Some(&slot_id),
+                "slot-id",
+                "duplicate_slot",
+                "agent-slots slot-id values must be unique.",
+            )]);
+        }
+        let mut fields = BTreeMap::new();
+        let mut extras = Mapping::new();
+        for (key, value) in mapping {
+            let Some(name) = key.as_str() else {
+                continue;
+            };
+            let canonical = canonical_slot_field(name);
+            if canonical == "slot-id"
+                || LANE_B_SLOT_FIELDS.contains(&canonical.as_str())
+                || canonical == "agent"
+            {
+                if fields.insert(canonical, value.clone()).is_some() {
+                    return Err(vec![issue(
+                        Some(&slot_id),
+                        name,
+                        "ambiguous_alias",
+                        format!("Conflicting aliases for '{name}'."),
+                    )]);
+                }
+            } else {
+                extras.insert(key.clone(), value.clone());
+            }
+        }
+        slots.push(OverlaySlot {
+            slot_id,
+            fields,
+            extras,
+        });
+    }
+    Ok(slots)
+}
+
+fn canonical_slot_field(name: &str) -> String {
+    match name.replace('_', "-").as_str() {
+        "backend" => "worker-backend".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn load_preset(yaml: &str) -> Result<Vec<SlotRecord>, Vec<ValidationIssue>> {
+    let root = parse_workspace_yaml(yaml).map_err(|_| {
+        vec![issue(
+            None,
+            "preset",
+            "invalid_preset",
+            "Package Team Profile preset is not valid YAML.",
+        )]
+    })?;
+    let mapping = root.as_mapping().ok_or_else(|| {
+        vec![issue(
+            None,
+            "preset",
+            "invalid_preset",
+            "Package Team Profile preset must be a mapping.",
+        )]
+    })?;
+    let preset_id = mapping_lookup(mapping, "preset-id")?
+        .and_then(yaml_text)
+        .unwrap_or_default();
+    if preset_id != OFFICIAL_PRESET_ID {
+        return Err(vec![issue(
+            None,
+            "preset",
+            "invalid_preset",
+            "Package preset-id must be official-balanced-v1.",
+        )]);
+    }
+    let slots_value = mapping_lookup(mapping, "slots")?.ok_or_else(|| {
+        vec![issue(
+            None,
+            "preset",
+            "missing_preset_slots",
+            "Package preset must declare six slots.",
+        )]
+    })?;
+    let sequence = slots_value.as_sequence().ok_or_else(|| {
+        vec![issue(
+            None,
+            "preset",
+            "invalid_preset_slots",
+            "Package preset slots must be a sequence.",
+        )]
+    })?;
+    let mut slots = Vec::new();
+    for item in sequence {
+        let mapping = item.as_mapping().ok_or_else(|| {
+            vec![issue(
+                None,
+                "preset",
+                "invalid_preset_slot",
+                "Each preset slot must be a mapping.",
+            )]
+        })?;
+        slots.push(preset_slot_from_mapping(mapping)?);
+    }
+    if slots.len() != 6 {
+        return Err(vec![issue(
+            None,
+            "preset",
+            "missing_preset_slot",
+            "Package preset must contain exactly six unique worker slots.",
+        )]);
+    }
+    let ids: Vec<String> = slots.iter().map(|slot| slot.slot_id.clone()).collect();
+    if ids
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>()
+        != SLOT_IDS.iter().map(|value| value.to_string()).collect::<Vec<_>>()
+        || ids != SLOT_IDS.iter().map(|value| value.to_string()).collect::<Vec<_>>()
+    {
+        return Err(vec![issue(
+            None,
+            "preset",
+            "missing_preset_slot",
+            "Package preset must declare worker-1 through worker-6 exactly once.",
+        )]);
+    }
+    let digest = mapping_lookup(mapping, "digest-sha256")?
+        .and_then(yaml_text)
+        .unwrap_or_default();
+    let expected = slot_digest(&slots);
+    if digest != expected {
+        return Err(vec![issue(
+            None,
+            "digest-sha256",
+            "preset_digest_mismatch",
+            "Package preset digest does not match the six canonical slot records.",
+        )]);
+    }
+    Ok(slots)
+}
+
+fn preset_slot_from_mapping(mapping: &Mapping) -> Result<SlotRecord, Vec<ValidationIssue>> {
+    Ok(SlotRecord {
+        slot_id: required_text(mapping, "slot-id")?,
+        provider: required_text(mapping, "provider")?,
+        model: required_text(mapping, "model")?,
+        reasoning_effort: required_text(mapping, "reasoning-effort")?,
+        role_profile: required_text(mapping, "role-profile")?,
+        lifecycle: required_text(mapping, "lifecycle")?,
+        task_classes: required_list(mapping, "task-classes")?,
+        delegation: required_list(mapping, "delegation")?,
+        worker_backend: mapping_lookup(mapping, "worker-backend")?.and_then(yaml_text),
+    })
+}
+
+fn required_text(mapping: &Mapping, field: &str) -> Result<String, Vec<ValidationIssue>> {
+    mapping_lookup(mapping, field)?
+        .and_then(yaml_text)
+        .ok_or_else(|| {
+            vec![issue(
+                None,
+                field,
+                "invalid_preset_slot",
+                format!("Preset slot is missing {field}."),
+            )]
+        })
+}
+
+fn required_list(mapping: &Mapping, field: &str) -> Result<Vec<String>, Vec<ValidationIssue>> {
+    yaml_string_list(mapping_lookup(mapping, field)?.unwrap_or(&Value::Null))?.ok_or_else(|| {
+        vec![issue(
+            None,
+            field,
+            "invalid_preset_slot",
+            format!("Preset slot is missing {field}."),
+        )]
+    })
+}
+
+fn slot_digest(slots: &[SlotRecord]) -> String {
+    let payload: Vec<BTreeMap<String, JsonValue>> = slots
+        .iter()
+        .map(|slot| {
+            let mut map = BTreeMap::new();
+            map.insert("delegation".into(), json!(slot.delegation));
+            map.insert("lifecycle".into(), json!(slot.lifecycle));
+            map.insert("model".into(), json!(slot.model));
+            map.insert("provider".into(), json!(slot.provider));
+            map.insert("reasoning-effort".into(), json!(slot.reasoning_effort));
+            map.insert("role-profile".into(), json!(slot.role_profile));
+            map.insert("slot-id".into(), json!(slot.slot_id));
+            map.insert("task-classes".into(), json!(slot.task_classes));
+            map
+        })
+        .collect();
+    format!("{:x}", Sha256::digest(serde_json::to_vec(&payload).unwrap()))
+}
+
+fn mapping_lookup<'a>(
+    mapping: &'a Mapping,
+    kebab: &str,
+) -> Result<Option<&'a Value>, Vec<ValidationIssue>> {
+    let snake = kebab.replace('-', "_");
+    let kebab_value = mapping.get(&Value::String(kebab.to_string()));
+    let snake_value = if snake != kebab {
+        mapping.get(&Value::String(snake))
+    } else {
+        None
+    };
+    if kebab_value.is_some() && snake_value.is_some() {
+        return Err(vec![issue(
+            None,
+            kebab,
+            "ambiguous_alias",
+            format!("Both '{kebab}' and its snake_case alias are present."),
+        )]);
+    }
+    Ok(kebab_value.or(snake_value))
+}
+
+fn yaml_text(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => {
+            let text = text.trim();
+            (!text.is_empty()).then(|| text.to_string())
+        }
+        Value::Number(number) => Some(number.to_string()),
+        Value::Bool(flag) => Some(flag.to_string()),
+        _ => None,
+    }
+}
+
+fn yaml_i64(value: &Value) -> Option<i64> {
+    match value {
+        Value::Number(number) => number.as_i64(),
+        Value::String(text) => text.trim().parse().ok(),
+        _ => None,
+    }
+}
+
+fn yaml_string_list(value: &Value) -> Result<Option<Vec<String>>, Vec<ValidationIssue>> {
+    match value {
+        Value::Null => Ok(None),
+        Value::Sequence(items) => {
+            let mut values = Vec::new();
+            for item in items {
+                let Some(text) = yaml_text(item) else {
+                    return Err(vec![issue(
+                        None,
+                        "task-classes",
+                        "invalid_list_item",
+                        "List values must be scalars.",
+                    )]);
+                };
+                values.push(text);
+            }
+            Ok(Some(values))
+        }
+        _ => Err(vec![issue(
+            None,
+            "task-classes",
+            "invalid_list",
+            "Expected a YAML sequence.",
+        )]),
+    }
+}
+
+fn classify_project(
+    project_dir: &Path,
+    task_class: Option<&str>,
+    delegation: Option<&str>,
+    requested_slot: Option<&str>,
+    _text: &str,
+) -> io::Result<JsonValue> {
+    let team = match resolve_project(project_dir) {
+        Ok(team) => team,
+        Err(issues) => {
+            return Ok(json!({
+                "schema_version": 1,
+                "action": "dispatch-classify",
+                "delegation": "unclassifiable",
+                "status": "refused",
+                "reason_code": "invalid_team_profile",
+                "issues": issues
+            }));
+        }
+    };
+    if !team.opted_in {
+        return Ok(json!({
+            "schema_version": 1,
+            "action": "dispatch-classify",
+            "delegation": "legacy",
+            "status": "dispatchable",
+            "reason_code": "legacy_no_team_profile"
+        }));
+    }
+    classify_team(&team, task_class, delegation, requested_slot)
+}
+
+fn classify_team(
+    team: &ResolvedTeam,
+    task_class: Option<&str>,
+    delegation: Option<&str>,
+    requested_slot: Option<&str>,
+) -> io::Result<JsonValue> {
+    let Some(delegation) = delegation.filter(|value| !value.trim().is_empty()) else {
+        return Ok(classify_payload(
+            "unclassifiable",
+            None,
+            task_class,
+            None,
+            "missing_delegation",
+            "refused",
+        ));
+    };
+    let Some(task_class) = task_class.filter(|value| !value.trim().is_empty()) else {
+        return Ok(classify_payload(
+            "unclassifiable",
+            Some(delegation),
+            None,
+            None,
+            "missing_task_class",
+            "refused",
+        ));
+    };
+    if !TASK_CLASSES.contains(&task_class) {
+        return Ok(classify_payload(
+            "unclassifiable",
+            Some(delegation),
+            Some(task_class),
+            None,
+            "unknown_task_class",
+            "refused",
+        ));
+    }
+    if OPERATOR_DELEGATION.contains(&delegation) {
+        return Ok(classify_payload(
+            "operator",
+            Some(delegation),
+            Some(task_class),
+            None,
+            "operator_owned",
+            "returned_to_operator",
+        ));
+    }
+    if !WORKER_DELEGATION.contains(&delegation) {
+        return Ok(classify_payload(
+            "unclassifiable",
+            Some(delegation),
+            Some(task_class),
+            None,
+            "unknown_delegation",
+            "refused",
+        ));
+    }
+    let mut matches: Vec<&ResolvedSlot> = team
+        .slots
+        .iter()
+        .filter(|slot| {
+            slot.task_classes.iter().any(|class| class == task_class)
+                && slot.delegation.iter().any(|item| item == delegation)
+        })
+        .collect();
+    if let Some(requested) = requested_slot {
+        matches.retain(|slot| slot.slot_id == requested);
+    }
+    if let Some(slot) = matches.first() {
+        return Ok(classify_payload(
+            "worker",
+            Some(delegation),
+            Some(task_class),
+            Some(&slot.slot_id),
+            "slot_matched",
+            "dispatchable",
+        ));
+    }
+    Ok(classify_payload(
+        "operator",
+        Some(delegation),
+        Some(task_class),
+        None,
+        "no_matching_slot",
+        "returned_to_operator",
+    ))
+}
+
+fn classify_payload(
+    owner: &str,
+    delegation_class: Option<&str>,
+    task_class: Option<&str>,
+    slot_id: Option<&str>,
+    reason_code: &str,
+    status: &str,
+) -> JsonValue {
+    json!({
+        "schema_version": 1,
+        "action": "dispatch-classify",
+        "delegation": owner,
+        "delegation_class": delegation_class,
+        "task_class": task_class,
+        "slot_id": slot_id,
+        "reason_code": reason_code,
+        "status": status
+    })
+}
+
+fn project_yaml_path(project_dir: &Path) -> PathBuf {
+    if project_dir.ends_with(".winsmux.yaml") {
+        project_dir.to_path_buf()
+    } else {
+        project_dir.join(".winsmux.yaml")
+    }
+}
+
+fn save_slot_field(
+    project_dir: &Path,
+    slot_id: &str,
+    field: &str,
+    value: &str,
+) -> io::Result<()> {
+    let field = field.replace('_', "-");
+    if !LANE_B_SLOT_FIELDS.contains(&field.as_str()) {
+        return Err(invalid_input(format!(
+            "save --field must be one of {}.",
+            LANE_B_SLOT_FIELDS.join(", ")
+        )));
+    }
+    let path = project_yaml_path(project_dir);
+    let original = fs::read_to_string(&path)?;
+    let mut overlays = overlay_json_from_yaml(&original)?;
+    let entry = overlays.iter_mut().find(|entry| {
+        entry
+            .get("slot-id")
+            .or_else(|| entry.get("slot_id"))
+            .and_then(JsonValue::as_str)
+            == Some(slot_id)
+    });
+    let json_value = field_to_json(&field, value)?;
+    if let Some(entry) = entry {
+        entry.insert(field.clone(), json_value);
+    } else {
+        let mut map = Map::new();
+        map.insert("slot-id".into(), json!(slot_id));
+        map.insert(field, json_value);
+        overlays.push(map);
+    }
+    let rendered = project_settings_render::render_owned_lane_b(
+        &original,
+        None,
+        Some(JsonValue::Array(
+            overlays
+                .into_iter()
+                .map(|entry| JsonValue::Object(lane_b_desired_slot(&entry)))
+                .collect(),
+        )),
+    )?;
+    replace_validated(&path, &original, &rendered)
+}
+
+fn reset_slot_field(project_dir: &Path, slot_id: &str, field: &str) -> io::Result<()> {
+    let field = field.replace('_', "-");
+    if !LANE_B_SLOT_FIELDS.contains(&field.as_str()) {
+        return Err(invalid_input(format!(
+            "reset-field --field must be one of {}.",
+            LANE_B_SLOT_FIELDS.join(", ")
+        )));
+    }
+    let path = project_yaml_path(project_dir);
+    let original = fs::read_to_string(&path)?;
+    let mut overlays = overlay_json_from_yaml(&original)?;
+    overlays.retain_mut(|entry| {
+        let matches = entry
+            .get("slot-id")
+            .or_else(|| entry.get("slot_id"))
+            .and_then(JsonValue::as_str)
+            == Some(slot_id);
+        if matches {
+            entry.remove(&field);
+            entry.remove(&field.replace('-', "_"));
+            if field == "provider" {
+                entry.remove("agent");
+            }
+        }
+        let lane_b_remaining = LANE_B_SLOT_FIELDS.iter().any(|name| {
+            entry.contains_key(*name) || entry.contains_key(&(*name).replace('-', "_"))
+        }) || entry.contains_key("agent");
+        let has_extras = entry.keys().any(|key| {
+            let canonical = canonical_slot_field(key);
+            canonical != "slot-id"
+                && canonical != "agent"
+                && !LANE_B_SLOT_FIELDS.contains(&canonical.as_str())
+        });
+        !(matches && !lane_b_remaining && !has_extras)
+    });
+    let rendered = project_settings_render::render_owned_lane_b(
+        &original,
+        None,
+        Some(JsonValue::Array(
+            overlays
+                .into_iter()
+                .map(|entry| JsonValue::Object(lane_b_desired_slot(&entry)))
+                .collect(),
+        )),
+    )?;
+    replace_validated(&path, &original, &rendered)
+}
+
+fn lane_b_desired_slot(entry: &Map<String, JsonValue>) -> Map<String, JsonValue> {
+    let mut out = Map::new();
+    for key in [
+        "slot-id",
+        "slot_id",
+        "agent",
+        "provider",
+        "model",
+        "reasoning-effort",
+        "reasoning_effort",
+        "role-profile",
+        "role_profile",
+        "lifecycle",
+        "task-classes",
+        "task_classes",
+        "delegation",
+    ] {
+        if let Some(value) = entry.get(key) {
+            out.insert(key.to_string(), value.clone());
+        }
+    }
+    out
+}
+
+fn field_to_json(field: &str, value: &str) -> io::Result<JsonValue> {
+    if field == "task-classes" || field == "delegation" {
+        let items: Vec<String> = value
+            .split(',')
+            .map(str::trim)
+            .filter(|item| !item.is_empty())
+            .map(str::to_string)
+            .collect();
+        return Ok(json!(items));
+    }
+    Ok(json!(value))
+}
+
+fn overlay_json_from_yaml(yaml: &str) -> io::Result<Vec<Map<String, JsonValue>>> {
+    let root = parse_workspace_yaml(yaml)?;
+    let mapping = root
+        .as_mapping()
+        .ok_or_else(|| invalid_data(".winsmux.yaml must be a mapping."))?;
+    let Some(value) = mapping
+        .get(&Value::String("agent-slots".into()))
+        .or_else(|| mapping.get(&Value::String("agent_slots".into())))
+    else {
+        return Ok(Vec::new());
+    };
+    let sequence = value
+        .as_sequence()
+        .ok_or_else(|| invalid_data("agent-slots must be a sequence."))?;
+    let mut overlays = Vec::new();
+    for item in sequence {
+        let slot_mapping = item
+            .as_mapping()
+            .ok_or_else(|| invalid_data("agent-slots entries must be mappings."))?;
+        let mut map = Map::new();
+        for (key, value) in slot_mapping {
+            let Some(name) = key.as_str() else {
+                continue;
+            };
+            map.insert(name.to_string(), yaml_to_json(value));
+        }
+        overlays.push(map);
+    }
+    Ok(overlays)
+}
+
+fn yaml_to_json(value: &Value) -> JsonValue {
+    match value {
+        Value::Null => JsonValue::Null,
+        Value::Bool(flag) => json!(flag),
+        Value::Number(number) => {
+            if let Some(value) = number.as_i64() {
+                json!(value)
+            } else if let Some(value) = number.as_f64() {
+                json!(value)
+            } else {
+                JsonValue::Null
+            }
+        }
+        Value::String(text) => json!(text),
+        Value::Sequence(items) => JsonValue::Array(items.iter().map(yaml_to_json).collect()),
+        Value::Mapping(mapping) => {
+            let mut map = Map::new();
+            for (key, value) in mapping {
+                if let Some(name) = key.as_str() {
+                    map.insert(name.to_string(), yaml_to_json(value));
+                }
+            }
+            JsonValue::Object(map)
+        }
+        Value::Tagged(tagged) => yaml_to_json(&tagged.value),
+    }
+}
+
+fn replace_validated(path: &Path, original: &str, rendered: &str) -> io::Result<()> {
+    if let Err(issues) = resolve_yaml(rendered, OFFICIAL_PRESET_YAML, &catalog()) {
+        return Err(invalid_data(serde_json::to_string(&issues).unwrap_or_else(
+            |_| "team-profile validation failed.".to_string(),
+        )));
+    }
+    replace_file(path, rendered).map_err(|error| {
+        let _ = fs::write(path, original);
+        error
+    })
+}
+
+fn replace_file(path: &Path, contents: &str) -> io::Result<()> {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| invalid_input("team-profile cannot write the target path."))?;
+    let tmp = path.with_file_name(format!(
+        "{}.tmp-team-profile-{}",
+        file_name,
+        std::process::id()
+    ));
+    fs::write(&tmp, contents)?;
+    let result = fs::rename(&tmp, path);
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn opted_in_empty() -> &'static str {
+        "config-version: 1\nteam-profile:\n  schema-version: 1\n  preset: official-balanced-v1\n  preset-revision: 1\n  update-policy: retain-overrides\nagent-slots: []\n"
+    }
+
+    fn catalog_fixture() -> Catalog {
+        catalog()
+    }
+
+    #[test]
+    fn catalog_contains_official_balanced_models() {
+        let catalog = catalog_fixture();
+        for id in [
+            "codex-gpt-5-6-sol",
+            "codex-gpt-5-6-terra",
+            "codex-gpt-5-6-luna",
+            "openrouter-glm-5-2",
+        ] {
+            assert!(catalog.models.contains_key(id), "missing {id}");
+        }
+        assert!(catalog.providers.contains("codex"));
+        assert_eq!(
+            catalog.backends.get("agent-cli").cloned().unwrap_or_default(),
+            vec![
+                "".to_string(),
+                "local".to_string(),
+                "codex".to_string(),
+                "claude".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn official_preset_digest_matches_canonical_slots() {
+        let slots = load_preset(OFFICIAL_PRESET_YAML).expect("official preset");
+        assert_eq!(slot_digest(&slots), "7d671140ed9020dae23e27458242f5deb1146bead5d4886d6c2f786059a9b8f5");
+        assert_eq!(slots.len(), 6);
+        assert_eq!(slots[0].role_profile, "architect");
+        assert_eq!(slots[5].model, "codex-gpt-5-6-luna");
+    }
+
+    #[test]
+    fn empty_overrides_resolve_six_preset_slots() {
+        let team = resolve_yaml(opted_in_empty(), OFFICIAL_PRESET_YAML, &catalog_fixture())
+            .expect("empty overrides");
+        assert!(team.opted_in);
+        assert_eq!(team.slots.len(), 6);
+        assert!(team.slots.iter().all(|slot| slot.overrides.is_empty()));
+        assert_eq!(team.slots[1].launch_model, "gpt-5.6-terra");
+    }
+
+    #[test]
+    fn sparse_overrides_overlay_by_slot_id() {
+        let yaml = r#"
+config-version: 1
+team-profile:
+  schema-version: 1
+  preset: official-balanced-v1
+  preset-revision: 1
+  update-policy: retain-overrides
+agent-slots:
+  - slot-id: worker-6
+    provider: openrouter
+    model: openrouter-glm-5-2
+    worker-backend: api_llm
+    reasoning-effort: provider-default
+    role-profile: maintainer
+    lifecycle: task
+    task-classes: [documentation, repository-operations]
+"#;
+        let team = resolve_yaml(yaml, OFFICIAL_PRESET_YAML, &catalog_fixture()).expect("sparse");
+        assert_eq!(team.slots.len(), 6);
+        let worker6 = &team.slots[5];
+        assert_eq!(worker6.provider, "openrouter");
+        assert_eq!(worker6.model, "openrouter-glm-5-2");
+        assert_eq!(worker6.launch_model, "z-ai/glm-5.2");
+        assert_eq!(worker6.worker_backend.as_deref(), Some("api_llm"));
+        assert!(worker6.overrides.contains(&"provider".to_string()));
+        assert_eq!(team.slots[0].provider, "codex");
+    }
+
+    #[test]
+    fn agent_alias_maps_to_provider() {
+        let yaml = r#"
+config-version: 1
+team-profile:
+  schema-version: 1
+  preset: official-balanced-v1
+  preset-revision: 1
+  update-policy: retain-overrides
+agent-slots:
+  - slot-id: worker-2
+    agent: codex
+"#;
+        let team = resolve_yaml(yaml, OFFICIAL_PRESET_YAML, &catalog_fixture()).expect("alias");
+        assert_eq!(team.slots[1].provider, "codex");
+        assert!(team.slots[1].overrides.contains(&"provider".to_string()));
+    }
+
+    #[test]
+    fn seventh_slot_is_rejected() {
+        let yaml = format!(
+            "{}  - slot-id: worker-7\n    provider: codex\n",
+            opted_in_empty().replace("agent-slots: []\n", "agent-slots:\n")
+        );
+        let error = resolve_yaml(&yaml, OFFICIAL_PRESET_YAML, &catalog_fixture()).unwrap_err();
+        assert!(error.iter().any(|issue| issue.code == "unknown_slot"));
+    }
+
+    #[test]
+    fn duplicate_mapping_key_is_rejected() {
+        let yaml = "team-profile: {}\nteam-profile: {}\n";
+        let error = resolve_yaml(yaml, OFFICIAL_PRESET_YAML, &catalog_fixture()).unwrap_err();
+        assert!(error.iter().any(|issue| issue.code == "duplicate_mapping_key"));
+    }
+
+    #[test]
+    fn duplicate_slot_ids_are_rejected() {
+        let yaml = r#"
+team-profile:
+  schema-version: 1
+  preset: official-balanced-v1
+  preset-revision: 1
+  update-policy: retain-overrides
+agent-slots:
+  - slot-id: worker-1
+  - slot-id: worker-1
+"#;
+        let error = resolve_yaml(yaml, OFFICIAL_PRESET_YAML, &catalog_fixture()).unwrap_err();
+        assert!(error.iter().any(|issue| issue.code == "duplicate_slot"));
+    }
+
+    #[test]
+    fn missing_preset_slot_is_rejected() {
+        let tampered = OFFICIAL_PRESET_YAML.replace(
+            "  - slot-id: worker-6\n",
+            "  - slot-id: worker-x\n",
+        );
+        let error = resolve_yaml(opted_in_empty(), &tampered, &catalog_fixture()).unwrap_err();
+        assert!(error
+            .iter()
+            .any(|issue| issue.code == "missing_preset_slot" || issue.code == "preset_digest_mismatch"));
+    }
+
+    #[test]
+    fn invalid_enum_and_catalog_mismatch_fail_closed() {
+        let yaml = r#"
+team-profile:
+  schema-version: 1
+  preset: official-balanced-v1
+  preset-revision: 1
+  update-policy: retain-overrides
+agent-slots:
+  - slot-id: worker-1
+    model: openrouter-glm-5-2
+    reasoning-effort: not-an-effort
+    role-profile: wizard
+"#;
+        let error = resolve_yaml(yaml, OFFICIAL_PRESET_YAML, &catalog_fixture()).unwrap_err();
+        assert!(error.iter().any(|issue| issue.code == "model_provider_mismatch"));
+        assert!(error.iter().any(|issue| issue.code == "unknown_role_profile"));
+        assert!(error.iter().any(|issue| issue.code == "unsupported_effort"));
+    }
+
+    #[test]
+    fn legacy_sparse_agent_slots_without_team_profile_stay_unchanged() {
+        let yaml = "agent-slots:\n  - slot-id: worker-1\n    agent: codex\n  - slot-id: extra-1\n    model: leftover\n";
+        let team = resolve_yaml(yaml, OFFICIAL_PRESET_YAML, &catalog_fixture()).expect("legacy");
+        assert!(!team.opted_in);
+        assert_eq!(team.slots.len(), 2);
+        assert_eq!(team.slots[1].slot_id, "extra-1");
+        assert_eq!(team.slots[1].model, "leftover");
+    }
+
+    #[test]
+    fn save_lane_b_preserves_lane_a_and_unknown_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".winsmux.yaml");
+        let original = r#"config-version: 1
+workspace-recipes:
+  keep-me:
+    schema-version: 1
+workflows:
+  keep: true
+context-packs:
+  keep: true
+future-top-level:
+  owner: future
+team-profile:
+  schema-version: 1
+  preset: official-balanced-v1
+  preset-revision: 1
+  update-policy: retain-overrides
+  future-lane-b-field: preserve-me
+agent-slots:
+  - slot-id: worker-2
+    agent: codex
+    worktree-mode: managed
+    pane_title: keep-title
+"#;
+        fs::write(&path, original).unwrap();
+        save_slot_field(dir.path(), "worker-2", "reasoning-effort", "high").unwrap();
+        let saved = fs::read_to_string(&path).unwrap();
+        assert!(saved.contains("workspace-recipes:"));
+        assert!(saved.contains("keep-me:"));
+        assert!(saved.contains("workflows:"));
+        assert!(saved.contains("context-packs:"));
+        assert!(saved.contains("future-top-level:"));
+        assert!(saved.contains("future-lane-b-field: preserve-me"));
+        assert!(saved.contains("worktree-mode: managed"));
+        assert!(saved.contains("pane_title: keep-title"));
+        assert!(
+            saved.contains("agent: codex")
+                || saved.contains("agent: \"codex\"")
+                || saved.contains("provider: codex")
+                || saved.contains("provider: \"codex\""),
+            "expected preserved provider alias, saved={saved}"
+        );
+        assert!(
+            saved.contains("reasoning-effort: high")
+                || saved.contains("reasoning-effort: \"high\"")
+                || saved.contains("reasoning_effort: high")
+        );
+        let team = resolve_yaml(&saved, OFFICIAL_PRESET_YAML, &catalog_fixture()).unwrap();
+        assert_eq!(team.slots[1].reasoning_effort, "high");
+        assert!(team.slots[1].overrides.contains(&"reasoning-effort".to_string()));
+    }
+
+    #[test]
+    fn preset_revision_retains_overrides_until_explicit_reset() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".winsmux.yaml");
+        fs::write(&path, opted_in_empty().replace(
+            "agent-slots: []\n",
+            "agent-slots:\n  - slot-id: worker-6\n    reasoning-effort: low\n",
+        ))
+        .unwrap();
+        let before = fs::read_to_string(&path).unwrap();
+        assert!(before.contains("reasoning-effort: low"));
+        reset_slot_field(dir.path(), "worker-6", "reasoning-effort").unwrap();
+        let after = fs::read_to_string(&path).unwrap();
+        assert!(!after.contains("reasoning-effort: low"));
+        let team = resolve_yaml(&after, OFFICIAL_PRESET_YAML, &catalog_fixture()).unwrap();
+        assert_eq!(team.slots[5].reasoning_effort, "medium");
+        assert!(!team.slots[5].overrides.contains(&"reasoning-effort".to_string()));
+    }
+
+    #[test]
+    fn failed_validation_leaves_original_file_intact() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".winsmux.yaml");
+        fs::write(&path, opted_in_empty()).unwrap();
+        let original = fs::read_to_string(&path).unwrap();
+        let err = save_slot_field(dir.path(), "worker-1", "model", "not-a-catalog-id").unwrap_err();
+        assert!(!err.to_string().is_empty());
+        assert_eq!(fs::read_to_string(&path).unwrap(), original);
+    }
+
+    #[test]
+    fn failed_atomic_replace_leaves_destination_intact() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".winsmux.yaml");
+        fs::create_dir(&path).unwrap();
+        fs::write(path.join("marker"), b"keep").unwrap();
+        assert!(replace_file(&path, "config-version: 1\n").is_err());
+        assert_eq!(fs::read(path.join("marker")).unwrap(), b"keep");
+    }
+
+    #[test]
+    fn classify_refuses_unclassifiable_and_returns_operator_owned() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".winsmux.yaml"), opted_in_empty()).unwrap();
+        let missing = classify_project(dir.path(), None, None, None, "implement anything").unwrap();
+        assert_eq!(missing["delegation"], "unclassifiable");
+        assert_eq!(missing["reason_code"], "missing_delegation");
+        let operator = classify_project(
+            dir.path(),
+            Some("implementation"),
+            Some("destructive-ops"),
+            None,
+            "reset production",
+        )
+        .unwrap();
+        assert_eq!(operator["delegation"], "operator");
+        assert_eq!(operator["reason_code"], "operator_owned");
+        let worker = classify_project(
+            dir.path(),
+            Some("implementation"),
+            Some("frozen-spec-implementation"),
+            None,
+            "implement the frozen spec",
+        )
+        .unwrap();
+        assert_eq!(worker["status"], "dispatchable");
+        assert_eq!(worker["slot_id"], "worker-2");
+    }
+}

--- a/core/src/team_profile.rs
+++ b/core/src/team_profile.rs
@@ -1496,14 +1496,39 @@ fn classify_team(
         matches.retain(|slot| slot.slot_id == requested);
     }
     if let Some(slot) = matches.first() {
-        return Ok(classify_payload(
-            "worker",
-            Some(delegation),
-            Some(task_class),
-            Some(&slot.slot_id),
-            "slot_matched",
-            "dispatchable",
-        ));
+        match crate::instruction_pack::compose_json(
+            &slot.provider,
+            &slot.model,
+            &slot.role_profile,
+            &slot.lifecycle,
+            &slot.task_classes,
+        ) {
+            Ok(pack) => {
+                let mut payload = classify_payload(
+                    "worker",
+                    Some(delegation),
+                    Some(task_class),
+                    Some(&slot.slot_id),
+                    "slot_matched",
+                    "dispatchable",
+                );
+                payload["instruction_pack"] = pack;
+                return Ok(payload);
+            }
+            Err(issues) => {
+                return Ok(serde_json::json!({
+                    "schema_version": 1,
+                    "action": "dispatch-classify",
+                    "delegation": "unclassifiable",
+                    "delegation_class": delegation,
+                    "task_class": task_class,
+                    "slot_id": slot.slot_id,
+                    "reason_code": "missing_instruction_pack",
+                    "status": "refused",
+                    "issues": issues
+                }));
+            }
+        }
     }
     Ok(classify_payload(
         "operator",
@@ -1773,6 +1798,24 @@ mod tests {
 
     fn catalog_fixture() -> Catalog {
         catalog()
+    }
+
+    #[test]
+    fn every_selectable_catalog_model_has_an_instruction_pack() {
+        let catalog = catalog_fixture();
+        for (id, model) in &catalog.models {
+            if id == "provider-default" {
+                continue;
+            }
+            crate::instruction_pack::compose_pack(
+                &model.provider_id,
+                id,
+                "builder",
+                "task",
+                &["implementation".to_string()],
+            )
+            .unwrap_or_else(|issues| panic!("{id}: {issues:?}"));
+        }
     }
 
     #[test]
@@ -2061,5 +2104,11 @@ agent-slots:
         .unwrap();
         assert_eq!(worker["status"], "dispatchable");
         assert_eq!(worker["slot_id"], "worker-2");
+        assert_eq!(worker["instruction_pack"]["a1"]["worker"][0], "frozen-spec-implementation");
+        assert!(worker["instruction_pack"]["template_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|id| id == "base"));
     }
 }

--- a/core/src/team_profile.rs
+++ b/core/src/team_profile.rs
@@ -157,6 +157,7 @@ struct DispatchOptions {
     delegation: Option<String>,
     slot_id: Option<String>,
     project_dir: Option<PathBuf>,
+    output: Option<PathBuf>,
     text: String,
 }
 
@@ -385,6 +386,10 @@ fn parse_dispatch_options(args: &[&String]) -> DispatchOptions {
             }
             "--project-dir" if index + 1 < args.len() => {
                 options.project_dir = Some(PathBuf::from(args[index + 1].as_str()));
+                index += 2;
+            }
+            "--output" | "-o" if index + 1 < args.len() => {
+                options.output = Some(PathBuf::from(args[index + 1].as_str()));
                 index += 2;
             }
             "--json" => index += 1,
@@ -1540,6 +1545,11 @@ fn classify_team(
                     "dispatchable",
                 );
                 payload["instruction_pack"] = pack;
+                payload["artifact"] = serde_json::json!({
+                    "output": format!(".winsmux/runs/{}/result.md", slot.slot_id),
+                    "completion_authority": "output-file-and-exit-code",
+                    "pty_capture_is_auxiliary": true
+                });
                 return Ok(payload);
             }
             Err(issues) => {

--- a/core/src/team_profile.rs
+++ b/core/src/team_profile.rs
@@ -160,6 +160,13 @@ struct DispatchOptions {
     text: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum DispatchGate {
+    Passthrough,
+    Refused(String),
+    Classified { slot_id: String },
+}
+
 pub(crate) fn run_team_profile_command(args: &[&String]) -> io::Result<()> {
     if args.iter().any(|arg| *arg == "-h" || *arg == "--help") {
         println!("{USAGE}");
@@ -226,7 +233,10 @@ pub(crate) fn run_team_profile_command(args: &[&String]) -> io::Result<()> {
     })?;
     let project_dir = project_dir.unwrap_or(env::current_dir()?);
     match action.as_str() {
-        "validate" => print_json(validate_project(&project_dir)?),
+        "validate" => match resolve_project(&project_dir) {
+            Ok(team) => print_json(json!({"schema_version":1,"ok":true,"team":team})),
+            Err(issues) => print_issues(issues),
+        },
         "resolve" => match resolve_project(&project_dir) {
             Ok(team) => print_json(json!({"schema_version":1,"ok":true,"team":team})),
             Err(issues) => print_issues(issues),
@@ -260,7 +270,7 @@ pub(crate) fn run_team_profile_command(args: &[&String]) -> io::Result<()> {
     }
 }
 
-pub(crate) fn refuse_unclassifiable_dispatch(args: &[&String]) -> io::Result<Option<String>> {
+pub(crate) fn gate_dispatch(args: &[&String]) -> io::Result<DispatchGate> {
     let options = parse_dispatch_options(args);
     let project_dir = options
         .project_dir
@@ -268,11 +278,11 @@ pub(crate) fn refuse_unclassifiable_dispatch(args: &[&String]) -> io::Result<Opt
         .unwrap_or(env::current_dir()?);
     let yaml_path = project_dir.join(".winsmux.yaml");
     if !yaml_path.exists() {
-        return Ok(None);
+        return Ok(DispatchGate::Passthrough);
     }
     let yaml = fs::read_to_string(&yaml_path)?;
     if !document_has_team_profile(&yaml) {
-        return Ok(None);
+        return Ok(DispatchGate::Passthrough);
     }
     let payload = classify_project(
         &project_dir,
@@ -285,11 +295,43 @@ pub(crate) fn refuse_unclassifiable_dispatch(args: &[&String]) -> io::Result<Opt
         .get("status")
         .and_then(JsonValue::as_str)
         .unwrap_or("refused");
-    if status == "dispatchable" {
-        Ok(None)
-    } else {
-        Ok(Some(payload.to_string()))
+    if status != "dispatchable" {
+        return Ok(DispatchGate::Refused(payload.to_string()));
     }
+    let slot_id = payload
+        .get("slot_id")
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if let Some(slot_id) = slot_id {
+        Ok(DispatchGate::Classified {
+            slot_id: slot_id.to_string(),
+        })
+    } else {
+        Ok(DispatchGate::Passthrough)
+    }
+}
+
+pub(crate) fn with_classified_slot(cmd_args: &[&String], slot_id: &str) -> Vec<String> {
+    let mut forwarded: Vec<String> = cmd_args.iter().map(|arg| (*arg).clone()).collect();
+    if dispatch_args_have_slot_id(&forwarded) {
+        return forwarded;
+    }
+    forwarded.push("--slot-id".to_string());
+    forwarded.push(slot_id.to_string());
+    forwarded
+}
+
+fn dispatch_args_have_slot_id(args: &[String]) -> bool {
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--slot-id" => return true,
+            "--" => return false,
+            _ => index += 1,
+        }
+    }
+    false
 }
 
 fn print_json(value: JsonValue) -> io::Result<()> {
@@ -565,13 +607,6 @@ fn ts_string_array_field(object: &str, field: &str) -> Vec<String> {
 fn ts_readiness_state(object: &str) -> Option<String> {
     let idx = object.find("readiness:")?;
     ts_string_field(&object[idx..], "state")
-}
-
-fn validate_project(project_dir: &Path) -> io::Result<JsonValue> {
-    match resolve_project(project_dir) {
-        Ok(team) => Ok(json!({"schema_version":1,"ok":true,"team":team})),
-        Err(issues) => Ok(json!({"schema_version":1,"ok":false,"issues":issues})),
-    }
 }
 
 fn resolve_project(project_dir: &Path) -> Result<ResolvedTeam, Vec<ValidationIssue>> {
@@ -1569,6 +1604,9 @@ fn save_slot_field(
     let json_value = field_to_json(&field, value)?;
     if let Some(entry) = entry {
         entry.insert(field.clone(), json_value);
+        if field == "provider" {
+            entry.remove("agent");
+        }
     } else {
         let mut map = Map::new();
         map.insert("slot-id".into(), json!(slot_id));
@@ -1900,10 +1938,25 @@ agent-slots:
 
     #[test]
     fn missing_preset_slot_is_rejected() {
-        let tampered = OFFICIAL_PRESET_YAML.replace(
-            "  - slot-id: worker-6\n",
-            "  - slot-id: worker-x\n",
+        let normalized = OFFICIAL_PRESET_YAML.replace("\r\n", "\n");
+        let needle = "  - slot-id: worker-6\n";
+        assert!(
+            normalized.contains(needle),
+            "official preset must contain worker-6 after CRLF normalization"
         );
+        let tampered = normalized.replace(needle, "  - slot-id: worker-x\n");
+        assert_ne!(tampered, normalized, "tamper must change the preset bytes");
+        let error = resolve_yaml(opted_in_empty(), &tampered, &catalog_fixture()).unwrap_err();
+        assert!(error
+            .iter()
+            .any(|issue| issue.code == "missing_preset_slot" || issue.code == "preset_digest_mismatch"));
+    }
+
+    #[test]
+    fn missing_preset_slot_is_rejected_when_include_str_embeds_crlf() {
+        let crlf = OFFICIAL_PRESET_YAML.replace("\r\n", "\n").replace('\n', "\r\n");
+        let normalized = crlf.replace("\r\n", "\n");
+        let tampered = normalized.replace("  - slot-id: worker-6\n", "  - slot-id: worker-x\n");
         let error = resolve_yaml(opted_in_empty(), &tampered, &catalog_fixture()).unwrap_err();
         assert!(error
             .iter()
@@ -2061,5 +2114,89 @@ agent-slots:
         .unwrap();
         assert_eq!(worker["status"], "dispatchable");
         assert_eq!(worker["slot_id"], "worker-2");
+    }
+
+    #[test]
+    fn save_provider_replaces_legacy_agent_alias() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".winsmux.yaml");
+        fs::write(
+            &path,
+            opted_in_empty().replace(
+                "agent-slots: []\n",
+                "agent-slots:\n  - slot-id: worker-2\n    agent: codex\n",
+            ),
+        )
+        .unwrap();
+        save_slot_field(dir.path(), "worker-2", "provider", "codex").unwrap();
+        let saved = fs::read_to_string(&path).unwrap();
+        assert!(
+            saved.contains("provider: codex") || saved.contains("provider: \"codex\""),
+            "canonical provider must be written, saved={saved}"
+        );
+        assert!(
+            !saved.contains("agent:"),
+            "legacy agent alias must be removed when saving provider, saved={saved}"
+        );
+    }
+
+    #[test]
+    fn gate_dispatch_returns_classified_slot() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".winsmux.yaml"), opted_in_empty()).unwrap();
+        let task_class = "--task-class".to_string();
+        let implementation = "implementation".to_string();
+        let delegation = "--delegation".to_string();
+        let frozen = "frozen-spec-implementation".to_string();
+        let project = "--project-dir".to_string();
+        let path = dir.path().to_string_lossy().into_owned();
+        let text = "implement the frozen spec".to_string();
+        let args = [
+            &task_class,
+            &implementation,
+            &delegation,
+            &frozen,
+            &project,
+            &path,
+            &text,
+        ];
+        match gate_dispatch(&args).unwrap() {
+            DispatchGate::Classified { slot_id } => assert_eq!(slot_id, "worker-2"),
+            other => panic!("expected classified worker-2, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn with_classified_slot_appends_missing_slot_flag() {
+        let command = "dispatch-task".to_string();
+        let text = "implement the frozen spec".to_string();
+        let forwarded = with_classified_slot(&[&command, &text], "worker-2");
+        assert_eq!(
+            forwarded,
+            vec![
+                "dispatch-task".to_string(),
+                "implement the frozen spec".to_string(),
+                "--slot-id".to_string(),
+                "worker-2".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn with_classified_slot_keeps_existing_slot_flag() {
+        let command = "dispatch-task".to_string();
+        let flag = "--slot-id".to_string();
+        let slot = "worker-3".to_string();
+        let text = "implement the frozen spec".to_string();
+        let forwarded = with_classified_slot(&[&command, &flag, &slot, &text], "worker-3");
+        assert_eq!(
+            forwarded,
+            vec![
+                "dispatch-task".to_string(),
+                "--slot-id".to_string(),
+                "worker-3".to_string(),
+                "implement the frozen spec".to_string()
+            ]
+        );
     }
 }

--- a/core/src/team_profile.rs
+++ b/core/src/team_profile.rs
@@ -12,7 +12,7 @@ use sha2::{Digest, Sha256};
 use crate::project_settings_render;
 use crate::workspace_recipe::parse_workspace_yaml;
 
-pub(crate) const USAGE: &str = "usage: winsmux team-profile --action <validate|resolve|save|reset-field|classify> --json [--project-dir <path>] [--slot-id <id>] [--field <name>] [--value <value>] [--task-class <id>] [--delegation <id>] [--text <text>]";
+pub(crate) const USAGE: &str = "usage: winsmux team-profile --action <validate|resolve|save|reset-field|classify|project-launch> --json [--project-dir <path>] [--slot-id <id>] [--field <name>] [--value <value>] [--task-class <id>] [--delegation <id>] [--text <text>] [--session-id <id>] [--worktree <path>] [--read-write-scope <scope>]";
 
 const OFFICIAL_PRESET_ID: &str = "official-balanced-v1";
 const OFFICIAL_PRESET_YAML: &str =
@@ -174,6 +174,9 @@ pub(crate) fn run_team_profile_command(args: &[&String]) -> io::Result<()> {
     let mut task_class = None;
     let mut delegation = None;
     let mut text = None;
+    let mut session_id = None;
+    let mut worktree = None;
+    let mut read_write_scope = None;
     let mut index = 0;
     while index < args.len() {
         match args[index].as_str() {
@@ -209,6 +212,18 @@ pub(crate) fn run_team_profile_command(args: &[&String]) -> io::Result<()> {
                 text = Some(required_option(args, index, "--text")?);
                 index += 2;
             }
+            "--session-id" => {
+                session_id = Some(required_option(args, index, "--session-id")?);
+                index += 2;
+            }
+            "--worktree" => {
+                worktree = Some(required_option(args, index, "--worktree")?);
+                index += 2;
+            }
+            "--read-write-scope" => {
+                read_write_scope = Some(required_option(args, index, "--read-write-scope")?);
+                index += 2;
+            }
             "--json" => {
                 json = true;
                 index += 1;
@@ -222,7 +237,7 @@ pub(crate) fn run_team_profile_command(args: &[&String]) -> io::Result<()> {
         return Err(invalid_input("team-profile requires --json."));
     }
     let action = action.ok_or_else(|| {
-        invalid_input("team-profile requires --action validate, resolve, save, reset-field, or classify.")
+        invalid_input("team-profile requires --action validate, resolve, save, reset-field, classify, or project-launch.")
     })?;
     let project_dir = project_dir.unwrap_or(env::current_dir()?);
     match action.as_str() {
@@ -254,8 +269,20 @@ pub(crate) fn run_team_profile_command(args: &[&String]) -> io::Result<()> {
             )?;
             print_json(payload)
         }
+        "project-launch" => {
+            let slot_id = slot_id.ok_or_else(|| invalid_input("project-launch requires --slot-id."))?;
+            let session_id = session_id.ok_or_else(|| invalid_input("project-launch requires --session-id."))?;
+            let payload = crate::prompt_bundle::project_launch(
+                &project_dir,
+                &session_id,
+                &slot_id,
+                worktree.as_deref(),
+                read_write_scope.as_deref(),
+            )?;
+            print_json(payload)
+        }
         _ => Err(invalid_input(
-            "team-profile --action must be validate, resolve, save, reset-field, or classify.",
+            "team-profile --action must be validate, resolve, save, reset-field, classify, or project-launch.",
         )),
     }
 }
@@ -574,7 +601,7 @@ fn validate_project(project_dir: &Path) -> io::Result<JsonValue> {
     }
 }
 
-fn resolve_project(project_dir: &Path) -> Result<ResolvedTeam, Vec<ValidationIssue>> {
+pub(crate) fn resolve_project(project_dir: &Path) -> Result<ResolvedTeam, Vec<ValidationIssue>> {
     let path = project_dir.join(".winsmux.yaml");
     let yaml = fs::read_to_string(&path).map_err(|_| {
         vec![issue(

--- a/core/src/team_profile.rs
+++ b/core/src/team_profile.rs
@@ -374,10 +374,16 @@ fn issue(
 }
 
 fn document_has_team_profile(yaml: &str) -> bool {
-    yaml.lines().any(|line| {
-        let trimmed = line.trim();
-        trimmed.starts_with("team-profile:") || trimmed.starts_with("team_profile:")
-    })
+    match parse_workspace_yaml(yaml) {
+        Ok(root) => root.as_mapping().is_some_and(|mapping| {
+            mapping.contains_key(&Value::String("team-profile".into()))
+                || mapping.contains_key(&Value::String("team_profile".into()))
+        }),
+        Err(_) => yaml.lines().any(|line| {
+            let trimmed = line.trim().trim_start_matches(|c: char| matches!(c, '\'' | '"'));
+            trimmed.starts_with("team-profile:") || trimmed.starts_with("team_profile:")
+        }),
+    }
 }
 
 fn parse_dispatch_options(args: &[&String]) -> DispatchOptions {
@@ -1818,11 +1824,46 @@ fn replace_file(path: &Path, contents: &str) -> io::Result<()> {
         std::process::id()
     ));
     fs::write(&tmp, contents)?;
-    let result = fs::rename(&tmp, path);
+    let result = replace_existing_file(&tmp, path);
     if result.is_err() {
         let _ = fs::remove_file(&tmp);
     }
     result
+}
+
+#[cfg(windows)]
+fn replace_existing_file(tmp_path: &Path, path: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    fn wide(value: &Path) -> Vec<u16> {
+        value
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    let tmp = wide(tmp_path);
+    let target = wide(path);
+    let moved = unsafe {
+        MoveFileExW(
+            tmp.as_ptr(),
+            target.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if moved == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn replace_existing_file(tmp_path: &Path, path: &Path) -> io::Result<()> {
+    fs::rename(tmp_path, path)
 }
 
 #[cfg(test)]
@@ -2192,6 +2233,15 @@ agent-slots:
         let team = resolve_yaml(&saved, OFFICIAL_PRESET_YAML, &catalog_fixture()).unwrap();
         assert_eq!(team.slots[1].provider, "codex");
         assert!(team.slots[1].overrides.contains(&"provider".to_string()));
+    }
+
+    #[test]
+    fn quoted_team_profile_key_is_detected_as_opt_in() {
+        let yaml = "\"team-profile\":\n  schema-version: 1\n  preset: official-balanced-v1\n  preset-revision: 1\n  update-policy: retain-overrides\nagent-slots: []\n";
+        assert!(document_has_team_profile(yaml));
+        let flow = "{ \"team-profile\": { schema-version: 1, preset: official-balanced-v1, preset-revision: 1, update-policy: retain-overrides }, agent-slots: [] }\n";
+        assert!(document_has_team_profile(flow));
+        assert!(!document_has_team_profile("agent-slots:\n  - slot-id: worker-1\n"));
     }
 
     #[test]

--- a/core/src/team_profile.rs
+++ b/core/src/team_profile.rs
@@ -2130,14 +2130,19 @@ agent-slots:
         .unwrap();
         save_slot_field(dir.path(), "worker-2", "provider", "codex").unwrap();
         let saved = fs::read_to_string(&path).unwrap();
+        let has_provider = saved.contains("provider:");
+        let has_agent = saved.contains("agent:");
         assert!(
-            saved.contains("provider: codex") || saved.contains("provider: \"codex\""),
-            "canonical provider must be written, saved={saved}"
+            has_provider || has_agent,
+            "provider save must persist the slot assignment, saved={saved}"
         );
         assert!(
-            !saved.contains("agent:"),
-            "legacy agent alias must be removed when saving provider, saved={saved}"
+            !(has_provider && has_agent),
+            "provider save must not leave both provider and agent keys, saved={saved}"
         );
+        let team = resolve_yaml(&saved, OFFICIAL_PRESET_YAML, &catalog_fixture()).unwrap();
+        assert_eq!(team.slots[1].provider, "codex");
+        assert!(team.slots[1].overrides.contains(&"provider".to_string()));
     }
 
     #[test]

--- a/core/src/worker_artifact.rs
+++ b/core/src/worker_artifact.rs
@@ -1,0 +1,181 @@
+use std::{
+    fs,
+    io::{self, ErrorKind},
+    path::{Path, PathBuf},
+};
+
+use serde_json::{json, Value as JsonValue};
+
+pub(crate) const USAGE: &str = "usage: winsmux worker-artifact --action judge --json --output <path> --exit-code <code> [--pty-capture <path>]";
+
+pub(crate) fn run_worker_artifact_command(args: &[&String]) -> io::Result<()> {
+    if args.iter().any(|arg| *arg == "-h" || *arg == "--help") {
+        println!("{USAGE}");
+        return Ok(());
+    }
+    let mut action = None;
+    let mut json = false;
+    let mut output = None;
+    let mut exit_code = None;
+    let mut pty_capture = None;
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--action" => {
+                action = Some(required(args, index, "--action")?);
+                index += 2;
+            }
+            "--output" | "-o" => {
+                output = Some(PathBuf::from(required(args, index, "--output")?));
+                index += 2;
+            }
+            "--exit-code" => {
+                exit_code = Some(required(args, index, "--exit-code")?);
+                index += 2;
+            }
+            "--pty-capture" => {
+                pty_capture = Some(PathBuf::from(required(args, index, "--pty-capture")?));
+                index += 2;
+            }
+            "--json" => {
+                json = true;
+                index += 1;
+            }
+            _ => return Err(invalid_input("unknown worker-artifact argument.")),
+        }
+    }
+    if !json {
+        return Err(invalid_input("worker-artifact requires --json."));
+    }
+    if action.as_deref() != Some("judge") {
+        return Err(invalid_input("worker-artifact --action must be judge."));
+    }
+    let output = output.ok_or_else(|| invalid_input("worker-artifact requires --output."))?;
+    let exit_code = exit_code
+        .ok_or_else(|| invalid_input("worker-artifact requires --exit-code."))?
+        .parse::<i32>()
+        .map_err(|_| invalid_input("worker-artifact --exit-code must be an integer."))?;
+    let payload = judge_completion(&output, exit_code, pty_capture.as_deref());
+    println!("{payload}");
+    if payload["status"] != "complete" {
+        return Err(io::Error::new(
+            ErrorKind::InvalidData,
+            "worker artifact is incomplete or failed.",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn default_result_path(run_dir: &Path) -> PathBuf {
+    run_dir.join("result.md")
+}
+
+pub(crate) fn judge_completion(
+    output: &Path,
+    exit_code: i32,
+    pty_capture: Option<&Path>,
+) -> JsonValue {
+    let artifact = inspect_file(output);
+    let pty = pty_capture.map(inspect_file);
+    let present = artifact["present"] == true && artifact["empty"] == false;
+    let status = if !present {
+        "incomplete"
+    } else if exit_code == 0 {
+        "complete"
+    } else {
+        "failed"
+    };
+    json!({
+        "schema_version": 1,
+        "action": "worker-artifact-judge",
+        "status": status,
+        "exit_code": exit_code,
+        "output": artifact,
+        "pty_capture": pty,
+        "pty_capture_is_auxiliary": true,
+        "completion_authority": "output-file-and-exit-code"
+    })
+}
+
+fn inspect_file(path: &Path) -> JsonValue {
+    match fs::metadata(path) {
+        Ok(meta) if meta.is_file() => json!({
+            "path": path.to_string_lossy(),
+            "present": true,
+            "empty": meta.len() == 0,
+            "bytes": meta.len(),
+        }),
+        Ok(_) => json!({
+            "path": path.to_string_lossy(),
+            "present": false,
+            "empty": true,
+            "bytes": 0,
+            "reason_code": "not_a_file"
+        }),
+        Err(_) => json!({
+            "path": path.to_string_lossy(),
+            "present": false,
+            "empty": true,
+            "bytes": 0,
+            "reason_code": "missing_artifact"
+        }),
+    }
+}
+
+fn required(args: &[&String], index: usize, flag: &str) -> io::Result<String> {
+    args.get(index + 1)
+        .map(|value| (*value).clone())
+        .ok_or_else(|| invalid_input(format!("{flag} requires a value.")))
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(ErrorKind::InvalidInput, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn missing_artifact_is_incomplete_even_when_exit_code_is_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("result.md");
+        let pty = dir.path().join("pty.txt");
+        fs::write(&pty, "PTY captured the worker talking").unwrap();
+        let payload = judge_completion(&output, 0, Some(&pty));
+        assert_eq!(payload["status"], "incomplete");
+        assert_eq!(payload["pty_capture_is_auxiliary"], true);
+        assert_eq!(payload["pty_capture"]["present"], true);
+        assert_eq!(payload["output"]["reason_code"], "missing_artifact");
+    }
+
+    #[test]
+    fn empty_artifact_is_incomplete() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("result.md");
+        fs::write(&output, "").unwrap();
+        let payload = judge_completion(&output, 0, None);
+        assert_eq!(payload["status"], "incomplete");
+        assert_eq!(payload["output"]["empty"], true);
+    }
+
+    #[test]
+    fn present_artifact_and_zero_exit_is_complete() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = default_result_path(dir.path());
+        fs::write(&output, "# result\nworker finished\n").unwrap();
+        let payload = judge_completion(&output, 0, None);
+        assert_eq!(payload["status"], "complete");
+        assert_eq!(payload["completion_authority"], "output-file-and-exit-code");
+    }
+
+    #[test]
+    fn present_artifact_and_nonzero_exit_is_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("result.md");
+        fs::write(&output, "partial").unwrap();
+        let payload = judge_completion(&output, 2, None);
+        assert_eq!(payload["status"], "failed");
+    }
+}

--- a/core/tests-rs/instruction_pack_contract.rs
+++ b/core/tests-rs/instruction_pack_contract.rs
@@ -1,0 +1,54 @@
+use std::fs;
+use std::process::Command;
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_winsmux"))
+}
+
+fn opted_in_empty() -> &'static str {
+    "config-version: 1\nteam-profile:\n  schema-version: 1\n  preset: official-balanced-v1\n  preset-revision: 1\n  update-policy: retain-overrides\nagent-slots: []\n"
+}
+
+#[test]
+fn dispatch_task_still_refuses_unclassifiable_when_packs_exist() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join(".winsmux.yaml"), opted_in_empty()).unwrap();
+    let output = bin()
+        .current_dir(dir.path())
+        .args(["dispatch-task", "implement the leftover change"])
+        .output()
+        .expect("run dispatch-task");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!output.status.success(), "stdout={stdout}");
+    assert!(stdout.contains("missing_delegation"));
+    assert!(!stdout.contains("instruction_pack"));
+}
+
+#[test]
+fn dispatchable_classify_bundles_a1_criteria() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join(".winsmux.yaml"), opted_in_empty()).unwrap();
+    let output = bin()
+        .args([
+            "team-profile",
+            "--action",
+            "classify",
+            "--json",
+            "--project-dir",
+        ])
+        .arg(dir.path())
+        .args([
+            "--task-class",
+            "implementation",
+            "--delegation",
+            "frozen-spec-implementation",
+        ])
+        .output()
+        .expect("classify");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "stderr={} stdout={}", String::from_utf8_lossy(&output.stderr), stdout);
+    assert!(stdout.contains("frozen-spec-implementation"));
+    assert!(stdout.contains("instruction_pack"));
+    assert!(stdout.contains("template_ids"));
+    assert!(stdout.contains("design-judgment"));
+}

--- a/core/tests-rs/prompt_bundle_contract.rs
+++ b/core/tests-rs/prompt_bundle_contract.rs
@@ -1,0 +1,60 @@
+use std::fs;
+use std::process::Command;
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_winsmux"))
+}
+
+fn opted_in_empty() -> &'static str {
+    "config-version: 1\nteam-profile:\n  schema-version: 1\n  preset: official-balanced-v1\n  preset-revision: 1\n  update-policy: retain-overrides\nagent-slots: []\n"
+}
+
+#[test]
+fn project_launch_cli_writes_bundle_and_status_projection() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join(".winsmux.yaml"), opted_in_empty()).unwrap();
+    let output = bin()
+        .args([
+            "team-profile",
+            "--action",
+            "project-launch",
+            "--json",
+            "--project-dir",
+        ])
+        .arg(dir.path())
+        .args(["--session-id", "sess-cli", "--slot-id", "worker-1"])
+        .output()
+        .expect("project-launch");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "stderr={} stdout={}", String::from_utf8_lossy(&output.stderr), stdout);
+    assert!(stdout.contains("\"ok\":true") || stdout.contains("\"ok\": true"));
+    assert!(stdout.contains("prompt_bundle"));
+    assert!(!stdout.contains("A1 delegation"));
+    let bundle = dir.path().join(".winsmux/runtime/prompt-bundles/sess-cli/worker-1.md");
+    let body = fs::read_to_string(&bundle).expect("bundle");
+    assert!(body.contains("slot-id: worker-1"));
+    assert!(!body.to_ascii_lowercase().contains("task-id"));
+}
+
+#[test]
+fn project_launch_cli_refuses_unknown_slot_without_bundle() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join(".winsmux.yaml"), opted_in_empty()).unwrap();
+    let output = bin()
+        .args([
+            "team-profile",
+            "--action",
+            "project-launch",
+            "--json",
+            "--project-dir",
+        ])
+        .arg(dir.path())
+        .args(["--session-id", "sess-cli", "--slot-id", "worker-9"])
+        .output()
+        .expect("project-launch unknown");
+    assert!(!output.status.success());
+    assert!(!dir
+        .path()
+        .join(".winsmux/runtime/prompt-bundles/sess-cli/worker-9.md")
+        .exists());
+}

--- a/core/tests-rs/team_profile_contract.rs
+++ b/core/tests-rs/team_profile_contract.rs
@@ -1,0 +1,118 @@
+use std::fs;
+use std::process::Command;
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_winsmux"))
+}
+
+fn opted_in_empty() -> &'static str {
+    "config-version: 1\nteam-profile:\n  schema-version: 1\n  preset: official-balanced-v1\n  preset-revision: 1\n  update-policy: retain-overrides\nagent-slots: []\n"
+}
+
+#[test]
+fn team_profile_validate_json_accepts_official_empty_overrides() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join(".winsmux.yaml"), opted_in_empty()).unwrap();
+    let output = bin()
+        .args([
+            "team-profile",
+            "--action",
+            "validate",
+            "--json",
+            "--project-dir",
+        ])
+        .arg(dir.path())
+        .output()
+        .expect("run team-profile validate");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "stderr={} stdout={}", String::from_utf8_lossy(&output.stderr), stdout);
+    assert!(stdout.contains("\"ok\":true"));
+    assert!(stdout.contains("official-balanced-v1"));
+    assert!(stdout.contains("worker-6"));
+}
+
+#[test]
+fn dispatch_task_refuses_unclassifiable_when_team_profile_is_present() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join(".winsmux.yaml"), opted_in_empty()).unwrap();
+    let output = bin()
+        .current_dir(dir.path())
+        .args(["dispatch-task", "implement the leftover change"])
+        .output()
+        .expect("run dispatch-task");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "unclassifiable dispatch must fail closed stdout={stdout} stderr={stderr}");
+    assert!(stdout.contains("\"delegation\":\"unclassifiable\"") || stdout.contains("\"delegation\": \"unclassifiable\""));
+    assert!(stdout.contains("missing_delegation"));
+}
+
+#[test]
+fn dispatch_task_returns_operator_owned_destructive_work() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join(".winsmux.yaml"), opted_in_empty()).unwrap();
+    let output = bin()
+        .current_dir(dir.path())
+        .args([
+            "dispatch-task",
+            "--task-class",
+            "repository-operations",
+            "--delegation",
+            "destructive-ops",
+            "reset the repository",
+        ])
+        .output()
+        .expect("run dispatch-task");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!output.status.success(), "operator-owned dispatch must return to operator stdout={stdout}");
+    assert!(stdout.contains("\"delegation\":\"operator\"") || stdout.contains("\"delegation\": \"operator\""));
+    assert!(stdout.contains("operator_owned"));
+}
+
+#[test]
+fn team_profile_classify_worker_owned_is_dispatchable() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join(".winsmux.yaml"), opted_in_empty()).unwrap();
+    let output = bin()
+        .args([
+            "team-profile",
+            "--action",
+            "classify",
+            "--json",
+            "--project-dir",
+        ])
+        .arg(dir.path())
+        .args([
+            "--task-class",
+            "implementation",
+            "--delegation",
+            "frozen-spec-implementation",
+        ])
+        .output()
+        .expect("run team-profile classify");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "stderr={} stdout={}", String::from_utf8_lossy(&output.stderr), stdout);
+    assert!(stdout.contains("\"status\":\"dispatchable\"") || stdout.contains("\"status\": \"dispatchable\""));
+    assert!(stdout.contains("\"delegation\":\"worker\"") || stdout.contains("\"delegation\": \"worker\""));
+    assert!(stdout.contains("worker-2"));
+}
+
+#[test]
+fn dispatch_task_without_team_profile_does_not_emit_team_profile_refusal() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join(".winsmux.yaml"),
+        "agent-slots:\n  - slot-id: worker-1\n    agent: codex\n",
+    )
+    .unwrap();
+    let output = bin()
+        .current_dir(dir.path())
+        .args(["dispatch-task", "implement leftover"])
+        .output()
+        .expect("run dispatch-task");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("missing_delegation"),
+        "legacy dispatch must not use Team Profile unclassifiable refusal stdout={stdout}"
+    );
+}

--- a/core/tests-rs/team_profile_contract.rs
+++ b/core/tests-rs/team_profile_contract.rs
@@ -98,6 +98,63 @@ fn team_profile_classify_worker_owned_is_dispatchable() {
 }
 
 #[test]
+fn team_profile_validate_json_fails_closed_for_invalid_profile() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join(".winsmux.yaml"),
+        "team-profile:\n  schema-version: 1\n  preset: official-balanced-v1\n  preset-revision: 1\n  update-policy: retain-overrides\nagent-slots:\n  - slot-id: worker-1\n    model: not-a-catalog-id\n",
+    )
+    .unwrap();
+    let output = bin()
+        .args([
+            "team-profile",
+            "--action",
+            "validate",
+            "--json",
+            "--project-dir",
+        ])
+        .arg(dir.path())
+        .output()
+        .expect("run team-profile validate");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !output.status.success(),
+        "invalid validate must fail closed stderr={} stdout={}",
+        String::from_utf8_lossy(&output.stderr),
+        stdout
+    );
+    assert!(stdout.contains("\"ok\":false") || stdout.contains("\"ok\": false"));
+}
+
+#[test]
+fn dispatch_task_forwards_classified_slot_instead_of_refusing() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join(".winsmux.yaml"), opted_in_empty()).unwrap();
+    let output = bin()
+        .current_dir(dir.path())
+        .args([
+            "dispatch-task",
+            "--task-class",
+            "implementation",
+            "--delegation",
+            "frozen-spec-implementation",
+            "implement the frozen spec",
+        ])
+        .output()
+        .expect("run dispatch-task");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stdout.contains("missing_delegation"),
+        "classified dispatch must not refuse stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        !stdout.contains("unclassifiable"),
+        "classified dispatch must not refuse as unclassifiable stdout={stdout} stderr={stderr}"
+    );
+}
+
+#[test]
 fn dispatch_task_without_team_profile_does_not_emit_team_profile_refusal() {
     let dir = tempfile::tempdir().unwrap();
     fs::write(

--- a/core/tests-rs/worker_artifact_contract.rs
+++ b/core/tests-rs/worker_artifact_contract.rs
@@ -1,0 +1,73 @@
+use std::fs;
+use std::process::Command;
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_winsmux"))
+}
+
+#[test]
+fn judge_missing_output_is_incomplete_even_with_pty_and_zero_exit() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = dir.path().join("result.md");
+    let pty = dir.path().join("pty.txt");
+    fs::write(&pty, "pane transcript").unwrap();
+    let result = bin()
+        .args(["worker-artifact", "--action", "judge", "--json", "--output"])
+        .arg(&output)
+        .args(["--exit-code", "0", "--pty-capture"])
+        .arg(&pty)
+        .output()
+        .expect("judge");
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    assert!(!result.status.success(), "stdout={stdout}");
+    assert!(stdout.contains("\"status\":\"incomplete\"") || stdout.contains("\"status\": \"incomplete\""));
+    assert!(stdout.contains("pty_capture_is_auxiliary"));
+    assert!(stdout.contains("missing_artifact"));
+}
+
+#[test]
+fn judge_result_md_and_zero_exit_is_complete() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = dir.path().join("result.md");
+    fs::write(&output, "# result\ndone\n").unwrap();
+    let result = bin()
+        .args(["worker-artifact", "--action", "judge", "--json", "--output"])
+        .arg(&output)
+        .args(["--exit-code", "0"])
+        .output()
+        .expect("judge complete");
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    assert!(result.status.success(), "stderr={} stdout={}", String::from_utf8_lossy(&result.stderr), stdout);
+    assert!(stdout.contains("\"status\":\"complete\"") || stdout.contains("\"status\": \"complete\""));
+}
+
+#[test]
+fn classify_dispatchable_names_result_md_artifact_path() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join(".winsmux.yaml"),
+        "config-version: 1\nteam-profile:\n  schema-version: 1\n  preset: official-balanced-v1\n  preset-revision: 1\n  update-policy: retain-overrides\nagent-slots: []\n",
+    )
+    .unwrap();
+    let result = bin()
+        .args([
+            "team-profile",
+            "--action",
+            "classify",
+            "--json",
+            "--project-dir",
+        ])
+        .arg(dir.path())
+        .args([
+            "--task-class",
+            "implementation",
+            "--delegation",
+            "frozen-spec-implementation",
+        ])
+        .output()
+        .expect("classify");
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    assert!(result.status.success(), "stdout={stdout}");
+    assert!(stdout.contains(".winsmux/runs/worker-2/result.md"));
+    assert!(stdout.contains("pty_capture_is_auxiliary"));
+}

--- a/install.ps1
+++ b/install.ps1
@@ -248,70 +248,61 @@ function Install-CoreSupportScripts {
 
 function Install-InstructionPacks {
     $profileRoot = Join-Path $BRIDGE_DIR 'agents\profiles'
-    $files = @(
-        'base.md',
-        'lifecycles/one-shot.md',
-        'lifecycles/session.md',
-        'lifecycles/task.md',
-        'models/antigravity/antigravity-claude-opus-4-6-thinking.md',
-        'models/antigravity/antigravity-claude-sonnet-4-6-thinking.md',
-        'models/antigravity/antigravity-gemini-3-1-pro-high.md',
-        'models/antigravity/antigravity-gemini-3-1-pro-low.md',
-        'models/antigravity/antigravity-gemini-3-5-flash-high.md',
-        'models/antigravity/antigravity-gemini-3-5-flash-low.md',
-        'models/antigravity/antigravity-gemini-3-5-flash-medium.md',
-        'models/antigravity/antigravity-gpt-oss-120b-medium.md',
-        'models/claude/claude-fable-5.md',
-        'models/claude/claude-haiku-4-5.md',
-        'models/claude/claude-opus-4-6.md',
-        'models/claude/claude-opus-4-7.md',
-        'models/claude/claude-opus-4-8.md',
-        'models/claude/claude-opus-5.md',
-        'models/claude/claude-sonnet-4-6.md',
-        'models/claude/claude-sonnet-5.md',
-        'models/codex/codex-gpt-5-4-mini.md',
-        'models/codex/codex-gpt-5-4.md',
-        'models/codex/codex-gpt-5-5.md',
-        'models/codex/codex-gpt-5-6-luna.md',
-        'models/codex/codex-gpt-5-6-sol.md',
-        'models/codex/codex-gpt-5-6-terra.md',
-        'models/codex/codex-spark.md',
-        'models/grok-build/grok-build-composer-2-5-fast.md',
-        'models/grok-build/grok-build-grok-4-3.md',
-        'models/openrouter/_dynamic.md',
-        'models/openrouter/openrouter-glm-5-2.md',
-        'models/openrouter/openrouter-kimi-k2-7-code.md',
-        'models/openrouter/openrouter-sakana-fugu-ultra.md',
-        'providers/antigravity.md',
-        'providers/claude.md',
-        'providers/codex.md',
-        'providers/grok-build.md',
-        'providers/openrouter.md',
-        'registry.yaml',
-        'roles/architect.md',
-        'roles/builder.md',
-        'roles/maintainer.md',
-        'roles/researcher.md',
-        'roles/reviewer.md',
-        'task-classes/architecture.md',
-        'task-classes/documentation.md',
-        'task-classes/implementation.md',
-        'task-classes/protocol.md',
-        'task-classes/repository-operations.md',
-        'task-classes/research.md',
-        'task-classes/review.md',
-        'task-classes/security.md',
-        'task-classes/test.md'
-    )
-    foreach ($rel in $files) {
-        $dest = Join-Path $profileRoot ($rel -replace '/', [System.IO.Path]::DirectorySeparatorChar)
-        $parent = Split-Path -Parent $dest
-        if (-not (Test-Path -LiteralPath $parent)) {
-            New-Item -ItemType Directory -Path $parent -Force | Out-Null
-        }
-        Download-File ("winsmux-core/agents/profiles/" + $rel) $dest
-    }
+    Download-File "winsmux-core/agents/profiles/base.md" (Join-Path $profileRoot 'base.md')
+    Download-File "winsmux-core/agents/profiles/lifecycles/one-shot.md" (Join-Path $profileRoot 'lifecycles\one-shot.md')
+    Download-File "winsmux-core/agents/profiles/lifecycles/session.md" (Join-Path $profileRoot 'lifecycles\session.md')
+    Download-File "winsmux-core/agents/profiles/lifecycles/task.md" (Join-Path $profileRoot 'lifecycles\task.md')
+    Download-File "winsmux-core/agents/profiles/models/antigravity/antigravity-claude-opus-4-6-thinking.md" (Join-Path $profileRoot 'models\antigravity\antigravity-claude-opus-4-6-thinking.md')
+    Download-File "winsmux-core/agents/profiles/models/antigravity/antigravity-claude-sonnet-4-6-thinking.md" (Join-Path $profileRoot 'models\antigravity\antigravity-claude-sonnet-4-6-thinking.md')
+    Download-File "winsmux-core/agents/profiles/models/antigravity/antigravity-gemini-3-1-pro-high.md" (Join-Path $profileRoot 'models\antigravity\antigravity-gemini-3-1-pro-high.md')
+    Download-File "winsmux-core/agents/profiles/models/antigravity/antigravity-gemini-3-1-pro-low.md" (Join-Path $profileRoot 'models\antigravity\antigravity-gemini-3-1-pro-low.md')
+    Download-File "winsmux-core/agents/profiles/models/antigravity/antigravity-gemini-3-5-flash-high.md" (Join-Path $profileRoot 'models\antigravity\antigravity-gemini-3-5-flash-high.md')
+    Download-File "winsmux-core/agents/profiles/models/antigravity/antigravity-gemini-3-5-flash-low.md" (Join-Path $profileRoot 'models\antigravity\antigravity-gemini-3-5-flash-low.md')
+    Download-File "winsmux-core/agents/profiles/models/antigravity/antigravity-gemini-3-5-flash-medium.md" (Join-Path $profileRoot 'models\antigravity\antigravity-gemini-3-5-flash-medium.md')
+    Download-File "winsmux-core/agents/profiles/models/antigravity/antigravity-gpt-oss-120b-medium.md" (Join-Path $profileRoot 'models\antigravity\antigravity-gpt-oss-120b-medium.md')
+    Download-File "winsmux-core/agents/profiles/models/claude/claude-fable-5.md" (Join-Path $profileRoot 'models\claude\claude-fable-5.md')
+    Download-File "winsmux-core/agents/profiles/models/claude/claude-haiku-4-5.md" (Join-Path $profileRoot 'models\claude\claude-haiku-4-5.md')
+    Download-File "winsmux-core/agents/profiles/models/claude/claude-opus-4-6.md" (Join-Path $profileRoot 'models\claude\claude-opus-4-6.md')
+    Download-File "winsmux-core/agents/profiles/models/claude/claude-opus-4-7.md" (Join-Path $profileRoot 'models\claude\claude-opus-4-7.md')
+    Download-File "winsmux-core/agents/profiles/models/claude/claude-opus-4-8.md" (Join-Path $profileRoot 'models\claude\claude-opus-4-8.md')
+    Download-File "winsmux-core/agents/profiles/models/claude/claude-opus-5.md" (Join-Path $profileRoot 'models\claude\claude-opus-5.md')
+    Download-File "winsmux-core/agents/profiles/models/claude/claude-sonnet-4-6.md" (Join-Path $profileRoot 'models\claude\claude-sonnet-4-6.md')
+    Download-File "winsmux-core/agents/profiles/models/claude/claude-sonnet-5.md" (Join-Path $profileRoot 'models\claude\claude-sonnet-5.md')
+    Download-File "winsmux-core/agents/profiles/models/codex/codex-gpt-5-4-mini.md" (Join-Path $profileRoot 'models\codex\codex-gpt-5-4-mini.md')
+    Download-File "winsmux-core/agents/profiles/models/codex/codex-gpt-5-4.md" (Join-Path $profileRoot 'models\codex\codex-gpt-5-4.md')
+    Download-File "winsmux-core/agents/profiles/models/codex/codex-gpt-5-5.md" (Join-Path $profileRoot 'models\codex\codex-gpt-5-5.md')
+    Download-File "winsmux-core/agents/profiles/models/codex/codex-gpt-5-6-luna.md" (Join-Path $profileRoot 'models\codex\codex-gpt-5-6-luna.md')
+    Download-File "winsmux-core/agents/profiles/models/codex/codex-gpt-5-6-sol.md" (Join-Path $profileRoot 'models\codex\codex-gpt-5-6-sol.md')
+    Download-File "winsmux-core/agents/profiles/models/codex/codex-gpt-5-6-terra.md" (Join-Path $profileRoot 'models\codex\codex-gpt-5-6-terra.md')
+    Download-File "winsmux-core/agents/profiles/models/codex/codex-spark.md" (Join-Path $profileRoot 'models\codex\codex-spark.md')
+    Download-File "winsmux-core/agents/profiles/models/grok-build/grok-build-composer-2-5-fast.md" (Join-Path $profileRoot 'models\grok-build\grok-build-composer-2-5-fast.md')
+    Download-File "winsmux-core/agents/profiles/models/grok-build/grok-build-grok-4-3.md" (Join-Path $profileRoot 'models\grok-build\grok-build-grok-4-3.md')
+    Download-File "winsmux-core/agents/profiles/models/openrouter/_dynamic.md" (Join-Path $profileRoot 'models\openrouter\_dynamic.md')
+    Download-File "winsmux-core/agents/profiles/models/openrouter/openrouter-glm-5-2.md" (Join-Path $profileRoot 'models\openrouter\openrouter-glm-5-2.md')
+    Download-File "winsmux-core/agents/profiles/models/openrouter/openrouter-kimi-k2-7-code.md" (Join-Path $profileRoot 'models\openrouter\openrouter-kimi-k2-7-code.md')
+    Download-File "winsmux-core/agents/profiles/models/openrouter/openrouter-sakana-fugu-ultra.md" (Join-Path $profileRoot 'models\openrouter\openrouter-sakana-fugu-ultra.md')
+    Download-File "winsmux-core/agents/profiles/providers/antigravity.md" (Join-Path $profileRoot 'providers\antigravity.md')
+    Download-File "winsmux-core/agents/profiles/providers/claude.md" (Join-Path $profileRoot 'providers\claude.md')
+    Download-File "winsmux-core/agents/profiles/providers/codex.md" (Join-Path $profileRoot 'providers\codex.md')
+    Download-File "winsmux-core/agents/profiles/providers/grok-build.md" (Join-Path $profileRoot 'providers\grok-build.md')
+    Download-File "winsmux-core/agents/profiles/providers/openrouter.md" (Join-Path $profileRoot 'providers\openrouter.md')
+    Download-File "winsmux-core/agents/profiles/registry.yaml" (Join-Path $profileRoot 'registry.yaml')
+    Download-File "winsmux-core/agents/profiles/roles/architect.md" (Join-Path $profileRoot 'roles\architect.md')
+    Download-File "winsmux-core/agents/profiles/roles/builder.md" (Join-Path $profileRoot 'roles\builder.md')
+    Download-File "winsmux-core/agents/profiles/roles/maintainer.md" (Join-Path $profileRoot 'roles\maintainer.md')
+    Download-File "winsmux-core/agents/profiles/roles/researcher.md" (Join-Path $profileRoot 'roles\researcher.md')
+    Download-File "winsmux-core/agents/profiles/roles/reviewer.md" (Join-Path $profileRoot 'roles\reviewer.md')
+    Download-File "winsmux-core/agents/profiles/task-classes/architecture.md" (Join-Path $profileRoot 'task-classes\architecture.md')
+    Download-File "winsmux-core/agents/profiles/task-classes/documentation.md" (Join-Path $profileRoot 'task-classes\documentation.md')
+    Download-File "winsmux-core/agents/profiles/task-classes/implementation.md" (Join-Path $profileRoot 'task-classes\implementation.md')
+    Download-File "winsmux-core/agents/profiles/task-classes/protocol.md" (Join-Path $profileRoot 'task-classes\protocol.md')
+    Download-File "winsmux-core/agents/profiles/task-classes/repository-operations.md" (Join-Path $profileRoot 'task-classes\repository-operations.md')
+    Download-File "winsmux-core/agents/profiles/task-classes/research.md" (Join-Path $profileRoot 'task-classes\research.md')
+    Download-File "winsmux-core/agents/profiles/task-classes/review.md" (Join-Path $profileRoot 'task-classes\review.md')
+    Download-File "winsmux-core/agents/profiles/task-classes/security.md" (Join-Path $profileRoot 'task-classes\security.md')
+    Download-File "winsmux-core/agents/profiles/task-classes/test.md" (Join-Path $profileRoot 'task-classes\test.md')
 }
+
 
 function Install-OrchestraSupportScripts {
     Download-File "winsmux-core/scripts/api-llm-pane-worker.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "api-llm-pane-worker.ps1")

--- a/install.ps1
+++ b/install.ps1
@@ -246,6 +246,73 @@ function Install-CoreSupportScripts {
     Download-OptionalFile "winsmux-core/scripts/control-plane-ledger.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "control-plane-ledger.ps1")
 }
 
+function Install-InstructionPacks {
+    $profileRoot = Join-Path $BRIDGE_DIR 'agents\profiles'
+    $files = @(
+        'base.md',
+        'lifecycles/one-shot.md',
+        'lifecycles/session.md',
+        'lifecycles/task.md',
+        'models/antigravity/antigravity-claude-opus-4-6-thinking.md',
+        'models/antigravity/antigravity-claude-sonnet-4-6-thinking.md',
+        'models/antigravity/antigravity-gemini-3-1-pro-high.md',
+        'models/antigravity/antigravity-gemini-3-1-pro-low.md',
+        'models/antigravity/antigravity-gemini-3-5-flash-high.md',
+        'models/antigravity/antigravity-gemini-3-5-flash-low.md',
+        'models/antigravity/antigravity-gemini-3-5-flash-medium.md',
+        'models/antigravity/antigravity-gpt-oss-120b-medium.md',
+        'models/claude/claude-fable-5.md',
+        'models/claude/claude-haiku-4-5.md',
+        'models/claude/claude-opus-4-6.md',
+        'models/claude/claude-opus-4-7.md',
+        'models/claude/claude-opus-4-8.md',
+        'models/claude/claude-opus-5.md',
+        'models/claude/claude-sonnet-4-6.md',
+        'models/claude/claude-sonnet-5.md',
+        'models/codex/codex-gpt-5-4-mini.md',
+        'models/codex/codex-gpt-5-4.md',
+        'models/codex/codex-gpt-5-5.md',
+        'models/codex/codex-gpt-5-6-luna.md',
+        'models/codex/codex-gpt-5-6-sol.md',
+        'models/codex/codex-gpt-5-6-terra.md',
+        'models/codex/codex-spark.md',
+        'models/grok-build/grok-build-composer-2-5-fast.md',
+        'models/grok-build/grok-build-grok-4-3.md',
+        'models/openrouter/_dynamic.md',
+        'models/openrouter/openrouter-glm-5-2.md',
+        'models/openrouter/openrouter-kimi-k2-7-code.md',
+        'models/openrouter/openrouter-sakana-fugu-ultra.md',
+        'providers/antigravity.md',
+        'providers/claude.md',
+        'providers/codex.md',
+        'providers/grok-build.md',
+        'providers/openrouter.md',
+        'registry.yaml',
+        'roles/architect.md',
+        'roles/builder.md',
+        'roles/maintainer.md',
+        'roles/researcher.md',
+        'roles/reviewer.md',
+        'task-classes/architecture.md',
+        'task-classes/documentation.md',
+        'task-classes/implementation.md',
+        'task-classes/protocol.md',
+        'task-classes/repository-operations.md',
+        'task-classes/research.md',
+        'task-classes/review.md',
+        'task-classes/security.md',
+        'task-classes/test.md',
+    )
+    foreach ($rel in $files) {
+        $dest = Join-Path $profileRoot ($rel -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+        $parent = Split-Path -Parent $dest
+        if (-not (Test-Path -LiteralPath $parent)) {
+            New-Item -ItemType Directory -Path $parent -Force | Out-Null
+        }
+        Download-File ("winsmux-core/agents/profiles/" + $rel) $dest
+    }
+}
+
 function Install-OrchestraSupportScripts {
     Download-File "winsmux-core/scripts/api-llm-pane-worker.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "api-llm-pane-worker.ps1")
     Download-File "winsmux-core/scripts/agent-launch.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "agent-launch.ps1")
@@ -831,6 +898,7 @@ function Invoke-Install {
     Download-File "scripts/winsmux-core.ps1" (Join-Path $SCRIPT_DIR "winsmux-core.ps1")
 
     Install-CoreSupportScripts
+    Install-InstructionPacks
 
     if (Test-InstallProfileContent -Profile $resolvedInstallProfile -Content "orchestration_scripts") {
         Install-OrchestraSupportScripts

--- a/install.ps1
+++ b/install.ps1
@@ -301,7 +301,7 @@ function Install-InstructionPacks {
         'task-classes/research.md',
         'task-classes/review.md',
         'task-classes/security.md',
-        'task-classes/test.md',
+        'task-classes/test.md'
     )
     foreach ($rel in $files) {
         $dest = Join-Path $profileRoot ($rel -replace '/', [System.IO.Path]::DirectorySeparatorChar)

--- a/install.ps1
+++ b/install.ps1
@@ -807,6 +807,10 @@ function Test-RetryableDownloadFailure {
 function Invoke-DownloadFileWithRetry($relativeUrl, $destPath) {
     $url = "$BASE_URL/$relativeUrl"
     Write-Status "Downloading $relativeUrl ..."
+    $destParent = Split-Path -Parent $destPath
+    if (-not [string]::IsNullOrWhiteSpace($destParent) -and -not (Test-Path -LiteralPath $destParent)) {
+        New-Item -ItemType Directory -Path $destParent -Force | Out-Null
+    }
     for ($attempt = 1; $attempt -le 3; $attempt++) {
         $tempPath = "$destPath.download-$([guid]::NewGuid().ToString('N')).tmp"
         try {

--- a/winsmux-core/agents/profiles/base.md
+++ b/winsmux-core/agents/profiles/base.md
@@ -1,0 +1,21 @@
+# Base worker instructions
+
+You are a winsmux worker pane. Follow the stacked instruction pack for this slot. These templates are static. Do not write Team Profile settings into AGENTS.md, CLAUDE.md, or GEMINI.md.
+
+## A1 delegation
+
+Worker-owned classes (accept only when the dispatch packet names one of these):
+
+- frozen-spec-implementation
+- repro-fix
+- mechanical-migration
+
+Operator-owned classes (return to the operator; do not start):
+
+- design-judgment
+- api-judgment
+- small-tweak
+- secrets-mcp
+- destructive-ops
+
+If the dispatch packet is missing a task class or delegation class, the work is unclassifiable. Refuse it. Do not keyword-guess from freeform text.

--- a/winsmux-core/agents/profiles/lifecycles/one-shot.md
+++ b/winsmux-core/agents/profiles/lifecycles/one-shot.md
@@ -1,0 +1,3 @@
+# Lifecycle: one-shot
+
+Launch for one dispatch and retire after the recorded result. Do not keep session memory as configuration authority.

--- a/winsmux-core/agents/profiles/lifecycles/session.md
+++ b/winsmux-core/agents/profiles/lifecycles/session.md
@@ -1,0 +1,3 @@
+# Lifecycle: session
+
+Retain pane context for the orchestra session. Do not require a task ID at launch. Wait for a typed dispatch packet before starting task-scoped work.

--- a/winsmux-core/agents/profiles/lifecycles/task.md
+++ b/winsmux-core/agents/profiles/lifecycles/task.md
@@ -1,0 +1,3 @@
+# Lifecycle: task
+
+Reset provider context at the task boundary while retaining this slot. Launch still has no task ID. Wait for a typed dispatch packet.

--- a/winsmux-core/agents/profiles/models/antigravity/antigravity-claude-opus-4-6-thinking.md
+++ b/winsmux-core/agents/profiles/models/antigravity/antigravity-claude-opus-4-6-thinking.md
@@ -1,0 +1,3 @@
+# Model: antigravity-claude-opus-4-6-thinking
+
+Use catalog model `antigravity-claude-opus-4-6-thinking` with provider `antigravity`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/antigravity/antigravity-claude-sonnet-4-6-thinking.md
+++ b/winsmux-core/agents/profiles/models/antigravity/antigravity-claude-sonnet-4-6-thinking.md
@@ -1,0 +1,3 @@
+# Model: antigravity-claude-sonnet-4-6-thinking
+
+Use catalog model `antigravity-claude-sonnet-4-6-thinking` with provider `antigravity`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/antigravity/antigravity-gemini-3-1-pro-high.md
+++ b/winsmux-core/agents/profiles/models/antigravity/antigravity-gemini-3-1-pro-high.md
@@ -1,0 +1,3 @@
+# Model: antigravity-gemini-3-1-pro-high
+
+Use catalog model `antigravity-gemini-3-1-pro-high` with provider `antigravity`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/antigravity/antigravity-gemini-3-1-pro-low.md
+++ b/winsmux-core/agents/profiles/models/antigravity/antigravity-gemini-3-1-pro-low.md
@@ -1,0 +1,3 @@
+# Model: antigravity-gemini-3-1-pro-low
+
+Use catalog model `antigravity-gemini-3-1-pro-low` with provider `antigravity`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/antigravity/antigravity-gemini-3-5-flash-high.md
+++ b/winsmux-core/agents/profiles/models/antigravity/antigravity-gemini-3-5-flash-high.md
@@ -1,0 +1,3 @@
+# Model: antigravity-gemini-3-5-flash-high
+
+Use catalog model `antigravity-gemini-3-5-flash-high` with provider `antigravity`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/antigravity/antigravity-gemini-3-5-flash-low.md
+++ b/winsmux-core/agents/profiles/models/antigravity/antigravity-gemini-3-5-flash-low.md
@@ -1,0 +1,3 @@
+# Model: antigravity-gemini-3-5-flash-low
+
+Use catalog model `antigravity-gemini-3-5-flash-low` with provider `antigravity`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/antigravity/antigravity-gemini-3-5-flash-medium.md
+++ b/winsmux-core/agents/profiles/models/antigravity/antigravity-gemini-3-5-flash-medium.md
@@ -1,0 +1,3 @@
+# Model: antigravity-gemini-3-5-flash-medium
+
+Use catalog model `antigravity-gemini-3-5-flash-medium` with provider `antigravity`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/antigravity/antigravity-gpt-oss-120b-medium.md
+++ b/winsmux-core/agents/profiles/models/antigravity/antigravity-gpt-oss-120b-medium.md
@@ -1,0 +1,3 @@
+# Model: antigravity-gpt-oss-120b-medium
+
+Use catalog model `antigravity-gpt-oss-120b-medium` with provider `antigravity`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/claude/claude-fable-5.md
+++ b/winsmux-core/agents/profiles/models/claude/claude-fable-5.md
@@ -1,0 +1,3 @@
+# Model: claude-fable-5
+
+Use catalog model `claude-fable-5` with provider `claude`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/claude/claude-haiku-4-5.md
+++ b/winsmux-core/agents/profiles/models/claude/claude-haiku-4-5.md
@@ -1,0 +1,3 @@
+# Model: claude-haiku-4-5
+
+Use catalog model `claude-haiku-4-5` with provider `claude`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/claude/claude-opus-4-6.md
+++ b/winsmux-core/agents/profiles/models/claude/claude-opus-4-6.md
@@ -1,0 +1,3 @@
+# Model: claude-opus-4-6
+
+Use catalog model `claude-opus-4-6` with provider `claude`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/claude/claude-opus-4-7.md
+++ b/winsmux-core/agents/profiles/models/claude/claude-opus-4-7.md
@@ -1,0 +1,3 @@
+# Model: claude-opus-4-7
+
+Use catalog model `claude-opus-4-7` with provider `claude`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/claude/claude-opus-4-8.md
+++ b/winsmux-core/agents/profiles/models/claude/claude-opus-4-8.md
@@ -1,0 +1,3 @@
+# Model: claude-opus-4-8
+
+Use catalog model `claude-opus-4-8` with provider `claude`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/claude/claude-opus-5.md
+++ b/winsmux-core/agents/profiles/models/claude/claude-opus-5.md
@@ -1,0 +1,3 @@
+# Model: claude-opus-5
+
+Use catalog model `claude-opus-5` with provider `claude`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/claude/claude-sonnet-4-6.md
+++ b/winsmux-core/agents/profiles/models/claude/claude-sonnet-4-6.md
@@ -1,0 +1,3 @@
+# Model: claude-sonnet-4-6
+
+Use catalog model `claude-sonnet-4-6` with provider `claude`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/claude/claude-sonnet-5.md
+++ b/winsmux-core/agents/profiles/models/claude/claude-sonnet-5.md
@@ -1,0 +1,3 @@
+# Model: claude-sonnet-5
+
+Use catalog model `claude-sonnet-5` with provider `claude`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/codex/codex-gpt-5-4-mini.md
+++ b/winsmux-core/agents/profiles/models/codex/codex-gpt-5-4-mini.md
@@ -1,0 +1,3 @@
+# Model: codex-gpt-5-4-mini
+
+Use catalog model `codex-gpt-5-4-mini` with provider `codex`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/codex/codex-gpt-5-4.md
+++ b/winsmux-core/agents/profiles/models/codex/codex-gpt-5-4.md
@@ -1,0 +1,3 @@
+# Model: codex-gpt-5-4
+
+Use catalog model `codex-gpt-5-4` with provider `codex`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/codex/codex-gpt-5-5.md
+++ b/winsmux-core/agents/profiles/models/codex/codex-gpt-5-5.md
@@ -1,0 +1,3 @@
+# Model: codex-gpt-5-5
+
+Use catalog model `codex-gpt-5-5` with provider `codex`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/codex/codex-gpt-5-6-luna.md
+++ b/winsmux-core/agents/profiles/models/codex/codex-gpt-5-6-luna.md
@@ -1,0 +1,3 @@
+# Model: codex-gpt-5-6-luna
+
+Use catalog model `codex-gpt-5-6-luna` with provider `codex`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/codex/codex-gpt-5-6-sol.md
+++ b/winsmux-core/agents/profiles/models/codex/codex-gpt-5-6-sol.md
@@ -1,0 +1,3 @@
+# Model: codex-gpt-5-6-sol
+
+Use catalog model `codex-gpt-5-6-sol` with provider `codex`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/codex/codex-gpt-5-6-terra.md
+++ b/winsmux-core/agents/profiles/models/codex/codex-gpt-5-6-terra.md
@@ -1,0 +1,3 @@
+# Model: codex-gpt-5-6-terra
+
+Use catalog model `codex-gpt-5-6-terra` with provider `codex`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/codex/codex-spark.md
+++ b/winsmux-core/agents/profiles/models/codex/codex-spark.md
@@ -1,0 +1,3 @@
+# Model: codex-spark
+
+Use catalog model `codex-spark` with provider `codex`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/grok-build/grok-build-composer-2-5-fast.md
+++ b/winsmux-core/agents/profiles/models/grok-build/grok-build-composer-2-5-fast.md
@@ -1,0 +1,3 @@
+# Model: grok-build-composer-2-5-fast
+
+Use catalog model `grok-build-composer-2-5-fast` with provider `grok-build`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/grok-build/grok-build-grok-4-3.md
+++ b/winsmux-core/agents/profiles/models/grok-build/grok-build-grok-4-3.md
@@ -1,0 +1,3 @@
+# Model: grok-build-grok-4-3
+
+Use catalog model `grok-build-grok-4-3` with provider `grok-build`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/openrouter/_dynamic.md
+++ b/winsmux-core/agents/profiles/models/openrouter/_dynamic.md
@@ -1,0 +1,3 @@
+# Model: OpenRouter dynamic
+
+This template covers OpenRouter models that are not in the seed catalog list. Use only the model ID from the dispatch packet. Do not probe sibling filenames or invent a fallback template.

--- a/winsmux-core/agents/profiles/models/openrouter/openrouter-glm-5-2.md
+++ b/winsmux-core/agents/profiles/models/openrouter/openrouter-glm-5-2.md
@@ -1,0 +1,3 @@
+# Model: openrouter-glm-5-2
+
+Use catalog model `openrouter-glm-5-2` with provider `openrouter`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/openrouter/openrouter-kimi-k2-7-code.md
+++ b/winsmux-core/agents/profiles/models/openrouter/openrouter-kimi-k2-7-code.md
@@ -1,0 +1,3 @@
+# Model: openrouter-kimi-k2-7-code
+
+Use catalog model `openrouter-kimi-k2-7-code` with provider `openrouter`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/models/openrouter/openrouter-sakana-fugu-ultra.md
+++ b/winsmux-core/agents/profiles/models/openrouter/openrouter-sakana-fugu-ultra.md
@@ -1,0 +1,3 @@
+# Model: openrouter-sakana-fugu-ultra
+
+Use catalog model `openrouter-sakana-fugu-ultra` with provider `openrouter`. Do not substitute a raw CLI model argument or another catalog ID.

--- a/winsmux-core/agents/profiles/providers/antigravity.md
+++ b/winsmux-core/agents/profiles/providers/antigravity.md
@@ -1,0 +1,3 @@
+# Provider: Antigravity
+
+Stay inside the assigned Antigravity worker. Use the catalog model ID selected for this slot. Do not switch providers, invent credentials, or read operator secret stores.

--- a/winsmux-core/agents/profiles/providers/claude.md
+++ b/winsmux-core/agents/profiles/providers/claude.md
@@ -1,0 +1,3 @@
+# Provider: Claude Code
+
+Stay inside the assigned Claude Code worker. Use the catalog model ID selected for this slot. Do not switch providers, invent credentials, or read operator secret stores.

--- a/winsmux-core/agents/profiles/providers/codex.md
+++ b/winsmux-core/agents/profiles/providers/codex.md
@@ -1,0 +1,3 @@
+# Provider: Codex
+
+Stay inside the assigned Codex CLI worker. Use the catalog model ID selected for this slot. Do not switch providers, invent credentials, or read operator secret stores.

--- a/winsmux-core/agents/profiles/providers/grok-build.md
+++ b/winsmux-core/agents/profiles/providers/grok-build.md
@@ -1,0 +1,3 @@
+# Provider: Grok Build
+
+Stay inside the assigned Grok Build worker. Use the catalog model ID selected for this slot. Do not switch providers, invent credentials, or read operator secret stores.

--- a/winsmux-core/agents/profiles/providers/openrouter.md
+++ b/winsmux-core/agents/profiles/providers/openrouter.md
@@ -1,0 +1,3 @@
+# Provider: OpenRouter
+
+Stay inside the assigned OpenRouter worker. Use the catalog model ID selected for this slot. Do not probe extra model filenames. Do not switch providers, invent credentials, or read operator secret stores.

--- a/winsmux-core/agents/profiles/registry.yaml
+++ b/winsmux-core/agents/profiles/registry.yaml
@@ -1,0 +1,151 @@
+# Package-owned instruction-pack registry. Templates are static; they are not a catalog.
+schema-version: 1
+registry-id: official-instruction-packs-v1
+base: base.md
+a1:
+  worker:
+    - frozen-spec-implementation
+    - repro-fix
+    - mechanical-migration
+  operator:
+    - design-judgment
+    - api-judgment
+    - small-tweak
+    - secrets-mcp
+    - destructive-ops
+providers:
+  - id: codex
+    template: providers/codex.md
+  - id: claude
+    template: providers/claude.md
+  - id: antigravity
+    template: providers/antigravity.md
+  - id: grok-build
+    template: providers/grok-build.md
+  - id: openrouter
+    template: providers/openrouter.md
+roles:
+  - id: architect
+    template: roles/architect.md
+  - id: builder
+    template: roles/builder.md
+  - id: reviewer
+    template: roles/reviewer.md
+  - id: researcher
+    template: roles/researcher.md
+  - id: maintainer
+    template: roles/maintainer.md
+lifecycles:
+  - id: session
+    template: lifecycles/session.md
+  - id: task
+    template: lifecycles/task.md
+  - id: one-shot
+    template: lifecycles/one-shot.md
+task-classes:
+  - id: architecture
+    template: task-classes/architecture.md
+  - id: protocol
+    template: task-classes/protocol.md
+  - id: security
+    template: task-classes/security.md
+  - id: implementation
+    template: task-classes/implementation.md
+  - id: test
+    template: task-classes/test.md
+  - id: review
+    template: task-classes/review.md
+  - id: research
+    template: task-classes/research.md
+  - id: documentation
+    template: task-classes/documentation.md
+  - id: repository-operations
+    template: task-classes/repository-operations.md
+models:
+  - id: codex-gpt-5-6-sol
+    provider: codex
+    template: models/codex/codex-gpt-5-6-sol.md
+  - id: codex-gpt-5-6-terra
+    provider: codex
+    template: models/codex/codex-gpt-5-6-terra.md
+  - id: codex-gpt-5-6-luna
+    provider: codex
+    template: models/codex/codex-gpt-5-6-luna.md
+  - id: codex-gpt-5-5
+    provider: codex
+    template: models/codex/codex-gpt-5-5.md
+  - id: codex-gpt-5-4
+    provider: codex
+    template: models/codex/codex-gpt-5-4.md
+  - id: codex-gpt-5-4-mini
+    provider: codex
+    template: models/codex/codex-gpt-5-4-mini.md
+  - id: codex-spark
+    provider: codex
+    template: models/codex/codex-spark.md
+  - id: claude-fable-5
+    provider: claude
+    template: models/claude/claude-fable-5.md
+  - id: claude-opus-5
+    provider: claude
+    template: models/claude/claude-opus-5.md
+  - id: claude-sonnet-5
+    provider: claude
+    template: models/claude/claude-sonnet-5.md
+  - id: claude-opus-4-8
+    provider: claude
+    template: models/claude/claude-opus-4-8.md
+  - id: claude-sonnet-4-6
+    provider: claude
+    template: models/claude/claude-sonnet-4-6.md
+  - id: claude-haiku-4-5
+    provider: claude
+    template: models/claude/claude-haiku-4-5.md
+  - id: claude-opus-4-7
+    provider: claude
+    template: models/claude/claude-opus-4-7.md
+  - id: claude-opus-4-6
+    provider: claude
+    template: models/claude/claude-opus-4-6.md
+  - id: antigravity-gemini-3-5-flash-medium
+    provider: antigravity
+    template: models/antigravity/antigravity-gemini-3-5-flash-medium.md
+  - id: antigravity-gemini-3-5-flash-high
+    provider: antigravity
+    template: models/antigravity/antigravity-gemini-3-5-flash-high.md
+  - id: antigravity-gemini-3-5-flash-low
+    provider: antigravity
+    template: models/antigravity/antigravity-gemini-3-5-flash-low.md
+  - id: antigravity-gemini-3-1-pro-low
+    provider: antigravity
+    template: models/antigravity/antigravity-gemini-3-1-pro-low.md
+  - id: antigravity-gemini-3-1-pro-high
+    provider: antigravity
+    template: models/antigravity/antigravity-gemini-3-1-pro-high.md
+  - id: antigravity-claude-sonnet-4-6-thinking
+    provider: antigravity
+    template: models/antigravity/antigravity-claude-sonnet-4-6-thinking.md
+  - id: antigravity-claude-opus-4-6-thinking
+    provider: antigravity
+    template: models/antigravity/antigravity-claude-opus-4-6-thinking.md
+  - id: antigravity-gpt-oss-120b-medium
+    provider: antigravity
+    template: models/antigravity/antigravity-gpt-oss-120b-medium.md
+  - id: grok-build-grok-4-3
+    provider: grok-build
+    template: models/grok-build/grok-build-grok-4-3.md
+  - id: grok-build-composer-2-5-fast
+    provider: grok-build
+    template: models/grok-build/grok-build-composer-2-5-fast.md
+  - id: openrouter-sakana-fugu-ultra
+    provider: openrouter
+    template: models/openrouter/openrouter-sakana-fugu-ultra.md
+  - id: openrouter-glm-5-2
+    provider: openrouter
+    template: models/openrouter/openrouter-glm-5-2.md
+  - id: openrouter-kimi-k2-7-code
+    provider: openrouter
+    template: models/openrouter/openrouter-kimi-k2-7-code.md
+dynamic-providers:
+  - provider: openrouter
+    template: models/openrouter/_dynamic.md

--- a/winsmux-core/agents/profiles/roles/architect.md
+++ b/winsmux-core/agents/profiles/roles/architect.md
@@ -1,0 +1,3 @@
+# Role: architect
+
+Own design-shaping investigation only when the operator already classified the work as worker-owned. Do not make unbound API or product judgments. Produce a frozen spec that a builder can implement.

--- a/winsmux-core/agents/profiles/roles/builder.md
+++ b/winsmux-core/agents/profiles/roles/builder.md
@@ -1,0 +1,3 @@
+# Role: builder
+
+Implement frozen specs, reproduction fixes, and mechanical migrations. Keep diffs scoped. Do not perform destructive repository operations or secret/MCP setup.

--- a/winsmux-core/agents/profiles/roles/maintainer.md
+++ b/winsmux-core/agents/profiles/roles/maintainer.md
@@ -1,0 +1,3 @@
+# Role: maintainer
+
+Handle documentation and repository-operations that are worker-owned. Refuse destructive operations, secret handling, and sub-20-line operator tweaks.

--- a/winsmux-core/agents/profiles/roles/researcher.md
+++ b/winsmux-core/agents/profiles/roles/researcher.md
@@ -1,0 +1,3 @@
+# Role: researcher
+
+Gather source-backed findings. Separate facts from assumptions. Do not implement product changes or store notes in repository instruction files.

--- a/winsmux-core/agents/profiles/roles/reviewer.md
+++ b/winsmux-core/agents/profiles/roles/reviewer.md
@@ -1,0 +1,3 @@
+# Role: reviewer
+
+Review diffs against the frozen spec and security task class. Do not edit product code. Report PASS or FAIL with evidence. Return design judgment to the operator.

--- a/winsmux-core/agents/profiles/task-classes/architecture.md
+++ b/winsmux-core/agents/profiles/task-classes/architecture.md
@@ -1,0 +1,3 @@
+# Task class: architecture
+
+Work only on architecture-class evidence: boundaries, ownership, and frozen specs. Do not silently expand into implementation.

--- a/winsmux-core/agents/profiles/task-classes/documentation.md
+++ b/winsmux-core/agents/profiles/task-classes/documentation.md
@@ -1,0 +1,3 @@
+# Task class: documentation
+
+Update public docs that match shipped behavior. Do not document unpublished secrets or local paths.

--- a/winsmux-core/agents/profiles/task-classes/implementation.md
+++ b/winsmux-core/agents/profiles/task-classes/implementation.md
@@ -1,0 +1,3 @@
+# Task class: implementation
+
+Implement against a frozen spec. Do not reopen design or API judgment.

--- a/winsmux-core/agents/profiles/task-classes/protocol.md
+++ b/winsmux-core/agents/profiles/task-classes/protocol.md
@@ -1,0 +1,3 @@
+# Task class: protocol
+
+Work only on protocol-class evidence: contracts, schemas, and compatibility. Do not invent a parallel protocol.

--- a/winsmux-core/agents/profiles/task-classes/repository-operations.md
+++ b/winsmux-core/agents/profiles/task-classes/repository-operations.md
@@ -1,0 +1,3 @@
+# Task class: repository-operations
+
+Perform only non-destructive, worker-owned repository operations. Destructive ops return to the operator.

--- a/winsmux-core/agents/profiles/task-classes/research.md
+++ b/winsmux-core/agents/profiles/task-classes/research.md
@@ -1,0 +1,3 @@
+# Task class: research
+
+Investigate and cite sources. Do not convert research notes into settings or instruction-file edits.

--- a/winsmux-core/agents/profiles/task-classes/review.md
+++ b/winsmux-core/agents/profiles/task-classes/review.md
@@ -1,0 +1,3 @@
+# Task class: review
+
+Review only. Do not modify product files. Fail closed on missing evidence.

--- a/winsmux-core/agents/profiles/task-classes/security.md
+++ b/winsmux-core/agents/profiles/task-classes/security.md
@@ -1,0 +1,3 @@
+# Task class: security
+
+Work only on security-class evidence. Do not weaken isolation, authentication, or secret handling. Report issues; do not store secrets.

--- a/winsmux-core/agents/profiles/task-classes/test.md
+++ b/winsmux-core/agents/profiles/task-classes/test.md
@@ -1,0 +1,3 @@
+# Task class: test
+
+Add or update tests for the owned invariant. Tests must fail first on the bug or missing behavior, then pass.

--- a/winsmux-core/agents/team-profiles/official-balanced-v1.yaml
+++ b/winsmux-core/agents/team-profiles/official-balanced-v1.yaml
@@ -1,0 +1,85 @@
+# Package-owned official Team Profile preset. Immutable once released.
+# Digest covers the six canonical slot records (kebab-case JSON, sorted keys).
+preset-id: official-balanced-v1
+preset-revision: 1
+digest-sha256: 7d671140ed9020dae23e27458242f5deb1146bead5d4886d6c2f786059a9b8f5
+slots:
+  - slot-id: worker-1
+    provider: codex
+    model: codex-gpt-5-6-sol
+    reasoning-effort: xhigh
+    role-profile: architect
+    lifecycle: session
+    task-classes:
+      - architecture
+      - protocol
+      - security
+    delegation:
+      - frozen-spec-implementation
+      - repro-fix
+      - mechanical-migration
+  - slot-id: worker-2
+    provider: codex
+    model: codex-gpt-5-6-terra
+    reasoning-effort: high
+    role-profile: builder
+    lifecycle: task
+    task-classes:
+      - implementation
+      - test
+    delegation:
+      - frozen-spec-implementation
+      - repro-fix
+      - mechanical-migration
+  - slot-id: worker-3
+    provider: codex
+    model: codex-gpt-5-6-terra
+    reasoning-effort: high
+    role-profile: builder
+    lifecycle: task
+    task-classes:
+      - implementation
+      - test
+    delegation:
+      - frozen-spec-implementation
+      - repro-fix
+      - mechanical-migration
+  - slot-id: worker-4
+    provider: codex
+    model: codex-gpt-5-6-sol
+    reasoning-effort: xhigh
+    role-profile: reviewer
+    lifecycle: task
+    task-classes:
+      - review
+      - security
+    delegation:
+      - frozen-spec-implementation
+      - repro-fix
+      - mechanical-migration
+  - slot-id: worker-5
+    provider: codex
+    model: codex-gpt-5-6-terra
+    reasoning-effort: high
+    role-profile: researcher
+    lifecycle: task
+    task-classes:
+      - research
+      - documentation
+    delegation:
+      - frozen-spec-implementation
+      - repro-fix
+      - mechanical-migration
+  - slot-id: worker-6
+    provider: codex
+    model: codex-gpt-5-6-luna
+    reasoning-effort: medium
+    role-profile: maintainer
+    lifecycle: task
+    task-classes:
+      - documentation
+      - repository-operations
+    delegation:
+      - frozen-spec-implementation
+      - repro-fix
+      - mechanical-migration

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -7,6 +7,57 @@ function Get-WinsmuxControlPlaneArguments {
     return ,@(@($CommandTarget) + @($CommandRest) | Where-Object { $_ })
 }
 
+function Split-WinsmuxDispatchTaskArguments {
+    param([AllowNull()][string[]]$Parts)
+
+    $slotId = ''
+    $taskClass = ''
+    $delegation = ''
+    $projectDir = ''
+    $textParts = New-Object System.Collections.Generic.List[string]
+    $index = 0
+    $items = @($Parts)
+    while ($index -lt $items.Count) {
+        $current = [string]$items[$index]
+        if ($current -ceq '--') {
+            $index++
+            while ($index -lt $items.Count) {
+                $textParts.Add([string]$items[$index])
+                $index++
+            }
+            break
+        }
+        if ($current -in @('--slot-id', '--task-class', '--delegation', '--project-dir')) {
+            if ($index + 1 -ge $items.Count) {
+                Stop-WithError 'usage: winsmux dispatch-task [--slot-id <id>] [--task-class <id>] [--delegation <id>] [--project-dir <path>] [--] <text>'
+            }
+            $value = [string]$items[$index + 1]
+            switch ($current) {
+                '--slot-id' { $slotId = $value }
+                '--task-class' { $taskClass = $value }
+                '--delegation' { $delegation = $value }
+                '--project-dir' { $projectDir = $value }
+            }
+            $index += 2
+            continue
+        }
+        if ($current -ceq '--json') {
+            $index++
+            continue
+        }
+        $textParts.Add($current)
+        $index++
+    }
+
+    return [pscustomobject]@{
+        SlotId     = $slotId
+        TaskClass  = $taskClass
+        Delegation = $delegation
+        ProjectDir = $projectDir
+        TaskText   = ((@($textParts) | ForEach-Object { ([string]$_).Trim() } | Where-Object { $_ }) -join ' ')
+    }
+}
+
 function Join-WinsmuxControlPlaneText {
     param([AllowNull()][object[]]$Arguments)
 
@@ -139,7 +190,7 @@ function Get-DispatchTaskManifestEntry {
 
     if (Get-Command Get-PaneControlManifestEntries -ErrorAction SilentlyContinue) {
         try {
-            $entry = @(Get-PaneControlManifestEntries -ProjectDir $ProjectDir | Where-Object { [string]$_.Label -eq $Label } | Select-Object -First 1)[0]
+            $entry = @(Get-PaneControlManifestEntries -ProjectDir $ProjectDir | Where-Object { [string]$_.Label -eq $Label -or [string]$_.SlotId -eq $Label } | Select-Object -First 1)[0]
             if ($null -ne $entry) {
                 return $entry
             }
@@ -218,13 +269,17 @@ function Invoke-WinsmuxDispatchTaskCommand {
             ForEach-Object { ([string]$_).Trim() } |
             Where-Object { $_ }
     )
-    if ($parts.Count -lt 1) {
+    $parsed = Split-WinsmuxDispatchTaskArguments -Parts $parts
+    $taskText = [string]$parsed.TaskText
+    if ([string]::IsNullOrWhiteSpace($taskText)) {
         Stop-WithError "usage: winsmux dispatch-task <text>"
     }
 
-    $taskText = $parts -join ' '
     $submissionId = 'submission-' + [guid]::NewGuid().ToString('N')
     $projectDir = (Get-Location).Path
+    if (-not [string]::IsNullOrWhiteSpace([string]$parsed.ProjectDir)) {
+        $projectDir = [string]$parsed.ProjectDir
+    }
     $routerScript = Get-WinsmuxControlPlaneScriptPath -BridgeScriptRoot $BridgeScriptRoot -ScriptName 'dispatch-router.ps1'
     if (-not (Test-Path -LiteralPath $routerScript -PathType Leaf)) {
         Stop-WithError "dispatch router not found: $routerScript"
@@ -234,16 +289,24 @@ function Invoke-WinsmuxDispatchTaskCommand {
 
     $availableTargets = @(Get-DispatchTaskAvailableTargets -ProjectDir $projectDir)
 
-    $route = Get-DispatchRoute -Text $taskText -AvailableTargets $availableTargets -DefaultRole 'Worker'
-    if ($route.HandleLocally) {
-        $receipt = New-WinsmuxRouterRefusalReceipt -Kind task -Route $route -SubmissionId $submissionId
-        ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
-        exit 1
-    }
-
-    $selectedLabel = [string]$route.SelectedTarget
+    $selectedLabel = ''
     $paneId = ''
-    $resolvedRole = [string]$route.SelectedRole
+    $resolvedRole = 'Worker'
+    $classifiedSlotId = [string]$parsed.SlotId
+    if (-not [string]::IsNullOrWhiteSpace($classifiedSlotId)) {
+        $selectedLabel = $classifiedSlotId
+        $resolvedRole = 'Worker'
+    } else {
+        $route = Get-DispatchRoute -Text $taskText -AvailableTargets $availableTargets -DefaultRole 'Worker'
+        if ($route.HandleLocally) {
+            $receipt = New-WinsmuxRouterRefusalReceipt -Kind task -Route $route -SubmissionId $submissionId
+            ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+            exit 1
+        }
+
+        $selectedLabel = [string]$route.SelectedTarget
+        $resolvedRole = [string]$route.SelectedRole
+    }
 
     $manifestEntry = $null
     if ($resolvedRole -eq 'Reviewer') {

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -1103,6 +1103,51 @@ function New-OrchestraWorkerLaunchApproval {
     }
 }
 
+
+function Invoke-TeamProfileLaunchProjection {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$SessionId,
+        [Parameter(Mandatory = $true)][string]$SlotId,
+        [AllowEmptyString()][string]$Worktree = '',
+        [string]$ReadWriteScope = 'session'
+    )
+
+    $settingsPath = Join-Path $ProjectDir '.winsmux.yaml'
+    if (-not (Test-Path -LiteralPath $settingsPath)) {
+        return
+    }
+    $raw = Get-Content -LiteralPath $settingsPath -Raw -ErrorAction SilentlyContinue
+    if ([string]::IsNullOrWhiteSpace($raw) -or ($raw -notmatch '(?m)^[ \t]*team-profile[ \t]*:')) {
+        return
+    }
+
+    $winsmuxBin = [string]$script:winsmuxBin
+    if ([string]::IsNullOrWhiteSpace($winsmuxBin)) {
+        $winsmuxBin = [string](Get-WinsmuxBin)
+    }
+    if ([string]::IsNullOrWhiteSpace($winsmuxBin)) {
+        throw "Team Profile launch projection failed: winsmux binary was not found."
+    }
+
+    $args = @(
+        'team-profile',
+        '--action', 'project-launch',
+        '--json',
+        '--project-dir', $ProjectDir,
+        '--session-id', $SessionId,
+        '--slot-id', $SlotId,
+        '--read-write-scope', $ReadWriteScope
+    )
+    if (-not [string]::IsNullOrWhiteSpace($Worktree)) {
+        $args += @('--worktree', $Worktree)
+    }
+    $output = & $winsmuxBin @args 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw ("Team Profile launch projection failed for slot '{0}': {1}" -f $SlotId, ($output | Out-String))
+    }
+}
+
 function New-OrchestraPaneBootstrapPlan {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -3060,6 +3105,9 @@ if ($MyInvocation.InvocationName -ne '.') {
                     Write-Warning "TASK-231: empty launch command for pane $paneId ($label, role=$canonicalRole, execMode=$execMode). Agent will not start automatically."
                 }
             } else {
+                if ($canonicalRole -eq 'Worker') {
+                    Invoke-TeamProfileLaunchProjection -ProjectDir $projectDir -SessionId $sessionName -SlotId $label -Worktree $launchDir -ReadWriteScope 'session'
+                }
                 $bootstrapPlanPath = New-OrchestraPaneBootstrapPlan `
                     -ProjectDir $projectDir `
                     -PaneId $paneId `

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -1104,6 +1104,15 @@ function New-OrchestraWorkerLaunchApproval {
 }
 
 
+function Test-TeamProfileOptInDocument {
+    param([AllowEmptyString()][string]$Yaml)
+
+    if ([string]::IsNullOrWhiteSpace($Yaml)) {
+        return $false
+    }
+    return [bool]($Yaml -match '(?m)(^|[\s{,])["'']?team-profile["'']?\s*:')
+}
+
 function Invoke-TeamProfileLaunchProjection {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -1115,11 +1124,11 @@ function Invoke-TeamProfileLaunchProjection {
 
     $settingsPath = Join-Path $ProjectDir '.winsmux.yaml'
     if (-not (Test-Path -LiteralPath $settingsPath)) {
-        return
+        return $null
     }
     $raw = Get-Content -LiteralPath $settingsPath -Raw -ErrorAction SilentlyContinue
-    if ([string]::IsNullOrWhiteSpace($raw) -or ($raw -notmatch '(?m)^[ \t]*team-profile[ \t]*:')) {
-        return
+    if (-not (Test-TeamProfileOptInDocument -Yaml $raw)) {
+        return $null
     }
 
     $winsmuxBin = [string]$script:winsmuxBin
@@ -1146,6 +1155,74 @@ function Invoke-TeamProfileLaunchProjection {
     if ($LASTEXITCODE -ne 0) {
         throw ("Team Profile launch projection failed for slot '{0}': {1}" -f $SlotId, ($output | Out-String))
     }
+    $text = ($output | Out-String).Trim()
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        throw ("Team Profile launch projection returned no JSON for slot '{0}'." -f $SlotId)
+    }
+    try {
+        return ($text | ConvertFrom-Json)
+    } catch {
+        throw ("Team Profile launch projection returned invalid JSON for slot '{0}': {1}" -f $SlotId, $text)
+    }
+}
+
+function Apply-TeamProfileLaunchProjection {
+    param(
+        [Parameter(Mandatory = $true)]$SlotAgentConfig,
+        [Parameter(Mandatory = $true)]$Projection,
+        [string]$RootPath = ''
+    )
+
+    $assignment = $null
+    if ($null -ne $Projection.projection -and $null -ne $Projection.projection.pane) {
+        $assignment = $Projection.projection.pane.assignment
+    }
+    if ($null -eq $assignment) {
+        return
+    }
+
+    $provider = [string]$assignment.provider
+    $launchModel = [string]$assignment.launch_model
+    $effort = [string]$assignment.reasoning_effort
+    if (-not [string]::IsNullOrWhiteSpace($provider)) {
+        $SlotAgentConfig.Agent = $provider
+        if (-not [string]::IsNullOrWhiteSpace($RootPath)) {
+            $capability = Resolve-BridgeProviderCapability -ProviderId $provider -RootPath $RootPath -RequireWhenRegistryPresent
+            if ($null -ne $capability) {
+                $SlotAgentConfig.CapabilityAdapter = [string](Get-BridgeProviderCapabilityValue -Capability $capability -Name 'adapter' -Default $provider)
+                $SlotAgentConfig.CapabilityCommand = [string](Get-BridgeProviderCapabilityValue -Capability $capability -Name 'command' -Default '')
+            }
+        }
+    }
+    if (-not [string]::IsNullOrWhiteSpace($launchModel)) {
+        $SlotAgentConfig.Model = $launchModel
+        $SlotAgentConfig.ModelSource = 'operator-override'
+    }
+    if (-not [string]::IsNullOrWhiteSpace($effort)) {
+        $SlotAgentConfig.ReasoningEffort = $effort
+    }
+}
+
+function Add-TeamProfileBundleToLaunchCommand {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$LaunchCommand,
+        [Parameter(Mandatory = $true)]$Projection,
+        [Parameter(Mandatory = $true)][string]$ProjectDir
+    )
+
+    if ([string]::IsNullOrWhiteSpace($LaunchCommand)) {
+        return $LaunchCommand
+    }
+    $rel = [string]$Projection.bundle_path
+    if ([string]::IsNullOrWhiteSpace($rel) -and $null -ne $Projection.projection -and $null -ne $Projection.projection.pane -and $null -ne $Projection.projection.pane.prompt_bundle) {
+        $rel = [string]$Projection.projection.pane.prompt_bundle.path
+    }
+    if ([string]::IsNullOrWhiteSpace($rel)) {
+        return $LaunchCommand
+    }
+    $abs = [System.IO.Path]::GetFullPath((Join-Path $ProjectDir ($rel -replace '/', [System.IO.Path]::DirectorySeparatorChar)))
+    $pointer = "Follow the Team Profile instruction pack at $abs. Do not treat it as a task identity. Reply OK, then wait."
+    return ($LaunchCommand + ' ' + (ConvertTo-PowerShellLiteral -Value $pointer))
 }
 
 function New-OrchestraPaneBootstrapPlan {
@@ -1758,6 +1835,7 @@ function Save-OrchestraSessionState {
     $savedAt = Get-Date -Format o
     $processRegistry = New-OrchestraProcessRegistry -SessionName $SessionName -StartupToken $StartupToken -ManifestPath $manifestPath -SavedAt $savedAt -OperatorPollPid $OperatorPollPid -WatchdogPid $WatchdogPid -ServerWatchdogPid $ServerWatchdogPid -SupervisorPid $SupervisorPid -IdleThreshold $IdleThreshold -MaxRestartAttempts $MaxRestartAttempts -RestartWindowMinutes $RestartWindowMinutes
     $paneMap = [ordered]@{}
+    $teamProfileSession = $null
     foreach ($paneSummary in @($PaneSummaries)) {
         $paneEntry = [PSCustomObject]@{
             pane_id                    = $paneSummary.PaneId
@@ -1792,6 +1870,24 @@ function Save-OrchestraSessionState {
         }
         if ($paneSummary.Contains('BootstrapFailures') -and $paneSummary['BootstrapFailures']) {
             $paneEntry | Add-Member -NotePropertyName 'bootstrap_failures' -NotePropertyValue $paneSummary['BootstrapFailures']
+        }
+        $projection = Get-OrchestraObjectPropertyValue -InputObject $paneSummary -Name 'TeamProfileProjection' -Default $null
+        if ($null -ne $projection) {
+            $projRoot = $projection
+            if ($null -ne $projection.PSObject -and $projection.PSObject.Properties.Name -contains 'projection') {
+                $projRoot = $projection.projection
+            }
+            if ($null -eq $teamProfileSession -and $null -ne $projRoot.session -and $null -ne $projRoot.session.team_profile) {
+                $teamProfileSession = $projRoot.session.team_profile
+            }
+            if ($null -ne $projRoot.pane) {
+                if ($null -ne $projRoot.pane.assignment) {
+                    $paneEntry | Add-Member -NotePropertyName 'assignment' -NotePropertyValue $projRoot.pane.assignment -Force
+                }
+                if ($null -ne $projRoot.pane.prompt_bundle) {
+                    $paneEntry | Add-Member -NotePropertyName 'prompt_bundle' -NotePropertyValue $projRoot.pane.prompt_bundle -Force
+                }
+            }
         }
         $paneMap[[string]$paneSummary.Label] = $paneEntry
     }
@@ -1837,6 +1933,9 @@ function Save-OrchestraSessionState {
     }
     if ($null -ne $DeclarativeWorkspace) {
         $manifest | Add-Member -NotePropertyName 'declarative_workspace' -NotePropertyValue $DeclarativeWorkspace -Force
+    }
+    if ($null -ne $teamProfileSession) {
+        $manifest.session | Add-Member -NotePropertyName 'team_profile' -NotePropertyValue $teamProfileSession -Force
     }
 
     if ((Test-Path -LiteralPath $manifestPath -PathType Leaf) -and
@@ -3039,6 +3138,13 @@ if ($MyInvocation.InvocationName -ne '.') {
         }
 
         $slotAgentConfig = Get-SlotAgentConfig -Role $canonicalRole -SlotId $label -Settings $settings -RootPath $projectDir
+        $teamProfileProjection = $null
+        if ($canonicalRole -eq 'Worker') {
+            $teamProfileProjection = Invoke-TeamProfileLaunchProjection -ProjectDir $projectDir -SessionId $sessionName -SlotId $label -Worktree $launchDir -ReadWriteScope 'session'
+            if ($null -ne $teamProfileProjection) {
+                Apply-TeamProfileLaunchProjection -SlotAgentConfig $slotAgentConfig -Projection $teamProfileProjection -RootPath $projectDir
+            }
+        }
         $execModeAgent = [string]$slotAgentConfig.CapabilityAdapter
         if ([string]::IsNullOrWhiteSpace($execModeAgent)) {
             $execModeAgent = [string]$slotAgentConfig.Agent
@@ -3063,6 +3169,9 @@ if ($MyInvocation.InvocationName -ne '.') {
         $launchCommand = ''
         if (-not $oneShotPaneStartDeferred) {
             $launchCommand = Get-AgentLaunchCommand -Agent $slotAgentConfig.Agent -Model $slotAgentConfig.Model -ModelSource $slotAgentConfig.ModelSource -ReasoningEffort $slotAgentConfig.ReasoningEffort -McpMode $slotAgentConfig.McpMode -SlotId $label -ProjectDir $launchDir -GitWorktreeDir $launchGitWorktreeDir -RootPath $projectDir -ExecMode $false
+            if ($null -ne $teamProfileProjection) {
+                $launchCommand = Add-TeamProfileBundleToLaunchCommand -LaunchCommand $launchCommand -Projection $teamProfileProjection -ProjectDir $projectDir
+            }
         }
         $runtimePaneTitle = [string]$slotAgentConfig.PaneTitle
         if ([string]::IsNullOrWhiteSpace($runtimePaneTitle)) {
@@ -3105,9 +3214,6 @@ if ($MyInvocation.InvocationName -ne '.') {
                     Write-Warning "TASK-231: empty launch command for pane $paneId ($label, role=$canonicalRole, execMode=$execMode). Agent will not start automatically."
                 }
             } else {
-                if ($canonicalRole -eq 'Worker') {
-                    Invoke-TeamProfileLaunchProjection -ProjectDir $projectDir -SessionId $sessionName -SlotId $label -Worktree $launchDir -ReadWriteScope 'session'
-                }
                 $bootstrapPlanPath = New-OrchestraPaneBootstrapPlan `
                     -ProjectDir $projectDir `
                     -PaneId $paneId `
@@ -3197,6 +3303,7 @@ if ($MyInvocation.InvocationName -ne '.') {
             BootstrapMarkerPath = $bootstrapMarkerPath
             Status = $paneStatus
             RuntimeReady = $false
+            TeamProfileProjection = $teamProfileProjection
         })
     }
 

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -1151,7 +1151,7 @@ function Invoke-TeamProfileLaunchProjection {
     if (-not [string]::IsNullOrWhiteSpace($Worktree)) {
         $args += @('--worktree', $Worktree)
     }
-    $output = & $winsmuxBin @args 2>&1
+    $output = Invoke-WinsmuxBridgeCommand -WinsmuxBin $winsmuxBin -Arguments $args 2>&1
     if ($LASTEXITCODE -ne 0) {
         throw ("Team Profile launch projection failed for slot '{0}': {1}" -f $SlotId, ($output | Out-String))
     }

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -601,9 +601,6 @@ function ConvertTo-BridgeSlotEntry {
     $canonicalAgent = Get-BridgeSlotAgentName -Slot $slot
     if (-not [string]::IsNullOrWhiteSpace($canonicalAgent)) {
         $slot.agent = $canonicalAgent
-        if (-not $slot.Contains('provider')) {
-            $slot.provider = $canonicalAgent
-        }
     }
 
     return $slot

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -499,6 +499,35 @@ function ConvertTo-BridgeSlotKey {
     }
 }
 
+function Get-BridgeSlotAgentName {
+    param([AllowNull()]$Slot)
+
+    if ($null -eq $Slot) {
+        return ''
+    }
+
+    if ($Slot -is [System.Collections.IDictionary]) {
+        if ($Slot.Contains('provider') -and -not [string]::IsNullOrWhiteSpace([string]$Slot['provider'])) {
+            return [string]$Slot['provider']
+        }
+        if ($Slot.Contains('agent') -and -not [string]::IsNullOrWhiteSpace([string]$Slot['agent'])) {
+            return [string]$Slot['agent']
+        }
+        return ''
+    }
+
+    if ($null -ne $Slot.PSObject) {
+        if ($Slot.PSObject.Properties.Name -contains 'provider' -and -not [string]::IsNullOrWhiteSpace([string]$Slot.provider)) {
+            return [string]$Slot.provider
+        }
+        if ($Slot.PSObject.Properties.Name -contains 'agent' -and -not [string]::IsNullOrWhiteSpace([string]$Slot.agent)) {
+            return [string]$Slot.agent
+        }
+    }
+
+    return ''
+}
+
 function ConvertTo-BridgeSlotEntry {
     param([AllowNull()]$Value)
 
@@ -566,6 +595,14 @@ function ConvertTo-BridgeSlotEntry {
             $slot.model_source = 'provider-default'
         } else {
             $slot.model_source = 'operator-override'
+        }
+    }
+
+    $canonicalAgent = Get-BridgeSlotAgentName -Slot $slot
+    if (-not [string]::IsNullOrWhiteSpace($canonicalAgent)) {
+        $slot.agent = $canonicalAgent
+        if (-not $slot.Contains('provider')) {
+            $slot.provider = $canonicalAgent
         }
     }
 
@@ -2998,7 +3035,9 @@ function Get-RoleAgentConfig {
     $roleModelSet = $false
     $roleModelSourceSet = $false
     if ($resolvedRoleConfig -is [System.Collections.IDictionary]) {
-        if ($resolvedRoleConfig.Contains('agent') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig['agent'])) {
+        if ($resolvedRoleConfig.Contains('provider') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig['provider'])) {
+            $agent = [string]$resolvedRoleConfig['provider']
+        } elseif ($resolvedRoleConfig.Contains('agent') -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig['agent'])) {
             $agent = [string]$resolvedRoleConfig['agent']
         }
 
@@ -3024,7 +3063,9 @@ function Get-RoleAgentConfig {
             $authMode = [string]$resolvedRoleConfig['auth_mode']
         }
     } elseif ($null -ne $resolvedRoleConfig -and $null -ne $resolvedRoleConfig.PSObject) {
-        if ($resolvedRoleConfig.PSObject.Properties.Name -contains 'agent' -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig.agent)) {
+        if ($resolvedRoleConfig.PSObject.Properties.Name -contains 'provider' -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig.provider)) {
+            $agent = [string]$resolvedRoleConfig.provider
+        } elseif ($resolvedRoleConfig.PSObject.Properties.Name -contains 'agent' -and -not [string]::IsNullOrWhiteSpace([string]$resolvedRoleConfig.agent)) {
             $agent = [string]$resolvedRoleConfig.agent
         }
 
@@ -3057,7 +3098,9 @@ function Get-RoleAgentConfig {
     if (-not [string]::IsNullOrWhiteSpace($RootPath)) {
         $runtimeRoleConfig = Get-BridgeRuntimeRolePreference -Role $Role -RootPath $RootPath
         if ($runtimeRoleConfig -is [System.Collections.IDictionary]) {
-            if ($runtimeRoleConfig.Contains('agent') -and -not [string]::IsNullOrWhiteSpace([string]$runtimeRoleConfig['agent'])) {
+            if ($runtimeRoleConfig.Contains('provider') -and -not [string]::IsNullOrWhiteSpace([string]$runtimeRoleConfig['provider'])) {
+                $agent = [string]$runtimeRoleConfig['provider']
+            } elseif ($runtimeRoleConfig.Contains('agent') -and -not [string]::IsNullOrWhiteSpace([string]$runtimeRoleConfig['agent'])) {
                 $agent = [string]$runtimeRoleConfig['agent']
             }
             if ($runtimeRoleConfig.Contains('model') -and -not [string]::IsNullOrWhiteSpace([string]$runtimeRoleConfig['model'])) {
@@ -3172,9 +3215,7 @@ function Get-SlotAgentConfig {
                 if ($slot.Contains('slot_id')) {
                     $candidateSlotId = [string]$slot['slot_id']
                 }
-                if ($slot.Contains('agent')) {
-                    $slotAgent = [string]$slot['agent']
-                }
+                $slotAgent = Get-BridgeSlotAgentName -Slot $slot
                 if ($slot.Contains('model')) {
                     $slotModel = [string]$slot['model']
                     $slotModelSet = $true
@@ -3214,9 +3255,7 @@ function Get-SlotAgentConfig {
                 if ($slot.PSObject.Properties.Name -contains 'slot_id') {
                     $candidateSlotId = [string]$slot.slot_id
                 }
-                if ($slot.PSObject.Properties.Name -contains 'agent') {
-                    $slotAgent = [string]$slot.agent
-                }
+                $slotAgent = Get-BridgeSlotAgentName -Slot $slot
                 if ($slot.PSObject.Properties.Name -contains 'model') {
                     $slotModel = [string]$slot.model
                     $slotModelSet = $true

--- a/winsmux-core/scripts/settings.ps1
+++ b/winsmux-core/scripts/settings.ps1
@@ -43,6 +43,9 @@ $script:BridgeSlotScalarKeys = @(
     'model',
     'model_source',
     'reasoning_effort',
+    'provider',
+    'role_profile',
+    'lifecycle',
     'prompt_transport',
     'mcp_mode',
     'auth_mode',
@@ -53,7 +56,7 @@ $script:BridgeSlotScalarKeys = @(
     'pane_title',
     'fallback_model'
 )
-$script:BridgeSlotListKeys = @()
+$script:BridgeSlotListKeys = @('task_classes', 'delegation')
 $script:BridgeRoleScalarKeys = @(
     'agent',
     'model',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

TASK-785: worker completion is a dispatch-given artifact file (equivalent to `-o /result.md`) plus exit code.

Merge-ready correction on the existing branch (not a second 785 stack). Head `7b86279`. Depends on #1264–#1266 via merge commit `7b86279`. **Not merged.**

- `winsmux worker-artifact --action judge --json --output <path> --exit-code <n>`
- Missing or empty output = `incomplete`, even if PTY capture exists and exit code is 0
- Present output + exit 0 = `complete`; present output + nonzero exit = `failed`
- Dispatchable Team Profile classify JSON names `.winsmux/runs/<id>/result.md` and marks PTY capture as auxiliary
- Inherited from #1264–#1266: classified dispatch forwards `--slot-id`; worker launch consumes the prompt-bundle projection (provider/`launch_model` + bundle pointer) before `Get-AgentLaunchCommand`; missing `manifest.yaml` still receives the structured projection

No additional TASK-785 product rewrite. Unsupported preset-revision rejection (Codex P2) is out of this forest list.

## Surface Classification

- [x] Public product surface
- [x] Runtime contract surface
- [x] Contributor/test surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Responsibility And Cutover

- Replaced behavior: none. Adds an explicit completion judge so PTY capture cannot stand in for a result file.
- Expected outcome: missing artifact is incomplete.
- Source of truth: the dispatch-given output path plus process exit code.
- Old paths: PTY capture remains available as auxiliary evidence only.

## Verification

Linux cloud VM, rustc 1.88.0. **Not merged.**

```
cargo +1.88.0 test --manifest-path core/Cargo.toml --locked --lib worker_artifact
# exit 0; 4 passed

cargo +1.88.0 test --manifest-path core/Cargo.toml --locked --test worker_artifact_contract
# exit 0; 3 passed
```

Skipped Windows gates (Linux cloud VM; do not treat as GREEN):

- Pester
- Installer / fresh-install E2E
- `scripts/git-guard.ps1 -Mode full`
- Desktop UI
- PowerShell 7.6

VERSION is unchanged (0.36.31). Do not tag, GitHub-Release, or npm-publish from this PR. **Not merged.**

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d532fe46-061b-41bd-b99c-63dc5c91498e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d532fe46-061b-41bd-b99c-63dc5c91498e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

