### PR TITLE
feat(app): add 3-step first-run Simple vs Team wizard

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -189,6 +189,8 @@ $whitelistPatterns = @(
     'winsmux-app/src/workerPaneRouting.ts',
     'winsmux-app/src/workerPaneInput.ts',
     'winsmux-app/src/teamProfileSettings.ts',
+    'winsmux-app/src/firstRunOnboarding.ts',
+    'winsmux-app/src/firstRunWizard.ts',
     'winsmux-app/src/workflowGate.ts',
     'winsmux-app/src/styles.css',
     'winsmux-app/src-tauri/Cargo.toml',

--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -40,6 +40,7 @@
     "test:common-contract-package": "node ./scripts/generate-common-contract-bindings.mjs --check && node ./scripts/common-contract-package-check.mjs",
     "test:bakeoff-runner": "node ./scripts/bakeoff-runner-check.mjs",
     "test:worker-start-planning": "node ./scripts/worker-start-planning-check.mjs",
+    "test:first-run-onboarding": "node ./scripts/first-run-onboarding-check.mjs",
     "test:source-graph": "node ./scripts/source-graph-check.mjs",
     "test:windows-context-menu": "pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/windows-context-menu-e2e.ps1",
     "test:viewport-harness": "npm run build && node ./scripts/viewport-harness.mjs",

--- a/winsmux-app/scripts/first-run-onboarding-check.mjs
+++ b/winsmux-app/scripts/first-run-onboarding-check.mjs
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+async function loadFirstRunOnboardingModule() {
+  const sourcePath = path.resolve("src/firstRunOnboarding.ts");
+  const source = await readFile(sourcePath, "utf8");
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: sourcePath,
+  });
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "winsmux-first-run-onboarding-"));
+  const modulePath = path.join(tempDir, "firstRunOnboarding.mjs");
+  await writeFile(modulePath, transpiled.outputText, "utf8");
+
+  try {
+    return await import(pathToFileURL(modulePath).href);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const {
+  FIRST_RUN_LAUNCH_TARGET,
+  ORCHESTRA_MODE_RELATIVE_PATH,
+  ORCHESTRA_MODE_STORAGE_KEY,
+  isAllowedOrchestraModeRelativePath,
+  launchTargetAfterMode,
+  launchTargetsAfterMode,
+  nextWizardStep,
+  parseOrchestraModeJson,
+  serializeOrchestraMode,
+  shouldShowFirstRunWizard,
+  simpleModeMustNotHideExtraPanes,
+  teamModeStartGateContract,
+} = await loadFirstRunOnboardingModule();
+
+function assertNoExtraLaunchTargets(targets) {
+  assert.deepEqual(targets, [FIRST_RUN_LAUNCH_TARGET]);
+  assert.equal(targets.includes("worker-2"), false);
+  assert.equal(targets.includes("worker-3"), false);
+  assert.equal(targets.includes("worker-4"), false);
+  assert.equal(targets.includes("worker-5"), false);
+  assert.equal(targets.includes("worker-6"), false);
+}
+
+// F01: sessionCount 0, no mode → show step 1 select project
+const f01 = nextWizardStep({ sessionCount: 0 });
+assert.equal(shouldShowFirstRunWizard(0), true);
+assert.equal(f01.step, "select-project");
+assert.equal(f01.writeMode, false);
+assert.equal(f01.persistMode, null);
+
+// F02: project chosen, no mode → show step 2; cancel does not write mode
+const f02 = nextWizardStep({ sessionCount: 0, projectChosen: true });
+assert.equal(f02.step, "choose-mode");
+assert.equal(f02.writeMode, false);
+const f02Cancel = nextWizardStep({
+  sessionCount: 0,
+  projectChosen: true,
+  modeStepCancelled: true,
+});
+assert.equal(f02Cancel.step, "choose-mode");
+assert.equal(f02Cancel.writeMode, false);
+assert.equal(f02Cancel.persistMode, null);
+
+// F03: choose simple → persist mode=simple; launch target worker-1; no hide of extra panes
+const f03 = nextWizardStep({ sessionCount: 0, projectChosen: true, selectedMode: "simple" });
+assert.equal(f03.step, "launch");
+assert.equal(f03.writeMode, true);
+assert.equal(f03.persistMode, "simple");
+assertNoExtraLaunchTargets(f03.launchTargets);
+assert.equal(simpleModeMustNotHideExtraPanes(".pane { display: flex; }"), true);
+
+// F04: choose team → persist mode=team; start-gate refuse still represented
+const f04 = nextWizardStep({ sessionCount: 0, projectChosen: true, selectedMode: "team" });
+assert.equal(f04.persistMode, "team");
+assert.equal(f04.writeMode, true);
+assert.equal(f04.mustHonorStartGate, true);
+assert.deepEqual(teamModeStartGateContract(), { mustHonorStartGate: true });
+assertNoExtraLaunchTargets(f04.launchTargets);
+
+// F05: sessionCount ≥ 1 → skip wizard
+assert.equal(shouldShowFirstRunWizard(1), false);
+assert.equal(shouldShowFirstRunWizard(8), false);
+const f05 = nextWizardStep({ sessionCount: 1 });
+assert.equal(f05.step, "skipped");
+assert.equal(f05.writeMode, false);
+
+// F06: cancel picker → remain step 1; no session; no mode write
+const f06 = nextWizardStep({ sessionCount: 0, pickerCancelled: true });
+assert.equal(f06.step, "select-project");
+assert.equal(f06.writeMode, false);
+assert.equal(f06.persistMode, null);
+assert.deepEqual(f06.launchTargets, []);
+
+// F07: extra key / bad mode / wrong schema_version → reject
+assert.throws(() => parseOrchestraModeJson('{"schema_version":1,"mode":"simple","extra":true}'));
+assert.throws(() => parseOrchestraModeJson('{"schema_version":1,"mode":"advanced"}'));
+assert.throws(() => parseOrchestraModeJson('{"schema_version":2,"mode":"simple"}'));
+assert.throws(() => parseOrchestraModeJson("[]"));
+const f07 = nextWizardStep({
+  sessionCount: 0,
+  projectChosen: true,
+  existingModeJson: '{"schema_version":1,"mode":"simple","extra":1}',
+});
+assert.equal(f07.step, "choose-mode");
+assert.equal(f07.modeRejected, true);
+assert.equal(f07.writeMode, false);
+assert.deepEqual(f07.launchTargets, []);
+
+// F08: launch after simple does not include worker-2..6 start targets
+assert.equal(launchTargetAfterMode("simple"), "worker-1");
+assert.equal(launchTargetAfterMode("team"), "worker-1");
+assertNoExtraLaunchTargets(launchTargetsAfterMode("simple"));
+assertNoExtraLaunchTargets(launchTargetsAfterMode("team"));
+assertNoExtraLaunchTargets(f03.launchTargets);
+
+// F09: CSS contract — helper returns false if hide rules target extra worker panes
+assert.equal(simpleModeMustNotHideExtraPanes("#pane-worker-2 { display: none; }"), false);
+assert.equal(simpleModeMustNotHideExtraPanes("#pane-worker-3 { visibility: hidden; }"), false);
+assert.equal(simpleModeMustNotHideExtraPanes("#pane-worker-4 { height: 0; }"), false);
+assert.equal(simpleModeMustNotHideExtraPanes("#pane-worker-5 { position: absolute; left: -9999px; }"), false);
+assert.equal(simpleModeMustNotHideExtraPanes("#pane-worker-6 { transform: translateX(-100vw); }"), false);
+assert.equal(simpleModeMustNotHideExtraPanes('#pane-worker-2 { aria-hidden: true; }'), false);
+assert.equal(simpleModeMustNotHideExtraPanes("#pane-worker-1 { display: none; }"), true);
+assert.equal(simpleModeMustNotHideExtraPanes(".pane { display: none; }"), true);
+
+const stylesCss = await readFile(path.resolve("src/styles.css"), "utf8");
+assert.equal(simpleModeMustNotHideExtraPanes(stylesCss), true);
+
+// F10: serializer round-trip only simple|team
+assert.equal(serializeOrchestraMode("simple"), '{"schema_version":1,"mode":"simple"}');
+assert.equal(serializeOrchestraMode("team"), '{"schema_version":1,"mode":"team"}');
+for (const mode of ["simple", "team"]) {
+  const json = serializeOrchestraMode(mode);
+  const parsed = parseOrchestraModeJson(json);
+  assert.deepEqual(Object.keys(parsed).sort(), ["mode", "schema_version"]);
+  assert.deepEqual(parsed, { schema_version: 1, mode });
+}
+assert.throws(() => serializeOrchestraMode("advanced"));
+assert.equal(ORCHESTRA_MODE_STORAGE_KEY, "winsmux.orchestra-mode.v1");
+assert.equal(ORCHESTRA_MODE_RELATIVE_PATH, ".winsmux/orchestra-mode.json");
+assert.equal(isAllowedOrchestraModeRelativePath(".winsmux/orchestra-mode.json"), true);
+assert.equal(isAllowedOrchestraModeRelativePath("../orchestra-mode.json"), false);
+assert.equal(isAllowedOrchestraModeRelativePath("/tmp/orchestra-mode.json"), false);
+assert.equal(isAllowedOrchestraModeRelativePath(".winsmux/../secrets.json"), false);
+
+const mainSource = await readFile(path.resolve("src/main.ts"), "utf8");
+assert.match(mainSource, /from "\.\/firstRunOnboarding"/);
+assert.match(mainSource, /shouldShowFirstRunWizard/);
+assert.match(mainSource, /ORCHESTRA_MODE_STORAGE_KEY/);
+assert.match(mainSource, /first_launch_mode_selection/);
+assert.match(mainSource, /async function launchFirstRunManagedWorker/);
+assert.match(mainSource, /writeDesktopOrchestraMode/);
+assert.match(mainSource, /maybeStartFirstRunOnboarding/);
+assert.equal(simpleModeMustNotHideExtraPanes(mainSource), true);
+
+const launchFn = mainSource.match(/async function launchFirstRunManagedWorker[\s\S]*?\n\}/);
+assert.ok(launchFn, "launchFirstRunManagedWorker must exist");
+assert.equal(/worker-[2-6]/.test(launchFn[0]), false, "first-run launch must not start worker-2..6");
+assert.match(launchFn[0], /launchTargetsAfterMode|launchTargetAfterMode|worker-1/);
+
+const desktopClient = await readFile(path.resolve("src/desktopClient.ts"), "utf8");
+assert.match(desktopClient, /desktop_write_orchestra_mode/);
+
+const libSource = await readFile(path.resolve("src-tauri/src/lib.rs"), "utf8");
+assert.match(libSource, /fn desktop_write_orchestra_mode/);
+assert.match(libSource, /fn write_orchestra_mode_file/);
+
+console.log("first-run-onboarding-check: ok");

--- a/winsmux-app/scripts/first-run-onboarding-check.mjs
+++ b/winsmux-app/scripts/first-run-onboarding-check.mjs
@@ -32,6 +32,7 @@ const {
   ORCHESTRA_MODE_RELATIVE_PATH,
   ORCHESTRA_MODE_STORAGE_KEY,
   isAllowedOrchestraModeRelativePath,
+  isMissingOrchestraModeFileError,
   launchTargetAfterMode,
   launchTargetsAfterMode,
   nextWizardStep,
@@ -115,6 +116,26 @@ assert.equal(f07.step, "choose-mode");
 assert.equal(f07.modeRejected, true);
 assert.equal(f07.writeMode, false);
 assert.deepEqual(f07.launchTargets, []);
+const f07Unreadable = nextWizardStep({
+  sessionCount: 0,
+  projectChosen: true,
+  existingModeReadFailed: true,
+});
+assert.equal(f07Unreadable.step, "choose-mode");
+assert.equal(f07Unreadable.modeRejected, true);
+assert.equal(f07Unreadable.writeMode, false);
+assert.equal(
+  isMissingOrchestraModeFileError("desktop_file_read_full(.winsmux/orchestra-mode.json) failed: Failed to read full file: The system cannot find the file specified. (os error 2)"),
+  true,
+);
+assert.equal(
+  isMissingOrchestraModeFileError("desktop_file_read_full(.winsmux/orchestra-mode.json) failed: desktop.file.read_full rejected a file larger than 1048576 bytes"),
+  false,
+);
+assert.equal(
+  isMissingOrchestraModeFileError("desktop_file_read_full(.winsmux/orchestra-mode.json) failed: Failed to decode full file as UTF-8: invalid utf-8"),
+  false,
+);
 
 // F08: launch after simple does not include worker-2..6 start targets
 assert.equal(launchTargetAfterMode("simple"), "worker-1");
@@ -192,6 +213,13 @@ const applyLaunchAt = mainSource.indexOf("await applyInitialProjectDirFromLaunch
 const maybeStartAt = mainSource.indexOf("await maybeStartFirstRunOnboarding(firstRunSessionCountAtBoot)");
 assert.ok(bootSnapshotAt >= 0 && applyLaunchAt > bootSnapshotAt && maybeStartAt > applyLaunchAt);
 assert.match(wizardSource, /shouldShowFirstRunWizard\(sessionCountAtBoot\)/);
+assert.match(wizardSource, /existingModeReadFailed/);
+assert.match(wizardSource, /isMissingOrchestraModeFileError/);
+assert.match(wizardSource, /status: "unreadable"/);
+assert.doesNotMatch(
+  wizardSource,
+  /getDesktopFullFile[\s\S]{0,240}catch \{[\s\S]{0,40}return null;/,
+);
 assert.equal(
   /projectSessionEntries\.length/.test(wizardSource),
   false,

--- a/winsmux-app/scripts/first-run-onboarding-check.mjs
+++ b/winsmux-app/scripts/first-run-onboarding-check.mjs
@@ -154,19 +154,50 @@ assert.equal(isAllowedOrchestraModeRelativePath("/tmp/orchestra-mode.json"), fal
 assert.equal(isAllowedOrchestraModeRelativePath(".winsmux/../secrets.json"), false);
 
 const mainSource = await readFile(path.resolve("src/main.ts"), "utf8");
-assert.match(mainSource, /from "\.\/firstRunOnboarding"/);
-assert.match(mainSource, /shouldShowFirstRunWizard/);
-assert.match(mainSource, /ORCHESTRA_MODE_STORAGE_KEY/);
-assert.match(mainSource, /first_launch_mode_selection/);
-assert.match(mainSource, /async function launchFirstRunManagedWorker/);
-assert.match(mainSource, /writeDesktopOrchestraMode/);
+const wizardSource = await readFile(path.resolve("src/firstRunWizard.ts"), "utf8");
+assert.match(mainSource, /from "\.\/firstRunWizard"/);
 assert.match(mainSource, /maybeStartFirstRunOnboarding/);
+assert.match(wizardSource, /from "\.\/firstRunOnboarding"/);
+assert.match(wizardSource, /shouldShowFirstRunWizard/);
+assert.match(wizardSource, /ORCHESTRA_MODE_STORAGE_KEY/);
+assert.match(wizardSource, /first_launch_mode_selection/);
+assert.match(wizardSource, /async function launchFirstRunManagedWorker/);
+assert.match(wizardSource, /writeDesktopOrchestraMode/);
 assert.equal(simpleModeMustNotHideExtraPanes(mainSource), true);
+assert.equal(simpleModeMustNotHideExtraPanes(wizardSource), true);
 
-const launchFn = mainSource.match(/async function launchFirstRunManagedWorker[\s\S]*?\n\}/);
+const launchFn = wizardSource.match(/async function launchFirstRunManagedWorker[\s\S]*?\n\}/);
 assert.ok(launchFn, "launchFirstRunManagedWorker must exist");
 assert.equal(/worker-[2-6]/.test(launchFn[0]), false, "first-run launch must not start worker-2..6");
 assert.match(launchFn[0], /launchTargetsAfterMode|launchTargetAfterMode|worker-1/);
+
+// F11: empty-store first run with --project-dir must use the boot session count,
+// not the post-launch-arg session list, and start at choose-mode when a project is already set.
+const f11 = nextWizardStep({ sessionCount: 0, projectChosen: true });
+assert.equal(shouldShowFirstRunWizard(0), true);
+assert.equal(f11.step, "choose-mode");
+assert.equal(f11.writeMode, false);
+const f11Existing = nextWizardStep({
+  sessionCount: 0,
+  projectChosen: true,
+  existingModeJson: '{"schema_version":1,"mode":"simple"}',
+});
+assert.equal(f11Existing.step, "launch");
+assert.equal(f11Existing.writeMode, false);
+assert.match(mainSource, /firstRunSessionCountAtBoot = projectSessionEntries\.length/);
+assert.match(mainSource, /await applyInitialProjectDirFromLaunchArgs\(\);/);
+assert.match(mainSource, /maybeStartFirstRunOnboarding\(firstRunSessionCountAtBoot\)/);
+const bootSnapshotAt = mainSource.indexOf("const firstRunSessionCountAtBoot = projectSessionEntries.length");
+const applyLaunchAt = mainSource.indexOf("await applyInitialProjectDirFromLaunchArgs()");
+const maybeStartAt = mainSource.indexOf("await maybeStartFirstRunOnboarding(firstRunSessionCountAtBoot)");
+assert.ok(bootSnapshotAt >= 0 && applyLaunchAt > bootSnapshotAt && maybeStartAt > applyLaunchAt);
+assert.match(wizardSource, /shouldShowFirstRunWizard\(sessionCountAtBoot\)/);
+assert.equal(
+  /projectSessionEntries\.length/.test(wizardSource),
+  false,
+  "wizard skip-check must not reread projectSessionEntries.length after launch-arg apply",
+);
+assert.doesNotMatch(mainSource, /shouldShowFirstRunWizard\(projectSessionEntries\.length\)/);
 
 const desktopClient = await readFile(path.resolve("src/desktopClient.ts"), "utf8");
 assert.match(desktopClient, /desktop_write_orchestra_mode/);
@@ -174,5 +205,8 @@ assert.match(desktopClient, /desktop_write_orchestra_mode/);
 const libSource = await readFile(path.resolve("src-tauri/src/lib.rs"), "utf8");
 assert.match(libSource, /fn desktop_write_orchestra_mode/);
 assert.match(libSource, /fn write_orchestra_mode_file/);
+assert.match(libSource, /fn orchestra_mode_target_is_symlink/);
+assert.match(libSource, /symlink_metadata/);
+assert.match(libSource, /refused a symlink/);
 
 console.log("first-run-onboarding-check: ok");

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -218,9 +218,25 @@ fn write_orchestra_mode_file(
             );
         }
     }
+    if orchestra_mode_target_is_symlink(&target)? {
+        return Err(
+            "desktop_write_orchestra_mode refused a symlink at .winsmux/orchestra-mode.json"
+                .to_string(),
+        );
+    }
     std::fs::write(&target, contents)
         .map_err(|err| format!("desktop_write_orchestra_mode failed to write file: {err}"))?;
     Ok(target)
+}
+
+fn orchestra_mode_target_is_symlink(path: &Path) -> Result<bool, String> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(metadata.file_type().is_symlink()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(format!(
+            "desktop_write_orchestra_mode failed to inspect .winsmux/orchestra-mode.json: {err}"
+        )),
+    }
 }
 
 #[tauri::command]
@@ -2490,6 +2506,58 @@ mod tests {
         .expect("valid orchestra-mode.json should write");
         let body = std::fs::read_to_string(&written).expect("written orchestra-mode.json should read");
         assert_eq!(body, valid);
+        let _ = std::fs::remove_dir_all(project_dir);
+    }
+
+    fn try_create_file_symlink(original: &Path, link: &Path) -> bool {
+        #[cfg(windows)]
+        {
+            std::os::windows::fs::symlink_file(original, link).is_ok()
+        }
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(original, link).is_ok()
+        }
+        #[cfg(not(any(windows, unix)))]
+        {
+            let _ = (original, link);
+            false
+        }
+    }
+
+    #[test]
+    fn orchestra_mode_write_refuses_symlink_target() {
+        let project_dir = make_temp_launch_project("orchestra-mode-symlink");
+        let project = project_dir.to_string_lossy().to_string();
+        let outside = project_dir.join("outside.txt");
+        std::fs::write(&outside, "keep-me").expect("outside target should write");
+        let winsmux_dir = project_dir.join(".winsmux");
+        std::fs::create_dir_all(&winsmux_dir).expect(".winsmux should exist");
+        let link = winsmux_dir.join("orchestra-mode.json");
+        if !try_create_file_symlink(&outside, &link) {
+            assert!(
+                !orchestra_mode_target_is_symlink(&link).expect("missing path is not a symlink")
+            );
+            let _ = std::fs::remove_dir_all(project_dir);
+            return;
+        }
+        assert!(
+            orchestra_mode_target_is_symlink(&link).expect("created path should be a symlink")
+        );
+        let err = write_orchestra_mode_file(
+            &project,
+            ".winsmux/orchestra-mode.json",
+            r#"{"schema_version":1,"mode":"simple"}"#,
+        )
+        .expect_err("symlink orchestra-mode.json must be refused");
+        assert!(
+            err.contains("refused a symlink"),
+            "unexpected refuse error: {err}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&outside).expect("outside target should remain"),
+            "keep-me"
+        );
         let _ = std::fs::remove_dir_all(project_dir);
     }
 

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender};
@@ -122,6 +122,118 @@ where
 #[tauri::command]
 fn desktop_initial_project_dir() -> Option<String> {
     resolve_initial_project_dir_from_args(std::env::args())
+}
+
+const ORCHESTRA_MODE_RELATIVE_PATH: &str = ".winsmux/orchestra-mode.json";
+
+#[derive(Debug, Serialize)]
+struct OrchestraModeWriteResult {
+    ok: bool,
+    relative_path: String,
+}
+
+fn is_allowed_orchestra_mode_relative_path(relative_path: &str) -> bool {
+    let normalized = relative_path.replace('\\', "/");
+    if normalized.contains("..") {
+        return false;
+    }
+    let path = Path::new(relative_path);
+    if path.is_absolute() {
+        return false;
+    }
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => {}
+            _ => return false,
+        }
+    }
+    normalized == ORCHESTRA_MODE_RELATIVE_PATH
+}
+
+fn parse_orchestra_mode_json(contents: &str) -> Result<(), String> {
+    let value: serde_json::Value = serde_json::from_str(contents)
+        .map_err(|err| format!("Invalid orchestra-mode JSON: {err}"))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| "orchestra-mode JSON must be an object".to_string())?;
+    if object.len() != 2 || !object.contains_key("schema_version") || !object.contains_key("mode") {
+        return Err("orchestra-mode JSON must contain only schema_version and mode".to_string());
+    }
+    match object.get("schema_version") {
+        Some(serde_json::Value::Number(number)) if number.as_u64() == Some(1) => {}
+        _ => return Err("orchestra-mode JSON schema_version must be 1".to_string()),
+    }
+    match object.get("mode").and_then(|value| value.as_str()) {
+        Some("simple") | Some("team") => Ok(()),
+        _ => Err("orchestra-mode JSON mode must be simple or team".to_string()),
+    }
+}
+
+fn resolve_orchestra_mode_write_path(
+    project_dir: &str,
+    relative_path: &str,
+) -> Result<(PathBuf, PathBuf), String> {
+    if !is_allowed_orchestra_mode_relative_path(relative_path) {
+        return Err(
+            "desktop_write_orchestra_mode only writes .winsmux/orchestra-mode.json".to_string(),
+        );
+    }
+    if project_dir.trim().is_empty() {
+        return Err("desktop_write_orchestra_mode requires a project directory".to_string());
+    }
+    let project = PathBuf::from(project_dir.trim());
+    if !project.is_dir() {
+        return Err("desktop_write_orchestra_mode project directory does not exist".to_string());
+    }
+    let canonical_project = project.canonicalize().map_err(|err| {
+        format!("desktop_write_orchestra_mode failed to resolve project directory: {err}")
+    })?;
+    let target = canonical_project.join(relative_path);
+    if !target.starts_with(&canonical_project) {
+        return Err(
+            "desktop_write_orchestra_mode rejected a path outside the project directory".to_string(),
+        );
+    }
+    Ok((canonical_project, target))
+}
+
+fn write_orchestra_mode_file(
+    project_dir: &str,
+    relative_path: &str,
+    contents: &str,
+) -> Result<PathBuf, String> {
+    parse_orchestra_mode_json(contents)?;
+    let (canonical_project, target) = resolve_orchestra_mode_write_path(project_dir, relative_path)?;
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent).map_err(|err| {
+            format!("desktop_write_orchestra_mode failed to create .winsmux: {err}")
+        })?;
+        let canonical_parent = parent.canonicalize().map_err(|err| {
+            format!("desktop_write_orchestra_mode failed to resolve .winsmux: {err}")
+        })?;
+        if !canonical_parent.starts_with(&canonical_project) {
+            return Err(
+                "desktop_write_orchestra_mode rejected a path outside the project directory"
+                    .to_string(),
+            );
+        }
+    }
+    std::fs::write(&target, contents)
+        .map_err(|err| format!("desktop_write_orchestra_mode failed to write file: {err}"))?;
+    Ok(target)
+}
+
+#[tauri::command]
+fn desktop_write_orchestra_mode(
+    project_dir: String,
+    relative_path: String,
+    contents: String,
+) -> Result<OrchestraModeWriteResult, String> {
+    write_orchestra_mode_file(&project_dir, &relative_path, &contents)?;
+    Ok(OrchestraModeWriteResult {
+        ok: true,
+        relative_path: ORCHESTRA_MODE_RELATIVE_PATH.to_string(),
+    })
 }
 
 #[tauri::command]
@@ -1883,6 +1995,7 @@ pub fn run() {
             desktop_voice_capture_start,
             desktop_voice_capture_stop,
             desktop_initial_project_dir,
+            desktop_write_orchestra_mode,
             desktop_control_pipe_enabled,
             desktop_update_check,
             desktop_update_download_installer,
@@ -2342,6 +2455,42 @@ mod tests {
             .browser_fallback
             .reason
             .contains("does not transcribe audio into text"));
+    }
+
+    #[test]
+    fn orchestra_mode_write_accepts_simple_and_rejects_invalid_payloads() {
+        let project_dir = make_temp_launch_project("orchestra-mode");
+        let project = project_dir.to_string_lossy().to_string();
+        let valid = r#"{"schema_version":1,"mode":"simple"}"#;
+        assert!(write_orchestra_mode_file(&project, "../orchestra-mode.json", valid).is_err());
+        assert!(write_orchestra_mode_file(&project, "/tmp/orchestra-mode.json", valid).is_err());
+        assert!(write_orchestra_mode_file(
+            &project,
+            ".winsmux/orchestra-mode.json",
+            r#"{"schema_version":1,"mode":"simple","extra":true}"#
+        )
+        .is_err());
+        assert!(write_orchestra_mode_file(
+            &project,
+            ".winsmux/orchestra-mode.json",
+            r#"{"schema_version":2,"mode":"simple"}"#
+        )
+        .is_err());
+        assert!(write_orchestra_mode_file(
+            &project,
+            ".winsmux/orchestra-mode.json",
+            r#"{"schema_version":1,"mode":"advanced"}"#
+        )
+        .is_err());
+        let written = write_orchestra_mode_file(
+            &project,
+            ".winsmux/orchestra-mode.json",
+            valid,
+        )
+        .expect("valid orchestra-mode.json should write");
+        let body = std::fs::read_to_string(&written).expect("written orchestra-mode.json should read");
+        assert_eq!(body, valid);
+        let _ = std::fs::remove_dir_all(project_dir);
     }
 
     #[test]

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -957,6 +957,25 @@ export async function getDesktopInitialProjectDir() {
   return await invoke<string | null>("desktop_initial_project_dir");
 }
 
+export async function writeDesktopOrchestraMode(
+  projectDir: string,
+  relativePath: string,
+  contents: string,
+) {
+  if (!isTauri()) {
+    throw new Error("desktop_write_orchestra_mode is unavailable outside the Tauri runtime");
+  }
+  try {
+    return await invoke<{ ok: boolean; relative_path: string }>("desktop_write_orchestra_mode", {
+      projectDir,
+      relativePath,
+      contents,
+    });
+  } catch (error) {
+    throw normalizeDesktopError("desktop_write_orchestra_mode", error);
+  }
+}
+
 function buildProjectDirPayload(projectDir?: string | null) {
   const normalized = projectDir?.trim();
   return normalized ? { projectDir: normalized } : {};

--- a/winsmux-app/src/firstRunOnboarding.ts
+++ b/winsmux-app/src/firstRunOnboarding.ts
@@ -1,0 +1,191 @@
+export const ORCHESTRA_MODE_STORAGE_KEY = "winsmux.orchestra-mode.v1";
+export const ORCHESTRA_MODE_RELATIVE_PATH = ".winsmux/orchestra-mode.json";
+export const FIRST_RUN_LAUNCH_TARGET = "worker-1";
+
+export type OrchestraMode = "simple" | "team";
+export type WizardStepId = "select-project" | "choose-mode" | "launch" | "skipped";
+
+export interface OrchestraModeDocument {
+  schema_version: 1;
+  mode: OrchestraMode;
+}
+
+export interface WizardDecision {
+  step: WizardStepId;
+  persistMode: OrchestraMode | null;
+  writeMode: boolean;
+  launchTargets: string[];
+  mustHonorStartGate: boolean;
+  modeRejected: boolean;
+}
+
+export interface WizardState {
+  sessionCount: number;
+  projectChosen?: boolean;
+  pickerCancelled?: boolean;
+  selectedMode?: OrchestraMode | null;
+  modeStepCancelled?: boolean;
+  existingModeJson?: string | null;
+}
+
+const EXTRA_WORKER_PANE_IDS = ["worker-2", "worker-3", "worker-4", "worker-5", "worker-6"] as const;
+
+const HIDE_DECLARATION =
+  /(?:display\s*:\s*none|visibility\s*:\s*hidden|\bhidden\b\s*:|height\s*:\s*0(?:px|%|rem|em)?\b|width\s*:\s*0(?:px|%|rem|em)?\b|max-height\s*:\s*0|max-width\s*:\s*0|opacity\s*:\s*0(?:\.0+)?\b|clip(?:-path)?\s*:|transform\s*:[^;]*(?:translate|translateX|translateY|translate3d)\s*\(\s*-?\d{3,}|left\s*:\s*-?\d{3,}px|right\s*:\s*-?\d{3,}px|top\s*:\s*-?\d{3,}px|bottom\s*:\s*-?\d{3,}px|aria-hidden\s*:\s*true)/i;
+
+export function shouldShowFirstRunWizard(sessionCount: number): boolean {
+  return !(sessionCount >= 1);
+}
+
+export function teamModeStartGateContract(): { mustHonorStartGate: true } {
+  return { mustHonorStartGate: true };
+}
+
+export function launchTargetAfterMode(mode: OrchestraMode): typeof FIRST_RUN_LAUNCH_TARGET {
+  if (mode !== "simple" && mode !== "team") {
+    throw new Error("first-run launch target is only defined for simple or team");
+  }
+  return FIRST_RUN_LAUNCH_TARGET;
+}
+
+export function launchTargetsAfterMode(mode: OrchestraMode): readonly string[] {
+  return [launchTargetAfterMode(mode)];
+}
+
+export function serializeOrchestraMode(mode: OrchestraMode): string {
+  if (mode !== "simple" && mode !== "team") {
+    throw new Error("orchestra-mode.json mode must be simple or team");
+  }
+  return JSON.stringify({ schema_version: 1, mode });
+}
+
+export function parseOrchestraModeJson(text: string): OrchestraModeDocument {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("orchestra-mode.json is not valid JSON");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("orchestra-mode.json must be an object");
+  }
+  const record = parsed as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (keys.length !== 2 || !keys.includes("schema_version") || !keys.includes("mode")) {
+    throw new Error("orchestra-mode.json must contain only schema_version and mode");
+  }
+  if (record.schema_version !== 1) {
+    throw new Error("orchestra-mode.json schema_version must be 1");
+  }
+  if (record.mode !== "simple" && record.mode !== "team") {
+    throw new Error("orchestra-mode.json mode must be simple or team");
+  }
+  return { schema_version: 1, mode: record.mode };
+}
+
+export function isAllowedOrchestraModeRelativePath(relativePath: string): boolean {
+  const normalized = relativePath.replace(/\\/g, "/").trim();
+  if (normalized.includes("..") || normalized.startsWith("/") || /^[A-Za-z]:/.test(normalized)) {
+    return false;
+  }
+  return normalized === ORCHESTRA_MODE_RELATIVE_PATH;
+}
+
+function emptyDecision(step: WizardStepId, extras?: Partial<WizardDecision>): WizardDecision {
+  return {
+    step,
+    persistMode: null,
+    writeMode: false,
+    launchTargets: [],
+    mustHonorStartGate: false,
+    modeRejected: false,
+    ...extras,
+  };
+}
+
+function launchDecision(mode: OrchestraMode, writeMode: boolean): WizardDecision {
+  return {
+    step: "launch",
+    persistMode: mode,
+    writeMode,
+    launchTargets: [...launchTargetsAfterMode(mode)],
+    mustHonorStartGate: mode === "team" ? teamModeStartGateContract().mustHonorStartGate : false,
+    modeRejected: false,
+  };
+}
+
+export function nextWizardStep(state: WizardState): WizardDecision {
+  const projectChosen = Boolean(state.projectChosen);
+  if (!projectChosen && !shouldShowFirstRunWizard(state.sessionCount)) {
+    return emptyDecision("skipped");
+  }
+
+  if (state.pickerCancelled || !projectChosen) {
+    return emptyDecision("select-project");
+  }
+
+  let existingMode: OrchestraMode | null = null;
+  let modeRejected = false;
+  if (typeof state.existingModeJson === "string") {
+    try {
+      existingMode = parseOrchestraModeJson(state.existingModeJson).mode;
+    } catch {
+      modeRejected = true;
+    }
+  }
+
+  if (modeRejected) {
+    return emptyDecision("choose-mode", {
+      mustHonorStartGate: teamModeStartGateContract().mustHonorStartGate,
+      modeRejected: true,
+    });
+  }
+
+  if (state.modeStepCancelled) {
+    return emptyDecision("choose-mode", {
+      mustHonorStartGate: teamModeStartGateContract().mustHonorStartGate,
+    });
+  }
+
+  if (state.selectedMode === "simple" || state.selectedMode === "team") {
+    return launchDecision(state.selectedMode, true);
+  }
+
+  if (existingMode) {
+    return launchDecision(existingMode, false);
+  }
+
+  return emptyDecision("choose-mode", {
+    mustHonorStartGate: teamModeStartGateContract().mustHonorStartGate,
+  });
+}
+
+function selectorTargetsExtraWorkerPane(selector: string): boolean {
+  return EXTRA_WORKER_PANE_IDS.some((id) => {
+    const patterns = [
+      new RegExp(`#pane-${id}\\b`, "i"),
+      new RegExp(`#${id}\\b`, "i"),
+      new RegExp(`\\[id\\s*=\\s*['"]pane-${id}['"]\\]`, "i"),
+      new RegExp(`\\[data-(?:pane|worker)(?:-id)?\\s*=\\s*['"]${id}['"]\\]`, "i"),
+      new RegExp(`\\.pane-${id}\\b`, "i"),
+    ];
+    return patterns.some((pattern) => pattern.test(selector));
+  });
+}
+
+export function simpleModeMustNotHideExtraPanes(cssText: string): boolean {
+  const withoutComments = cssText.replace(/\/\*[\s\S]*?\*\//g, "");
+  const rules = withoutComments.split("}");
+  for (const rule of rules) {
+    const parts = rule.split("{");
+    if (parts.length < 2) {
+      continue;
+    }
+    const selector = parts[0];
+    const body = parts.slice(1).join("{");
+    if (selectorTargetsExtraWorkerPane(selector) && HIDE_DECLARATION.test(body)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/winsmux-app/src/firstRunOnboarding.ts
+++ b/winsmux-app/src/firstRunOnboarding.ts
@@ -26,6 +26,7 @@ export interface WizardState {
   selectedMode?: OrchestraMode | null;
   modeStepCancelled?: boolean;
   existingModeJson?: string | null;
+  existingModeReadFailed?: boolean;
 }
 
 const EXTRA_WORKER_PANE_IDS = ["worker-2", "worker-3", "worker-4", "worker-5", "worker-6"] as const;
@@ -35,6 +36,15 @@ const HIDE_DECLARATION =
 
 export function shouldShowFirstRunWizard(sessionCount: number): boolean {
   return !(sessionCount >= 1);
+}
+
+export function isMissingOrchestraModeFileError(message: string): boolean {
+  return (
+    /cannot find the file specified/i.test(message)
+    || /cannot find the path specified/i.test(message)
+    || /No such file or directory/i.test(message)
+    || /\(os error 2\)/i.test(message)
+  );
 }
 
 export function teamModeStartGateContract(): { mustHonorStartGate: true } {
@@ -122,6 +132,13 @@ export function nextWizardStep(state: WizardState): WizardDecision {
 
   if (state.pickerCancelled || !projectChosen) {
     return emptyDecision("select-project");
+  }
+
+  if (state.existingModeReadFailed) {
+    return emptyDecision("choose-mode", {
+      mustHonorStartGate: teamModeStartGateContract().mustHonorStartGate,
+      modeRejected: true,
+    });
   }
 
   let existingMode: OrchestraMode | null = null;

--- a/winsmux-app/src/firstRunWizard.ts
+++ b/winsmux-app/src/firstRunWizard.ts
@@ -1,0 +1,370 @@
+import { isTauri } from "@tauri-apps/api/core";
+import { getDesktopFullFile, writeDesktopOrchestraMode } from "./desktopClient";
+import {
+  ORCHESTRA_MODE_RELATIVE_PATH,
+  ORCHESTRA_MODE_STORAGE_KEY,
+  launchTargetsAfterMode,
+  nextWizardStep,
+  serializeOrchestraMode,
+  shouldShowFirstRunWizard,
+  type OrchestraMode,
+  type WizardStepId,
+} from "./firstRunOnboarding";
+import {
+  shouldRefuseTeamProfileStart,
+  type TeamProfileSettingsView,
+} from "./teamProfileSettings";
+
+export interface FirstRunWizardBindings {
+  getLanguageText(en: string, ja: string): string;
+  getActiveProjectDir(): string | null;
+  promptAndAddProjectSession(): Promise<boolean>;
+  recordDogfoodInput(taskRef: string, taskClass: string, payload: unknown): void;
+  focusWorkerPane(target: string): void;
+  loadTeamProfileSettings(): Promise<void>;
+  getTeamProfileSettingsView(): TeamProfileSettingsView | null;
+  appendRuntimeNotice(title: string, body: string): void;
+  startFocusedWorker(): Promise<void>;
+}
+
+let bindings: FirstRunWizardBindings | null = null;
+let firstRunWizardOpen = false;
+let firstRunWizardStep: WizardStepId = "select-project";
+let firstRunWizardError = "";
+let firstRunSelectedMode: OrchestraMode | null = null;
+
+export function bindFirstRunWizard(next: FirstRunWizardBindings) {
+  bindings = next;
+}
+
+function host(): FirstRunWizardBindings {
+  if (!bindings) {
+    throw new Error("first-run wizard bindings are not installed");
+  }
+  return bindings;
+}
+
+function createTextElement<K extends keyof HTMLElementTagNameMap>(
+  tagName: K,
+  className: string,
+  text: string | number | null | undefined,
+) {
+  const element = document.createElement(tagName);
+  if (className) {
+    element.className = className;
+  }
+  element.textContent = text === null || text === undefined ? "" : String(text);
+  return element;
+}
+
+export async function maybeStartFirstRunOnboarding(sessionCountAtBoot: number) {
+  if (!shouldShowFirstRunWizard(sessionCountAtBoot)) {
+    return;
+  }
+  firstRunWizardOpen = true;
+  firstRunWizardError = "";
+  firstRunSelectedMode = null;
+  const projectDir = host().getActiveProjectDir();
+  if (projectDir) {
+    const existing = await readExistingOrchestraModeJson(projectDir);
+    const decision = nextWizardStep({
+      sessionCount: sessionCountAtBoot,
+      projectChosen: true,
+      existingModeJson: existing,
+    });
+    firstRunWizardStep = decision.step;
+    firstRunSelectedMode = decision.persistMode;
+    firstRunWizardError = decision.modeRejected
+      ? host().getLanguageText(
+        "The existing orchestra mode file is invalid. Choose Simple or Team again.",
+        "既存のオーケストラモードファイルが無効です。Simple または Team を選び直してください。",
+      )
+      : "";
+  } else {
+    firstRunWizardStep = "select-project";
+  }
+  renderFirstRunWizard();
+}
+
+export function closeFirstRunWizard() {
+  firstRunWizardOpen = false;
+  firstRunWizardError = "";
+  const overlay = document.getElementById("first-run-wizard");
+  if (!overlay) {
+    return;
+  }
+  overlay.classList.remove("open");
+  overlay.hidden = true;
+  overlay.replaceChildren();
+}
+
+function ensureFirstRunWizard() {
+  let overlay = document.getElementById("first-run-wizard");
+  if (overlay) {
+    return overlay;
+  }
+  overlay = document.createElement("div");
+  overlay.id = "first-run-wizard";
+  overlay.className = "first-run-wizard";
+  overlay.setAttribute("role", "presentation");
+  document.body.appendChild(overlay);
+  return overlay;
+}
+
+async function readExistingOrchestraModeJson(projectDir: string | null) {
+  if (!projectDir) {
+    return null;
+  }
+  if (!isTauri()) {
+    try {
+      return window.localStorage.getItem(ORCHESTRA_MODE_STORAGE_KEY);
+    } catch {
+      return null;
+    }
+  }
+  try {
+    const file = await getDesktopFullFile(ORCHESTRA_MODE_RELATIVE_PATH, undefined, projectDir);
+    return file.content;
+  } catch {
+    return null;
+  }
+}
+
+async function persistFirstRunOrchestraMode(mode: OrchestraMode) {
+  const projectDir = host().getActiveProjectDir();
+  if (!projectDir) {
+    throw new Error(host().getLanguageText("Select a project folder first.", "先にプロジェクトフォルダを選択してください。"));
+  }
+  const json = serializeOrchestraMode(mode);
+  try {
+    window.localStorage.setItem(ORCHESTRA_MODE_STORAGE_KEY, json);
+  } catch (error) {
+    console.warn("Failed to persist orchestra mode locally", error);
+  }
+  if (!isTauri()) {
+    return;
+  }
+  try {
+    await writeDesktopOrchestraMode(projectDir, ORCHESTRA_MODE_RELATIVE_PATH, json);
+  } catch (error) {
+    try {
+      window.localStorage.removeItem(ORCHESTRA_MODE_STORAGE_KEY);
+    } catch {
+      // Keep fail-closed: do not leave a local mode after a rejected project write.
+    }
+    throw error;
+  }
+}
+
+async function handleFirstRunSelectProject() {
+  const selected = await host().promptAndAddProjectSession();
+  if (!selected) {
+    firstRunWizardStep = nextWizardStep({
+      sessionCount: 0,
+      pickerCancelled: true,
+    }).step;
+    renderFirstRunWizard();
+    return;
+  }
+  const existing = await readExistingOrchestraModeJson(host().getActiveProjectDir());
+  const decision = nextWizardStep({
+    sessionCount: 0,
+    projectChosen: true,
+    existingModeJson: existing,
+  });
+  firstRunWizardStep = decision.step;
+  firstRunSelectedMode = decision.persistMode;
+  firstRunWizardError = decision.modeRejected
+    ? host().getLanguageText(
+      "The existing orchestra mode file is invalid. Choose Simple or Team again.",
+      "既存のオーケストラモードファイルが無効です。Simple または Team を選び直してください。",
+    )
+    : "";
+  renderFirstRunWizard();
+}
+
+async function handleFirstRunChooseMode(mode: OrchestraMode) {
+  const decision = nextWizardStep({
+    sessionCount: 0,
+    projectChosen: true,
+    selectedMode: mode,
+  });
+  if (decision.writeMode && decision.persistMode) {
+    try {
+      await persistFirstRunOrchestraMode(decision.persistMode);
+    } catch (error) {
+      firstRunWizardError = error instanceof Error ? error.message : String(error);
+      firstRunWizardStep = "choose-mode";
+      renderFirstRunWizard();
+      return;
+    }
+  }
+  firstRunSelectedMode = decision.persistMode;
+  firstRunWizardStep = decision.step;
+  firstRunWizardError = "";
+  host().recordDogfoodInput("desktop-first-run-mode", "first_launch_mode_selection", {
+    selected: true,
+    mode: decision.persistMode,
+  });
+  renderFirstRunWizard();
+}
+
+function handleFirstRunModeCancel() {
+  const decision = nextWizardStep({
+    sessionCount: 0,
+    projectChosen: true,
+    modeStepCancelled: true,
+  });
+  firstRunSelectedMode = null;
+  firstRunWizardStep = decision.step;
+  renderFirstRunWizard();
+}
+
+async function handleFirstRunLaunch() {
+  const mode = firstRunSelectedMode;
+  if (!mode) {
+    firstRunWizardStep = "choose-mode";
+    renderFirstRunWizard();
+    return;
+  }
+  closeFirstRunWizard();
+  await launchFirstRunManagedWorker(mode);
+}
+
+async function launchFirstRunManagedWorker(mode: OrchestraMode) {
+  const runtime = host();
+  const targets = launchTargetsAfterMode(mode);
+  const target = targets[0];
+  if (target) {
+    runtime.focusWorkerPane(target);
+    if (mode === "team") {
+      await runtime.loadTeamProfileSettings();
+      const view = runtime.getTeamProfileSettingsView();
+      if (!view || shouldRefuseTeamProfileStart(view)) {
+        runtime.appendRuntimeNotice(
+          runtime.getLanguageText("Worker start blocked", "ワーカー起動を停止"),
+          runtime.getLanguageText(
+            "Start refused. One or more slots cannot run.",
+            "起動できません。実行できないスロットがあります。",
+          ),
+        );
+        return;
+      }
+    }
+    await runtime.startFocusedWorker();
+  }
+}
+
+export function renderFirstRunWizard() {
+  if (!firstRunWizardOpen) {
+    const existing = document.getElementById("first-run-wizard");
+    if (existing) {
+      existing.classList.remove("open");
+      existing.hidden = true;
+      existing.replaceChildren();
+    }
+    return;
+  }
+
+  const t = host().getLanguageText;
+  const overlay = ensureFirstRunWizard();
+  overlay.hidden = false;
+  overlay.classList.add("open");
+
+  const panel = document.createElement("div");
+  panel.className = "first-run-wizard-panel";
+  panel.setAttribute("role", "dialog");
+  panel.setAttribute("aria-modal", "true");
+  panel.setAttribute("aria-labelledby", "first-run-wizard-title");
+
+  const content = document.createElement("div");
+  content.className = "first-run-wizard-content";
+
+  const stepNumber = firstRunWizardStep === "select-project" ? 1 : firstRunWizardStep === "choose-mode" ? 2 : 3;
+  content.appendChild(createTextElement(
+    "p",
+    "first-run-wizard-step",
+    t(`Step ${stepNumber} of 3`, `ステップ ${stepNumber} / 3`),
+  ));
+
+  let title = t("Select project folder", "プロジェクトフォルダを選択");
+  let body = t("Choose a local project folder", "ローカルプロジェクトのフォルダを選択");
+  if (firstRunWizardStep === "choose-mode") {
+    title = t("Choose Simple or Team", "Simple または Team を選択");
+    body = t(
+      "Simple uses one live worker. Team keeps the existing Team Profile start-gate.",
+      "Simple はライブワーカーを1つ使います。Team は既存のチームプロファイル起動ゲートを維持します。",
+    );
+  } else if (firstRunWizardStep === "launch") {
+    title = t("Launch", "起動");
+    body = t(
+      "Start the first managed worker, then focus worker-1.",
+      "最初の管理ワーカーを起動し、worker-1 にフォーカスします。",
+    );
+  }
+
+  const heading = createTextElement("h2", "first-run-wizard-title", title);
+  heading.id = "first-run-wizard-title";
+  content.appendChild(heading);
+  content.appendChild(createTextElement("p", "first-run-wizard-body", body));
+
+  const error = createTextElement("p", "first-run-wizard-error", firstRunWizardError);
+  error.hidden = !firstRunWizardError;
+  error.setAttribute("role", "alert");
+  content.appendChild(error);
+
+  const actions = document.createElement("div");
+  actions.className = "first-run-wizard-actions";
+
+  if (firstRunWizardStep === "select-project") {
+    const selectButton = document.createElement("button");
+    selectButton.type = "button";
+    selectButton.className = "first-run-wizard-primary";
+    selectButton.textContent = t("Select project", "プロジェクトを選択");
+    selectButton.addEventListener("click", () => {
+      void handleFirstRunSelectProject();
+    });
+    actions.appendChild(selectButton);
+  } else if (firstRunWizardStep === "choose-mode") {
+    const simpleButton = document.createElement("button");
+    simpleButton.type = "button";
+    simpleButton.className = "first-run-wizard-primary";
+    simpleButton.textContent = t("Simple (one live worker)", "Simple（ライブワーカーは1つ）");
+    simpleButton.addEventListener("click", () => {
+      void handleFirstRunChooseMode("simple");
+    });
+    const teamButton = document.createElement("button");
+    teamButton.type = "button";
+    teamButton.className = "first-run-wizard-secondary";
+    teamButton.textContent = t(
+      "Team (existing Team Profile start-gate)",
+      "Team（既存のチームプロファイル起動ゲート）",
+    );
+    teamButton.addEventListener("click", () => {
+      void handleFirstRunChooseMode("team");
+    });
+    const cancelButton = document.createElement("button");
+    cancelButton.type = "button";
+    cancelButton.className = "first-run-wizard-cancel";
+    cancelButton.textContent = t("Cancel", "キャンセル");
+    cancelButton.addEventListener("click", () => {
+      handleFirstRunModeCancel();
+    });
+    actions.appendChild(simpleButton);
+    actions.appendChild(teamButton);
+    actions.appendChild(cancelButton);
+  } else {
+    const startButton = document.createElement("button");
+    startButton.type = "button";
+    startButton.className = "first-run-wizard-primary";
+    startButton.textContent = t("Start", "起動");
+    startButton.addEventListener("click", () => {
+      void handleFirstRunLaunch();
+    });
+    actions.appendChild(startButton);
+  }
+
+  content.appendChild(actions);
+  panel.appendChild(content);
+  overlay.replaceChildren(panel);
+}

--- a/winsmux-app/src/firstRunWizard.ts
+++ b/winsmux-app/src/firstRunWizard.ts
@@ -4,10 +4,12 @@ import {
   ORCHESTRA_MODE_RELATIVE_PATH,
   ORCHESTRA_MODE_STORAGE_KEY,
   launchTargetsAfterMode,
+  isMissingOrchestraModeFileError,
   nextWizardStep,
   serializeOrchestraMode,
   shouldShowFirstRunWizard,
   type OrchestraMode,
+  type WizardDecision,
   type WizardStepId,
 } from "./firstRunOnboarding";
 import {
@@ -67,11 +69,7 @@ export async function maybeStartFirstRunOnboarding(sessionCountAtBoot: number) {
   const projectDir = host().getActiveProjectDir();
   if (projectDir) {
     const existing = await readExistingOrchestraModeJson(projectDir);
-    const decision = nextWizardStep({
-      sessionCount: sessionCountAtBoot,
-      projectChosen: true,
-      existingModeJson: existing,
-    });
+    const decision = wizardDecisionFromExistingMode(sessionCountAtBoot, existing);
     firstRunWizardStep = decision.step;
     firstRunSelectedMode = decision.persistMode;
     firstRunWizardError = decision.modeRejected
@@ -111,22 +109,53 @@ function ensureFirstRunWizard() {
   return overlay;
 }
 
-async function readExistingOrchestraModeJson(projectDir: string | null) {
+type ExistingOrchestraModeRead =
+  | { status: "missing" }
+  | { status: "present"; json: string }
+  | { status: "unreadable" };
+
+function wizardDecisionFromExistingMode(
+  sessionCount: number,
+  existing: ExistingOrchestraModeRead,
+): WizardDecision {
+  if (existing.status === "unreadable") {
+    return nextWizardStep({
+      sessionCount,
+      projectChosen: true,
+      existingModeReadFailed: true,
+    });
+  }
+  return nextWizardStep({
+    sessionCount,
+    projectChosen: true,
+    existingModeJson: existing.status === "present" ? existing.json : null,
+  });
+}
+
+function desktopErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function readExistingOrchestraModeJson(projectDir: string | null): Promise<ExistingOrchestraModeRead> {
   if (!projectDir) {
-    return null;
+    return { status: "missing" };
   }
   if (!isTauri()) {
     try {
-      return window.localStorage.getItem(ORCHESTRA_MODE_STORAGE_KEY);
+      const stored = window.localStorage.getItem(ORCHESTRA_MODE_STORAGE_KEY);
+      return stored === null ? { status: "missing" } : { status: "present", json: stored };
     } catch {
-      return null;
+      return { status: "unreadable" };
     }
   }
   try {
     const file = await getDesktopFullFile(ORCHESTRA_MODE_RELATIVE_PATH, undefined, projectDir);
-    return file.content;
-  } catch {
-    return null;
+    return { status: "present", json: file.content };
+  } catch (error) {
+    if (isMissingOrchestraModeFileError(desktopErrorMessage(error))) {
+      return { status: "missing" };
+    }
+    return { status: "unreadable" };
   }
 }
 
@@ -167,11 +196,7 @@ async function handleFirstRunSelectProject() {
     return;
   }
   const existing = await readExistingOrchestraModeJson(host().getActiveProjectDir());
-  const decision = nextWizardStep({
-    sessionCount: 0,
-    projectChosen: true,
-    existingModeJson: existing,
-  });
+  const decision = wizardDecisionFromExistingMode(0, existing);
   firstRunWizardStep = decision.step;
   firstRunSelectedMode = decision.persistMode;
   firstRunWizardError = decision.modeRejected

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -18,7 +18,6 @@ import {
   getDesktopSummarySnapshot,
   getDesktopWorkersStatus,
   getDesktopTeamProfileSettingsView,
-  writeDesktopOrchestraMode,
   getDesktopVoiceCaptureStatus,
   resetDesktopTeamProfileField,
   pickDesktopRunWinner,
@@ -116,15 +115,10 @@ import {
   type SettingsScope,
 } from "./settingsNavigation";
 import {
-  ORCHESTRA_MODE_RELATIVE_PATH,
-  ORCHESTRA_MODE_STORAGE_KEY,
-  launchTargetsAfterMode,
-  nextWizardStep,
-  serializeOrchestraMode,
-  shouldShowFirstRunWizard,
-  type OrchestraMode,
-  type WizardStepId,
-} from "./firstRunOnboarding";
+  bindFirstRunWizard,
+  maybeStartFirstRunOnboarding,
+  renderFirstRunWizard,
+} from "./firstRunWizard";
 
 interface PaneEntry {
   terminal: Terminal;
@@ -954,10 +948,6 @@ const agentVaultProviders: AgentVaultProviderDefinition[] = [
 ];
 let projectSessionEntries: ProjectSessionEntry[] = readStoredProjectSessions();
 let activeProjectDir: string | null = readStoredActiveProjectDir();
-let firstRunWizardOpen = false;
-let firstRunWizardStep: WizardStepId = "select-project";
-let firstRunWizardError = "";
-let firstRunSelectedMode: OrchestraMode | null = null;
 
 const composerModes: Array<{ mode: ComposerMode; label: string; placeholder: string }> = [
   { mode: "ask", label: "Ask", placeholder: "Ask a question or request guidance" },
@@ -5212,310 +5202,6 @@ async function promptAndAddProjectSession() {
   });
   return true;
 }
-
-async function maybeStartFirstRunOnboarding() {
-  if (!shouldShowFirstRunWizard(projectSessionEntries.length)) {
-    return;
-  }
-  firstRunWizardOpen = true;
-  firstRunWizardStep = "select-project";
-  firstRunWizardError = "";
-  firstRunSelectedMode = null;
-  renderFirstRunWizard();
-}
-
-function closeFirstRunWizard() {
-  firstRunWizardOpen = false;
-  firstRunWizardError = "";
-  const overlay = document.getElementById("first-run-wizard");
-  if (!overlay) {
-    return;
-  }
-  overlay.classList.remove("open");
-  overlay.hidden = true;
-  overlay.replaceChildren();
-}
-
-function ensureFirstRunWizard() {
-  let overlay = document.getElementById("first-run-wizard");
-  if (overlay) {
-    return overlay;
-  }
-  overlay = document.createElement("div");
-  overlay.id = "first-run-wizard";
-  overlay.className = "first-run-wizard";
-  overlay.setAttribute("role", "presentation");
-  document.body.appendChild(overlay);
-  return overlay;
-}
-
-async function readExistingOrchestraModeJson(projectDir: string | null) {
-  if (!projectDir) {
-    return null;
-  }
-  if (!isTauri()) {
-    try {
-      return window.localStorage.getItem(ORCHESTRA_MODE_STORAGE_KEY);
-    } catch {
-      return null;
-    }
-  }
-  try {
-    const file = await getDesktopFullFile(ORCHESTRA_MODE_RELATIVE_PATH, undefined, projectDir);
-    return file.content;
-  } catch {
-    return null;
-  }
-}
-
-async function persistFirstRunOrchestraMode(mode: OrchestraMode) {
-  const projectDir = activeProjectDir;
-  if (!projectDir) {
-    throw new Error(getLanguageText("Select a project folder first.", "先にプロジェクトフォルダを選択してください。"));
-  }
-  const json = serializeOrchestraMode(mode);
-  try {
-    window.localStorage.setItem(ORCHESTRA_MODE_STORAGE_KEY, json);
-  } catch (error) {
-    console.warn("Failed to persist orchestra mode locally", error);
-  }
-  if (!isTauri()) {
-    return;
-  }
-  try {
-    await writeDesktopOrchestraMode(projectDir, ORCHESTRA_MODE_RELATIVE_PATH, json);
-  } catch (error) {
-    try {
-      window.localStorage.removeItem(ORCHESTRA_MODE_STORAGE_KEY);
-    } catch {
-      // Keep fail-closed: do not leave a local mode after a rejected project write.
-    }
-    throw error;
-  }
-}
-
-async function handleFirstRunSelectProject() {
-  const selected = await promptAndAddProjectSession();
-  if (!selected) {
-    firstRunWizardStep = nextWizardStep({
-      sessionCount: 0,
-      pickerCancelled: true,
-    }).step;
-    renderFirstRunWizard();
-    return;
-  }
-  const existing = await readExistingOrchestraModeJson(activeProjectDir);
-  const decision = nextWizardStep({
-    sessionCount: 0,
-    projectChosen: true,
-    existingModeJson: existing,
-  });
-  firstRunWizardStep = decision.step;
-  firstRunSelectedMode = decision.persistMode;
-  firstRunWizardError = decision.modeRejected
-    ? getLanguageText(
-      "The existing orchestra mode file is invalid. Choose Simple or Team again.",
-      "既存のオーケストラモードファイルが無効です。Simple または Team を選び直してください。",
-    )
-    : "";
-  renderFirstRunWizard();
-}
-
-async function handleFirstRunChooseMode(mode: OrchestraMode) {
-  const decision = nextWizardStep({
-    sessionCount: 0,
-    projectChosen: true,
-    selectedMode: mode,
-  });
-  if (decision.writeMode && decision.persistMode) {
-    try {
-      await persistFirstRunOrchestraMode(decision.persistMode);
-    } catch (error) {
-      firstRunWizardError = error instanceof Error ? error.message : String(error);
-      firstRunWizardStep = "choose-mode";
-      renderFirstRunWizard();
-      return;
-    }
-  }
-  firstRunSelectedMode = decision.persistMode;
-  firstRunWizardStep = decision.step;
-  firstRunWizardError = "";
-  void recordOperatorDogfoodEvent({
-    actionType: "input",
-    inputSource: "shortcut",
-    taskRef: "desktop-first-run-mode",
-    taskClass: "first_launch_mode_selection",
-    payload: {
-      selected: true,
-      mode: decision.persistMode,
-    },
-  });
-  renderFirstRunWizard();
-}
-
-function handleFirstRunModeCancel() {
-  const decision = nextWizardStep({
-    sessionCount: 0,
-    projectChosen: true,
-    modeStepCancelled: true,
-  });
-  firstRunSelectedMode = null;
-  firstRunWizardStep = decision.step;
-  renderFirstRunWizard();
-}
-
-async function handleFirstRunLaunch() {
-  const mode = firstRunSelectedMode;
-  if (!mode) {
-    firstRunWizardStep = "choose-mode";
-    renderFirstRunWizard();
-    return;
-  }
-  closeFirstRunWizard();
-  await launchFirstRunManagedWorker(mode);
-}
-
-async function launchFirstRunManagedWorker(mode: OrchestraMode) {
-  const targets = launchTargetsAfterMode(mode);
-  const target = targets[0];
-  if (target) {
-    focusWorkerPaneFromStatus(target);
-    if (mode === "team") {
-      await loadAndRenderTeamProfileSettings();
-      if (!teamProfileSettingsView || shouldRefuseTeamProfileStart(teamProfileSettingsView)) {
-        appendRuntimeConversation({
-          type: "system",
-          category: "attention",
-          timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
-          actor: "winsmux",
-          title: getLanguageText("Worker start blocked", "ワーカー起動を停止"),
-          body: getLanguageText(
-            "Start refused. One or more slots cannot run.",
-            "起動できません。実行できないスロットがあります。",
-          ),
-          tone: "warning",
-        });
-        renderConversation(getConversationItems());
-        return;
-      }
-    }
-    await startFocusedWorkerFromDesktop();
-  }
-}
-
-function renderFirstRunWizard() {
-  if (!firstRunWizardOpen) {
-    const existing = document.getElementById("first-run-wizard");
-    if (existing) {
-      existing.classList.remove("open");
-      existing.hidden = true;
-      existing.replaceChildren();
-    }
-    return;
-  }
-
-  const overlay = ensureFirstRunWizard();
-  overlay.hidden = false;
-  overlay.classList.add("open");
-
-  const panel = document.createElement("div");
-  panel.className = "first-run-wizard-panel";
-  panel.setAttribute("role", "dialog");
-  panel.setAttribute("aria-modal", "true");
-  panel.setAttribute("aria-labelledby", "first-run-wizard-title");
-
-  const content = document.createElement("div");
-  content.className = "first-run-wizard-content";
-
-  const stepNumber = firstRunWizardStep === "select-project" ? 1 : firstRunWizardStep === "choose-mode" ? 2 : 3;
-  content.appendChild(createTextElement(
-    "p",
-    "first-run-wizard-step",
-    getLanguageText(`Step ${stepNumber} of 3`, `ステップ ${stepNumber} / 3`),
-  ));
-
-  let title = getLanguageText("Select project folder", "プロジェクトフォルダを選択");
-  let body = getLanguageText("Choose a local project folder", "ローカルプロジェクトのフォルダを選択");
-  if (firstRunWizardStep === "choose-mode") {
-    title = getLanguageText("Choose Simple or Team", "Simple または Team を選択");
-    body = getLanguageText(
-      "Simple uses one live worker. Team keeps the existing Team Profile start-gate.",
-      "Simple はライブワーカーを1つ使います。Team は既存のチームプロファイル起動ゲートを維持します。",
-    );
-  } else if (firstRunWizardStep === "launch") {
-    title = getLanguageText("Launch", "起動");
-    body = getLanguageText(
-      "Start the first managed worker, then focus worker-1.",
-      "最初の管理ワーカーを起動し、worker-1 にフォーカスします。",
-    );
-  }
-
-  const heading = createTextElement("h2", "first-run-wizard-title", title);
-  heading.id = "first-run-wizard-title";
-  content.appendChild(heading);
-  content.appendChild(createTextElement("p", "first-run-wizard-body", body));
-
-  const error = createTextElement("p", "first-run-wizard-error", firstRunWizardError);
-  error.hidden = !firstRunWizardError;
-  error.setAttribute("role", "alert");
-  content.appendChild(error);
-
-  const actions = document.createElement("div");
-  actions.className = "first-run-wizard-actions";
-
-  if (firstRunWizardStep === "select-project") {
-    const selectButton = document.createElement("button");
-    selectButton.type = "button";
-    selectButton.className = "first-run-wizard-primary";
-    selectButton.textContent = getLanguageText("Select project", "プロジェクトを選択");
-    selectButton.addEventListener("click", () => {
-      void handleFirstRunSelectProject();
-    });
-    actions.appendChild(selectButton);
-  } else if (firstRunWizardStep === "choose-mode") {
-    const simpleButton = document.createElement("button");
-    simpleButton.type = "button";
-    simpleButton.className = "first-run-wizard-primary";
-    simpleButton.textContent = getLanguageText("Simple (one live worker)", "Simple（ライブワーカーは1つ）");
-    simpleButton.addEventListener("click", () => {
-      void handleFirstRunChooseMode("simple");
-    });
-    const teamButton = document.createElement("button");
-    teamButton.type = "button";
-    teamButton.className = "first-run-wizard-secondary";
-    teamButton.textContent = getLanguageText(
-      "Team (existing Team Profile start-gate)",
-      "Team（既存のチームプロファイル起動ゲート）",
-    );
-    teamButton.addEventListener("click", () => {
-      void handleFirstRunChooseMode("team");
-    });
-    const cancelButton = document.createElement("button");
-    cancelButton.type = "button";
-    cancelButton.className = "first-run-wizard-cancel";
-    cancelButton.textContent = getLanguageText("Cancel", "キャンセル");
-    cancelButton.addEventListener("click", () => {
-      handleFirstRunModeCancel();
-    });
-    actions.appendChild(simpleButton);
-    actions.appendChild(teamButton);
-    actions.appendChild(cancelButton);
-  } else {
-    const startButton = document.createElement("button");
-    startButton.type = "button";
-    startButton.className = "first-run-wizard-primary";
-    startButton.textContent = getLanguageText("Start", "起動");
-    startButton.addEventListener("click", () => {
-      void handleFirstRunLaunch();
-    });
-    actions.appendChild(startButton);
-  }
-
-  content.appendChild(actions);
-  panel.appendChild(content);
-  overlay.replaceChildren(panel);
-}
-
 
 function nextStartupTick() {
   return new Promise<void>((resolve) => {
@@ -18832,8 +18518,39 @@ window.addEventListener("DOMContentLoaded", async () => {
   void initializeDesktopUpdateState();
   window.setTimeout(() => {
     void (async () => {
+      bindFirstRunWizard({
+        getLanguageText,
+        getActiveProjectDir: () => activeProjectDir,
+        promptAndAddProjectSession,
+        recordDogfoodInput: (taskRef, taskClass, payload) => {
+          void recordOperatorDogfoodEvent({
+            actionType: "input",
+            inputSource: "shortcut",
+            taskRef,
+            taskClass,
+            payload,
+          });
+        },
+        focusWorkerPane: focusWorkerPaneFromStatus,
+        loadTeamProfileSettings: loadAndRenderTeamProfileSettings,
+        getTeamProfileSettingsView: () => teamProfileSettingsView,
+        appendRuntimeNotice: (title, body) => {
+          appendRuntimeConversation({
+            type: "system",
+            category: "attention",
+            timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
+            actor: "winsmux",
+            title,
+            body,
+            tone: "warning",
+          });
+          renderConversation(getConversationItems());
+        },
+        startFocusedWorker: startFocusedWorkerFromDesktop,
+      });
+      const firstRunSessionCountAtBoot = projectSessionEntries.length;
       await applyInitialProjectDirFromLaunchArgs();
-      await maybeStartFirstRunOnboarding();
+      await maybeStartFirstRunOnboarding(firstRunSessionCountAtBoot);
     })();
   }, 0);
   applyPopoutSurfaceState(popoutSurfaceState);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -18,6 +18,7 @@ import {
   getDesktopSummarySnapshot,
   getDesktopWorkersStatus,
   getDesktopTeamProfileSettingsView,
+  writeDesktopOrchestraMode,
   getDesktopVoiceCaptureStatus,
   resetDesktopTeamProfileField,
   pickDesktopRunWinner,
@@ -114,6 +115,16 @@ import {
   shouldDisableSettingsNavItem,
   type SettingsScope,
 } from "./settingsNavigation";
+import {
+  ORCHESTRA_MODE_RELATIVE_PATH,
+  ORCHESTRA_MODE_STORAGE_KEY,
+  launchTargetsAfterMode,
+  nextWizardStep,
+  serializeOrchestraMode,
+  shouldShowFirstRunWizard,
+  type OrchestraMode,
+  type WizardStepId,
+} from "./firstRunOnboarding";
 
 interface PaneEntry {
   terminal: Terminal;
@@ -943,6 +954,10 @@ const agentVaultProviders: AgentVaultProviderDefinition[] = [
 ];
 let projectSessionEntries: ProjectSessionEntry[] = readStoredProjectSessions();
 let activeProjectDir: string | null = readStoredActiveProjectDir();
+let firstRunWizardOpen = false;
+let firstRunWizardStep: WizardStepId = "select-project";
+let firstRunWizardError = "";
+let firstRunSelectedMode: OrchestraMode | null = null;
 
 const composerModes: Array<{ mode: ComposerMode; label: string; placeholder: string }> = [
   { mode: "ask", label: "Ask", placeholder: "Ask a question or request guidance" },
@@ -5173,7 +5188,7 @@ async function promptAndAddProjectSession() {
     } catch (error) {
       console.warn("Failed to open project folder picker", error);
       window.alert(getLanguageText("Could not open the folder picker.", "フォルダ選択を開けませんでした。"));
-      return;
+      return false;
     }
   } else {
     selectedPath = window.prompt(getLanguageText("Project path", "プロジェクトのパス"));
@@ -5181,7 +5196,7 @@ async function promptAndAddProjectSession() {
 
   const projectDir = normalizeProjectDirInput(selectedPath);
   if (!projectDir) {
-    return;
+    return false;
   }
 
   setActiveProjectDir(projectDir);
@@ -5195,7 +5210,312 @@ async function promptAndAddProjectSession() {
       projectName: getProjectDisplayName(projectDir),
     },
   });
+  return true;
 }
+
+async function maybeStartFirstRunOnboarding() {
+  if (!shouldShowFirstRunWizard(projectSessionEntries.length)) {
+    return;
+  }
+  firstRunWizardOpen = true;
+  firstRunWizardStep = "select-project";
+  firstRunWizardError = "";
+  firstRunSelectedMode = null;
+  renderFirstRunWizard();
+}
+
+function closeFirstRunWizard() {
+  firstRunWizardOpen = false;
+  firstRunWizardError = "";
+  const overlay = document.getElementById("first-run-wizard");
+  if (!overlay) {
+    return;
+  }
+  overlay.classList.remove("open");
+  overlay.hidden = true;
+  overlay.replaceChildren();
+}
+
+function ensureFirstRunWizard() {
+  let overlay = document.getElementById("first-run-wizard");
+  if (overlay) {
+    return overlay;
+  }
+  overlay = document.createElement("div");
+  overlay.id = "first-run-wizard";
+  overlay.className = "first-run-wizard";
+  overlay.setAttribute("role", "presentation");
+  document.body.appendChild(overlay);
+  return overlay;
+}
+
+async function readExistingOrchestraModeJson(projectDir: string | null) {
+  if (!projectDir) {
+    return null;
+  }
+  if (!isTauri()) {
+    try {
+      return window.localStorage.getItem(ORCHESTRA_MODE_STORAGE_KEY);
+    } catch {
+      return null;
+    }
+  }
+  try {
+    const file = await getDesktopFullFile(ORCHESTRA_MODE_RELATIVE_PATH, undefined, projectDir);
+    return file.content;
+  } catch {
+    return null;
+  }
+}
+
+async function persistFirstRunOrchestraMode(mode: OrchestraMode) {
+  const projectDir = activeProjectDir;
+  if (!projectDir) {
+    throw new Error(getLanguageText("Select a project folder first.", "先にプロジェクトフォルダを選択してください。"));
+  }
+  const json = serializeOrchestraMode(mode);
+  try {
+    window.localStorage.setItem(ORCHESTRA_MODE_STORAGE_KEY, json);
+  } catch (error) {
+    console.warn("Failed to persist orchestra mode locally", error);
+  }
+  if (!isTauri()) {
+    return;
+  }
+  try {
+    await writeDesktopOrchestraMode(projectDir, ORCHESTRA_MODE_RELATIVE_PATH, json);
+  } catch (error) {
+    try {
+      window.localStorage.removeItem(ORCHESTRA_MODE_STORAGE_KEY);
+    } catch {
+      // Keep fail-closed: do not leave a local mode after a rejected project write.
+    }
+    throw error;
+  }
+}
+
+async function handleFirstRunSelectProject() {
+  const selected = await promptAndAddProjectSession();
+  if (!selected) {
+    firstRunWizardStep = nextWizardStep({
+      sessionCount: 0,
+      pickerCancelled: true,
+    }).step;
+    renderFirstRunWizard();
+    return;
+  }
+  const existing = await readExistingOrchestraModeJson(activeProjectDir);
+  const decision = nextWizardStep({
+    sessionCount: 0,
+    projectChosen: true,
+    existingModeJson: existing,
+  });
+  firstRunWizardStep = decision.step;
+  firstRunSelectedMode = decision.persistMode;
+  firstRunWizardError = decision.modeRejected
+    ? getLanguageText(
+      "The existing orchestra mode file is invalid. Choose Simple or Team again.",
+      "既存のオーケストラモードファイルが無効です。Simple または Team を選び直してください。",
+    )
+    : "";
+  renderFirstRunWizard();
+}
+
+async function handleFirstRunChooseMode(mode: OrchestraMode) {
+  const decision = nextWizardStep({
+    sessionCount: 0,
+    projectChosen: true,
+    selectedMode: mode,
+  });
+  if (decision.writeMode && decision.persistMode) {
+    try {
+      await persistFirstRunOrchestraMode(decision.persistMode);
+    } catch (error) {
+      firstRunWizardError = error instanceof Error ? error.message : String(error);
+      firstRunWizardStep = "choose-mode";
+      renderFirstRunWizard();
+      return;
+    }
+  }
+  firstRunSelectedMode = decision.persistMode;
+  firstRunWizardStep = decision.step;
+  firstRunWizardError = "";
+  void recordOperatorDogfoodEvent({
+    actionType: "input",
+    inputSource: "shortcut",
+    taskRef: "desktop-first-run-mode",
+    taskClass: "first_launch_mode_selection",
+    payload: {
+      selected: true,
+      mode: decision.persistMode,
+    },
+  });
+  renderFirstRunWizard();
+}
+
+function handleFirstRunModeCancel() {
+  const decision = nextWizardStep({
+    sessionCount: 0,
+    projectChosen: true,
+    modeStepCancelled: true,
+  });
+  firstRunSelectedMode = null;
+  firstRunWizardStep = decision.step;
+  renderFirstRunWizard();
+}
+
+async function handleFirstRunLaunch() {
+  const mode = firstRunSelectedMode;
+  if (!mode) {
+    firstRunWizardStep = "choose-mode";
+    renderFirstRunWizard();
+    return;
+  }
+  closeFirstRunWizard();
+  await launchFirstRunManagedWorker(mode);
+}
+
+async function launchFirstRunManagedWorker(mode: OrchestraMode) {
+  const targets = launchTargetsAfterMode(mode);
+  const target = targets[0];
+  if (target) {
+    focusWorkerPaneFromStatus(target);
+    if (mode === "team") {
+      await loadAndRenderTeamProfileSettings();
+      if (!teamProfileSettingsView || shouldRefuseTeamProfileStart(teamProfileSettingsView)) {
+        appendRuntimeConversation({
+          type: "system",
+          category: "attention",
+          timestamp: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
+          actor: "winsmux",
+          title: getLanguageText("Worker start blocked", "ワーカー起動を停止"),
+          body: getLanguageText(
+            "Start refused. One or more slots cannot run.",
+            "起動できません。実行できないスロットがあります。",
+          ),
+          tone: "warning",
+        });
+        renderConversation(getConversationItems());
+        return;
+      }
+    }
+    await startFocusedWorkerFromDesktop();
+  }
+}
+
+function renderFirstRunWizard() {
+  if (!firstRunWizardOpen) {
+    const existing = document.getElementById("first-run-wizard");
+    if (existing) {
+      existing.classList.remove("open");
+      existing.hidden = true;
+      existing.replaceChildren();
+    }
+    return;
+  }
+
+  const overlay = ensureFirstRunWizard();
+  overlay.hidden = false;
+  overlay.classList.add("open");
+
+  const panel = document.createElement("div");
+  panel.className = "first-run-wizard-panel";
+  panel.setAttribute("role", "dialog");
+  panel.setAttribute("aria-modal", "true");
+  panel.setAttribute("aria-labelledby", "first-run-wizard-title");
+
+  const content = document.createElement("div");
+  content.className = "first-run-wizard-content";
+
+  const stepNumber = firstRunWizardStep === "select-project" ? 1 : firstRunWizardStep === "choose-mode" ? 2 : 3;
+  content.appendChild(createTextElement(
+    "p",
+    "first-run-wizard-step",
+    getLanguageText(`Step ${stepNumber} of 3`, `ステップ ${stepNumber} / 3`),
+  ));
+
+  let title = getLanguageText("Select project folder", "プロジェクトフォルダを選択");
+  let body = getLanguageText("Choose a local project folder", "ローカルプロジェクトのフォルダを選択");
+  if (firstRunWizardStep === "choose-mode") {
+    title = getLanguageText("Choose Simple or Team", "Simple または Team を選択");
+    body = getLanguageText(
+      "Simple uses one live worker. Team keeps the existing Team Profile start-gate.",
+      "Simple はライブワーカーを1つ使います。Team は既存のチームプロファイル起動ゲートを維持します。",
+    );
+  } else if (firstRunWizardStep === "launch") {
+    title = getLanguageText("Launch", "起動");
+    body = getLanguageText(
+      "Start the first managed worker, then focus worker-1.",
+      "最初の管理ワーカーを起動し、worker-1 にフォーカスします。",
+    );
+  }
+
+  const heading = createTextElement("h2", "first-run-wizard-title", title);
+  heading.id = "first-run-wizard-title";
+  content.appendChild(heading);
+  content.appendChild(createTextElement("p", "first-run-wizard-body", body));
+
+  const error = createTextElement("p", "first-run-wizard-error", firstRunWizardError);
+  error.hidden = !firstRunWizardError;
+  error.setAttribute("role", "alert");
+  content.appendChild(error);
+
+  const actions = document.createElement("div");
+  actions.className = "first-run-wizard-actions";
+
+  if (firstRunWizardStep === "select-project") {
+    const selectButton = document.createElement("button");
+    selectButton.type = "button";
+    selectButton.className = "first-run-wizard-primary";
+    selectButton.textContent = getLanguageText("Select project", "プロジェクトを選択");
+    selectButton.addEventListener("click", () => {
+      void handleFirstRunSelectProject();
+    });
+    actions.appendChild(selectButton);
+  } else if (firstRunWizardStep === "choose-mode") {
+    const simpleButton = document.createElement("button");
+    simpleButton.type = "button";
+    simpleButton.className = "first-run-wizard-primary";
+    simpleButton.textContent = getLanguageText("Simple (one live worker)", "Simple（ライブワーカーは1つ）");
+    simpleButton.addEventListener("click", () => {
+      void handleFirstRunChooseMode("simple");
+    });
+    const teamButton = document.createElement("button");
+    teamButton.type = "button";
+    teamButton.className = "first-run-wizard-secondary";
+    teamButton.textContent = getLanguageText(
+      "Team (existing Team Profile start-gate)",
+      "Team（既存のチームプロファイル起動ゲート）",
+    );
+    teamButton.addEventListener("click", () => {
+      void handleFirstRunChooseMode("team");
+    });
+    const cancelButton = document.createElement("button");
+    cancelButton.type = "button";
+    cancelButton.className = "first-run-wizard-cancel";
+    cancelButton.textContent = getLanguageText("Cancel", "キャンセル");
+    cancelButton.addEventListener("click", () => {
+      handleFirstRunModeCancel();
+    });
+    actions.appendChild(simpleButton);
+    actions.appendChild(teamButton);
+    actions.appendChild(cancelButton);
+  } else {
+    const startButton = document.createElement("button");
+    startButton.type = "button";
+    startButton.className = "first-run-wizard-primary";
+    startButton.textContent = getLanguageText("Start", "起動");
+    startButton.addEventListener("click", () => {
+      void handleFirstRunLaunch();
+    });
+    actions.appendChild(startButton);
+  }
+
+  content.appendChild(actions);
+  panel.appendChild(content);
+  overlay.replaceChildren(panel);
+}
+
 
 function nextStartupTick() {
   return new Promise<void>((resolve) => {
@@ -10464,6 +10784,7 @@ function applyLanguageChrome() {
     sourceControlMessage.placeholder = japanese ? "コミットメッセージ" : "Commit message";
   }
   applyWorkerPaneDirectInputState();
+  renderFirstRunWizard();
 }
 
 function applyThemeState(nextState: ThemeState) {
@@ -10506,6 +10827,7 @@ function applyThemeState(nextState: ThemeState) {
   renderSettingsControls();
   renderFooterLane();
   applyWorkerPaneDirectInputState();
+  renderFirstRunWizard();
 }
 
 function applyWorkerPaneDirectInputState(state: ThemeState = themeState) {
@@ -18509,7 +18831,10 @@ window.addEventListener("DOMContentLoaded", async () => {
   setTerminalDrawer(true);
   void initializeDesktopUpdateState();
   window.setTimeout(() => {
-    void applyInitialProjectDirFromLaunchArgs();
+    void (async () => {
+      await applyInitialProjectDirFromLaunchArgs();
+      await maybeStartFirstRunOnboarding();
+    })();
   }, 0);
   applyPopoutSurfaceState(popoutSurfaceState);
   registerDesktopSummaryLiveRefresh();

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -3107,6 +3107,97 @@ body[data-popout-surface="1"] #editor-surface {
   opacity: 0.62;
 }
 
+.first-run-wizard {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(15, 23, 42, 0.24);
+  backdrop-filter: blur(2px);
+}
+
+.first-run-wizard.open {
+  display: flex;
+}
+
+.first-run-wizard-panel {
+  width: min(560px, calc(100vw - 48px));
+  max-width: 100%;
+  border: 1px solid var(--border-muted);
+  border-radius: 18px;
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.3);
+  padding: 24px;
+}
+
+.first-run-wizard-content {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+
+.first-run-wizard-step {
+  margin: 0;
+  font-size: var(--text-xs);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.first-run-wizard-title {
+  margin: 0;
+  font-size: 22px;
+  line-height: 1.25;
+  color: var(--text-primary);
+}
+
+.first-run-wizard-body,
+.first-run-wizard-error {
+  margin: 0;
+  font-size: var(--text-sm);
+  line-height: 1.55;
+  color: var(--text-secondary);
+}
+
+.first-run-wizard-error {
+  color: var(--ws-danger, #b42318);
+}
+
+.first-run-wizard-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 22px;
+}
+
+.first-run-wizard-cancel,
+.first-run-wizard-secondary,
+.first-run-wizard-primary {
+  border: 0;
+  border-radius: 999px;
+  padding: 9px 16px;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.first-run-wizard-cancel,
+.first-run-wizard-secondary {
+  background: var(--ws-bg-subtle);
+  color: var(--text-primary);
+}
+
+.first-run-wizard-primary {
+  background: var(--text-primary);
+  color: var(--ws-bg);
+}
+
 #editor-surface,
 #context-panel {
   min-width: 0;


### PR DESCRIPTION
## Summary

TASK-664 only. Reopens the work from closed #1272 (GitHub auto-closed that stacked draft when #1271 deleted its base branch). Head is unchanged: `cursor/task-664-first-run-simple-mode` `2897f62a`.

Adds a 3-step desktop first-run wizard: **select project → choose Simple or Team → launch the first managed worker**.

- Reuses `promptAndAddProjectSession` and `winsmux.project-sessions.v1`.
- Reuses `startDesktopWorkerPaneWithLaunchCommand` via `startFocusedWorkerFromDesktop` for **worker-1 only**. The wizard does not start worker-2..6.
- Returning users with `project-sessions.v1` length ≥ 1 skip the wizard (implicit Team, current 0.36.32 behavior).
- Extra panes stay in the layout. This PR does not hide worker-2..6 with CSS or `hidden` camouflage (TASK-789).
- Team mode still honors `shouldRefuseTeamProfileStart`. The Team Profile catalog is unchanged.

Persisted mode JSON (no other keys):

```json
{"schema_version":1,"mode":"simple"}
```

Written to both `localStorage` key `winsmux.orchestra-mode.v1` and `<project>/.winsmux/orchestra-mode.json`. Invalid existing mode files fail closed and re-show step 2; they are not silently repaired.

Narrow Tauri command `desktop_write_orchestra_mode` writes only `.winsmux/orchestra-mode.json` under the resolved project dir. It rejects `..`, absolute escapes, extra JSON keys, invalid `mode`, and `schema_version` ≠ 1. No `@tauri-apps/plugin-fs`. No `orchestra_mode` on `BridgeSettingsSchema`. Default `worker_count` stays 6. VERSION is not bumped.

## Surface Classification

- [x] Public product surface
- [ ] Runtime contract surface
- [x] Contributor/test surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Responsibility And Cutover

- Replaced behavior, workflow, config path, or responsibility: first-run desktop path for empty `project-sessions.v1` now asks Simple vs Team before launching worker-1. Canonical mode file is `.winsmux/orchestra-mode.json` (TASK-789 / orchestra-start will read it later).
- Expected outcome: new users pick a project and a mode; existing 0.36.32 users with saved sessions skip the wizard.
- Source of truth: desktop localStorage for wizard skip; project `.winsmux/orchestra-mode.json` for later orchestra-start.
- Old paths preserved, redirected, deprecated, or removed: existing picker, worker-1 start, and Team Profile start-gate are reused. No orchestra-start.ps1 edits. Closed #1272 is historical only.

## Verification

Ubuntu local evidence (not Pester / orchestra-start / orchestra-smoke / Tauri desktop-pane-e2e):

```
cd winsmux-app
npm ci
node ./scripts/first-run-onboarding-check.mjs
npm run build
```

`test:first-run-onboarding` covers F01–F10. It is **not** added to `scripts/test-v03626-desktop-split-gate.ps1`. Windows Tests on this PR (base `main`) is the CI authority.

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.

Narrow write only: the new Tauri command can persist only `.winsmux/orchestra-mode.json` (`mode` is `simple` or `team`). Dogfood uses `first_launch_mode_selection` and does not log mode-file full paths. No npm publish, no tag.
