### PR TITLE
feat(app): add Agent Vault archive, group, and fork (TASK-665)

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -190,6 +190,7 @@ $whitelistPatterns = @(
     'winsmux-app/src/workerPaneInput.ts',
     'winsmux-app/src/teamProfileSettings.ts',
     'winsmux-app/src/firstRunOnboarding.ts',
+    'winsmux-app/src/agentVaultOrganize.ts',
     'winsmux-app/src/firstRunWizard.ts',
     'winsmux-app/src/workflowGate.ts',
     'winsmux-app/src/styles.css',

--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -41,6 +41,7 @@
     "test:bakeoff-runner": "node ./scripts/bakeoff-runner-check.mjs",
     "test:worker-start-planning": "node ./scripts/worker-start-planning-check.mjs",
     "test:first-run-onboarding": "node ./scripts/first-run-onboarding-check.mjs",
+    "test:agent-vault-organize": "node ./scripts/agent-vault-organize-check.mjs",
     "test:source-graph": "node ./scripts/source-graph-check.mjs",
     "test:windows-context-menu": "pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/windows-context-menu-e2e.ps1",
     "test:viewport-harness": "npm run build && node ./scripts/viewport-harness.mjs",

--- a/winsmux-app/scripts/agent-vault-organize-check.mjs
+++ b/winsmux-app/scripts/agent-vault-organize-check.mjs
@@ -34,6 +34,8 @@ const {
   buildAgentVaultForkLaunchCommand,
   buildAgentVaultResumeCommand,
   resolveAgentVaultLaunchDirectory,
+  shouldQueueAgentVaultLaunchCwd,
+  applyAgentVaultGroupPrompt,
   emptyAgentVaultOrganize,
   groupNameForSession,
   isArchived,
@@ -180,6 +182,17 @@ assert.equal(v13.groups.find((group) => group.name === "release")?.sessionIds.in
 assert.equal(assignSessionToGroup(v13, "summary:run-id", "").ok, false);
 assert.equal(assignSessionToGroup(v13, "summary:run-id", "   ").ok, false);
 
+const groupedForPrompt = assertOk(assignSessionToGroup(emptyAgentVaultOrganize(), "summary:run-id", "release"));
+assert.equal(groupNameForSession(assertOk(applyAgentVaultGroupPrompt(groupedForPrompt, "summary:run-id", "")), "summary:run-id"), null);
+assert.equal(groupNameForSession(assertOk(applyAgentVaultGroupPrompt(groupedForPrompt, "summary:run-id", "   ")), "summary:run-id"), null);
+const invalidPrompt = applyAgentVaultGroupPrompt(groupedForPrompt, "summary:run-id", "x".repeat(65));
+assert.equal(invalidPrompt.ok, false);
+assert.equal(groupNameForSession(groupedForPrompt, "summary:run-id"), "release");
+assert.equal(
+  groupNameForSession(assertOk(applyAgentVaultGroupPrompt(groupedForPrompt, "summary:run-id", "follow-up")), "summary:run-id"),
+  "follow-up",
+);
+
 // V14: fork cwd — `.` / relative worktree resolve against the active project; `..` fail-closed
 const baseDir = "C:/Users/sorab/proj";
 assert.equal(resolveAgentVaultLaunchDirectory("C:/other/app", baseDir), "C:/other/app");
@@ -193,6 +206,11 @@ assert.equal(resolveAgentVaultLaunchDirectory(".", ""), "");
 assert.equal(resolveAgentVaultLaunchDirectory("../escape", baseDir), "");
 assert.equal(resolveAgentVaultLaunchDirectory("workspace:c:/other", baseDir), "");
 assert.equal(resolveAgentVaultLaunchDirectory("", ""), "");
+
+assert.equal(shouldQueueAgentVaultLaunchCwd("fork", "C:/proj"), true);
+assert.equal(shouldQueueAgentVaultLaunchCwd("resume", "C:/proj"), false);
+assert.equal(shouldQueueAgentVaultLaunchCwd("fork", ""), false);
+assert.equal(shouldQueueAgentVaultLaunchCwd("resume", ""), false);
 
 const mainSource = await readFile(path.resolve("src/main.ts"), "utf8");
 assert.match(mainSource, /from "\.\/agentVaultOrganize"/);
@@ -208,12 +226,14 @@ assert.match(mainSource, /Forked from/);
 assert.match(mainSource, /buildAgentVaultForkLaunchCommand/);
 assert.match(mainSource, /isResumeCommand/);
 assert.match(mainSource, /workspacePath/);
+assert.match(mainSource, /shouldQueueAgentVaultLaunchCwd\(mode, launchCwd\)/);
 assert.match(mainSource, /queuePaneStartupCwd\(paneId, launchCwd\)/);
 assert.match(mainSource, /spawnPtyPane\(paneId, cols, rows, startupInput, cwd\)/);
 assert.match(mainSource, /mode === "fork" && !launchCwd/);
 assert.match(mainSource, /vaultOrganize\.resolveAgentVaultLaunchDirectory/);
 assert.doesNotMatch(mainSource, /function resolveAgentVaultLaunchDirectory/);
-assert.match(mainSource, /removeSessionFromGroup/);
+assert.match(mainSource, /applyAgentVaultGroupPrompt/);
+assert.doesNotMatch(mainSource, /if \(launchCwd\) \{/);
 assert.match(mainSource, /id: `worker:\$\{runId\}`/);
 assert.doesNotMatch(mainSource, /id: `worker:\$\{target\}`/);
 assert.match(mainSource, /row\.heartbeat\?\.run_id \|\| row\.workspace\?\.run_id/);

--- a/winsmux-app/scripts/agent-vault-organize-check.mjs
+++ b/winsmux-app/scripts/agent-vault-organize-check.mjs
@@ -40,6 +40,7 @@ const {
   loadAgentVaultOrganize,
   parseAgentVaultOrganizeJson,
   recordFork,
+  removeSessionFromGroup,
   searchTextWithGroupName,
   serializeAgentVaultOrganize,
   unarchiveSession,
@@ -171,6 +172,13 @@ assert.deepEqual(Object.keys(v12Parsed.groups[0]), ["id", "name", "sessionIds"])
 assert.deepEqual(Object.keys(v12Parsed.forks[0]), ["id", "fromId", "workspaceKey"]);
 assert.deepEqual(parseAgentVaultOrganizeJson(v12Json), v12State);
 
+// V13: empty/cleared group name is a UI concern; mutation layer still rejects empty assign
+const v13 = assertOk(removeSessionFromGroup(v04, "summary:run-id"));
+assert.equal(groupNameForSession(v13, "summary:run-id"), null);
+assert.equal(v13.groups.find((group) => group.name === "release")?.sessionIds.includes("summary:run-id") ?? false, false);
+assert.equal(assignSessionToGroup(v13, "summary:run-id", "").ok, false);
+assert.equal(assignSessionToGroup(v13, "summary:run-id", "   ").ok, false);
+
 const mainSource = await readFile(path.resolve("src/main.ts"), "utf8");
 assert.match(mainSource, /from "\.\/agentVaultOrganize"/);
 assert.match(mainSource, /AGENT_VAULT_ORGANIZE_STORAGE_KEY|winsmux\.agent-vault\.organize\.v1/);
@@ -184,7 +192,23 @@ assert.match(mainSource, /forkAgentVaultSession/);
 assert.match(mainSource, /Forked from/);
 assert.match(mainSource, /buildAgentVaultForkLaunchCommand/);
 assert.match(mainSource, /isResumeCommand/);
+assert.match(mainSource, /workspacePath/);
+assert.match(mainSource, /queuePaneStartupCwd\(paneId, launchCwd\)/);
+assert.match(mainSource, /spawnPtyPane\(paneId, cols, rows, startupInput, cwd\)/);
+assert.match(mainSource, /mode === "fork" && !launchCwd/);
+assert.match(mainSource, /removeSessionFromGroup/);
+assert.match(mainSource, /id: `worker:\$\{runId\}`/);
+assert.doesNotMatch(mainSource, /id: `worker:\$\{target\}`/);
+assert.match(mainSource, /function readAgentVaultWorkerRunId/);
 assert.doesNotMatch(mainSource, /desktop_write_.*organize|writeDesktopOrganize|\.winsmux\/.*organize/i);
+
+const restoreFn = mainSource.slice(mainSource.indexOf("async function restoreAgentVaultSession"));
+const recordAt = restoreFn.indexOf("recordFork");
+const startedAt = restoreFn.indexOf("ensurePanePtyStarted");
+assert.ok(startedAt >= 0, "restoreAgentVaultSession must start a pane");
+assert.ok(recordAt > startedAt, "recordFork must run after pane startup succeeds");
+const forkGuardAt = restoreFn.indexOf("mode === \"fork\" && !launchCwd");
+assert.ok(forkGuardAt >= 0 && (recordAt < 0 || forkGuardAt < recordAt), "fork without a path must fail before recording");
 
 const forbiddenFirstRun = [
   "src/firstRunOnboarding.ts",

--- a/winsmux-app/scripts/agent-vault-organize-check.mjs
+++ b/winsmux-app/scripts/agent-vault-organize-check.mjs
@@ -36,6 +36,7 @@ const {
   resolveAgentVaultLaunchDirectory,
   shouldQueueAgentVaultLaunchCwd,
   applyAgentVaultGroupPrompt,
+  persistableAgentVaultWorkspaceKey,
   emptyAgentVaultOrganize,
   groupNameForSession,
   isArchived,
@@ -124,7 +125,13 @@ assert.deepEqual(v07Loaded.state, v07Previous);
 const v08 = assertOk(recordFork(emptyAgentVaultOrganize(), "summary:run-id", "C:/proj"));
 assert.equal(v08.forks.length, 1);
 assert.equal(v08.forks[0].fromId, "summary:run-id");
-assert.equal(v08.forks[0].workspaceKey, "C:/proj");
+assert.equal(v08.forks[0].workspaceKey, "workspace");
+assert.equal(
+  assertOk(recordFork(emptyAgentVaultOrganize(), "summary:run-id", "workspace:c:/users/sorab/secret")).forks[0].workspaceKey,
+  "workspace",
+);
+assert.equal(persistableAgentVaultWorkspaceKey("__this_project__"), "__this_project__");
+assert.equal(persistableAgentVaultWorkspaceKey("unknown"), "unknown");
 assert.match(v08.forks[0].id, /^fork_[A-Za-z0-9]+$/);
 assert.equal(isArchived(v08, "summary:run-id"), false);
 assert.deepEqual(visibleVaultEntryIds(entries, v08, false), ["summary:run-id", "worker:w1"]);
@@ -166,7 +173,7 @@ const v12State = {
   schema_version: 1,
   archivedIds: ["summary:run-id"],
   groups: [{ id: "grp_01", name: "release", sessionIds: ["summary:run-id"] }],
-  forks: [{ id: "fork_01", fromId: "summary:run-id", workspaceKey: "C:/proj" }],
+  forks: [{ id: "fork_01", fromId: "summary:run-id", workspaceKey: "workspace" }],
 };
 const v12Json = serializeAgentVaultOrganize(v12State);
 const v12Parsed = JSON.parse(v12Json);
@@ -174,6 +181,16 @@ assert.deepEqual(Object.keys(v12Parsed), ["schema_version", "archivedIds", "grou
 assert.deepEqual(Object.keys(v12Parsed.groups[0]), ["id", "name", "sessionIds"]);
 assert.deepEqual(Object.keys(v12Parsed.forks[0]), ["id", "fromId", "workspaceKey"]);
 assert.deepEqual(parseAgentVaultOrganizeJson(v12Json), v12State);
+assert.equal(v12Parsed.forks[0].workspaceKey, "workspace");
+assert.doesNotMatch(v12Json, /C:\/|\\\\users\\/i);
+const v12Legacy = parseAgentVaultOrganizeJson(JSON.stringify({
+  schema_version: 1,
+  archivedIds: [],
+  groups: [],
+  forks: [{ id: "fork_01", fromId: "summary:run-id", workspaceKey: "C:/Users/sorab/secret" }],
+}));
+assert.equal(v12Legacy.forks[0].workspaceKey, "workspace");
+assert.doesNotMatch(serializeAgentVaultOrganize(v12Legacy), /Users\/sorab\/secret/i);
 
 // V13: empty/cleared group name is a UI concern; mutation layer still rejects empty assign
 const v13 = assertOk(removeSessionFromGroup(v04, "summary:run-id"));

--- a/winsmux-app/scripts/agent-vault-organize-check.mjs
+++ b/winsmux-app/scripts/agent-vault-organize-check.mjs
@@ -33,6 +33,7 @@ const {
   assignSessionToGroup,
   buildAgentVaultForkLaunchCommand,
   buildAgentVaultResumeCommand,
+  resolveAgentVaultLaunchDirectory,
   emptyAgentVaultOrganize,
   groupNameForSession,
   isArchived,
@@ -179,6 +180,20 @@ assert.equal(v13.groups.find((group) => group.name === "release")?.sessionIds.in
 assert.equal(assignSessionToGroup(v13, "summary:run-id", "").ok, false);
 assert.equal(assignSessionToGroup(v13, "summary:run-id", "   ").ok, false);
 
+// V14: fork cwd — `.` / relative worktree resolve against the active project; `..` fail-closed
+const baseDir = "C:/Users/sorab/proj";
+assert.equal(resolveAgentVaultLaunchDirectory("C:/other/app", baseDir), "C:/other/app");
+assert.equal(resolveAgentVaultLaunchDirectory("D:\\other\\app", baseDir), "D:\\other\\app");
+assert.equal(resolveAgentVaultLaunchDirectory(".", baseDir), baseDir);
+assert.equal(resolveAgentVaultLaunchDirectory("./", baseDir), baseDir);
+assert.equal(resolveAgentVaultLaunchDirectory("worktrees/task-665", baseDir), "C:/Users/sorab/proj/worktrees/task-665");
+assert.equal(resolveAgentVaultLaunchDirectory("", baseDir), baseDir);
+assert.equal(resolveAgentVaultLaunchDirectory("__this_project__", baseDir), baseDir);
+assert.equal(resolveAgentVaultLaunchDirectory(".", ""), "");
+assert.equal(resolveAgentVaultLaunchDirectory("../escape", baseDir), "");
+assert.equal(resolveAgentVaultLaunchDirectory("workspace:c:/other", baseDir), "");
+assert.equal(resolveAgentVaultLaunchDirectory("", ""), "");
+
 const mainSource = await readFile(path.resolve("src/main.ts"), "utf8");
 assert.match(mainSource, /from "\.\/agentVaultOrganize"/);
 assert.match(mainSource, /AGENT_VAULT_ORGANIZE_STORAGE_KEY|winsmux\.agent-vault\.organize\.v1/);
@@ -196,10 +211,12 @@ assert.match(mainSource, /workspacePath/);
 assert.match(mainSource, /queuePaneStartupCwd\(paneId, launchCwd\)/);
 assert.match(mainSource, /spawnPtyPane\(paneId, cols, rows, startupInput, cwd\)/);
 assert.match(mainSource, /mode === "fork" && !launchCwd/);
+assert.match(mainSource, /vaultOrganize\.resolveAgentVaultLaunchDirectory/);
+assert.doesNotMatch(mainSource, /function resolveAgentVaultLaunchDirectory/);
 assert.match(mainSource, /removeSessionFromGroup/);
 assert.match(mainSource, /id: `worker:\$\{runId\}`/);
 assert.doesNotMatch(mainSource, /id: `worker:\$\{target\}`/);
-assert.match(mainSource, /function readAgentVaultWorkerRunId/);
+assert.match(mainSource, /row\.heartbeat\?\.run_id \|\| row\.workspace\?\.run_id/);
 assert.doesNotMatch(mainSource, /desktop_write_.*organize|writeDesktopOrganize|\.winsmux\/.*organize/i);
 
 const restoreFn = mainSource.slice(mainSource.indexOf("async function restoreAgentVaultSession"));

--- a/winsmux-app/scripts/agent-vault-organize-check.mjs
+++ b/winsmux-app/scripts/agent-vault-organize-check.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+async function loadAgentVaultOrganizeModule() {
+  const sourcePath = path.resolve("src/agentVaultOrganize.ts");
+  const source = await readFile(sourcePath, "utf8");
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: sourcePath,
+  });
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "winsmux-agent-vault-organize-"));
+  const modulePath = path.join(tempDir, "agentVaultOrganize.mjs");
+  await writeFile(modulePath, transpiled.outputText, "utf8");
+
+  try {
+    return await import(pathToFileURL(modulePath).href);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const {
+  AGENT_VAULT_ORGANIZE_STORAGE_KEY,
+  archiveSession,
+  assignSessionToGroup,
+  buildAgentVaultForkLaunchCommand,
+  buildAgentVaultResumeCommand,
+  emptyAgentVaultOrganize,
+  groupNameForSession,
+  isArchived,
+  isResumeCommand,
+  loadAgentVaultOrganize,
+  parseAgentVaultOrganizeJson,
+  recordFork,
+  searchTextWithGroupName,
+  serializeAgentVaultOrganize,
+  unarchiveSession,
+  visibleVaultEntryIds,
+} = await loadAgentVaultOrganizeModule();
+
+const entries = [
+  { id: "summary:run-id", searchText: "summary run-id claude title workspace" },
+  { id: "worker:w1", searchText: "worker w1 codex other" },
+];
+
+function assertOk(result) {
+  assert.equal(result.ok, true, result.error ?? "expected organize mutation to succeed");
+  return result.state;
+}
+
+// V01: empty / missing JSON → default empty organize; all entries visible
+const v01Empty = parseAgentVaultOrganizeJson("");
+const v01Missing = parseAgentVaultOrganizeJson(undefined);
+assert.deepEqual(v01Empty, emptyAgentVaultOrganize());
+assert.deepEqual(v01Missing, emptyAgentVaultOrganize());
+assert.deepEqual(v01Empty, {
+  schema_version: 1,
+  archivedIds: [],
+  groups: [],
+  forks: [],
+});
+assert.deepEqual(visibleVaultEntryIds(entries, v01Empty, false), ["summary:run-id", "worker:w1"]);
+assert.equal(AGENT_VAULT_ORGANIZE_STORAGE_KEY, "winsmux.agent-vault.organize.v1");
+
+// V02: archive id → hidden unless showArchived
+const v02 = assertOk(archiveSession(emptyAgentVaultOrganize(), "summary:run-id"));
+assert.equal(isArchived(v02, "summary:run-id"), true);
+assert.deepEqual(visibleVaultEntryIds(entries, v02, false), ["worker:w1"]);
+assert.deepEqual(visibleVaultEntryIds(entries, v02, true), ["summary:run-id", "worker:w1"]);
+
+// V03: unarchive → visible again
+const v03 = assertOk(unarchiveSession(v02, "summary:run-id"));
+assert.equal(isArchived(v03, "summary:run-id"), false);
+assert.deepEqual(visibleVaultEntryIds(entries, v03, false), ["summary:run-id", "worker:w1"]);
+
+// V04: assign group name → session in exactly one group; search text includes name
+const v04 = assertOk(assignSessionToGroup(emptyAgentVaultOrganize(), "summary:run-id", "release"));
+assert.equal(v04.groups.length, 1);
+assert.equal(groupNameForSession(v04, "summary:run-id"), "release");
+assert.equal(v04.groups.filter((group) => group.sessionIds.includes("summary:run-id")).length, 1);
+assert.match(searchTextWithGroupName(entries[0], v04), /release/);
+assert.equal(searchTextWithGroupName(entries[1], v04).includes("release"), false);
+
+// V05: move to second group → removed from first
+const v05 = assertOk(assignSessionToGroup(v04, "summary:run-id", "hotfix"));
+assert.equal(groupNameForSession(v05, "summary:run-id"), "hotfix");
+assert.equal(v05.groups.find((group) => group.name === "release")?.sessionIds.includes("summary:run-id") ?? false, false);
+assert.equal(v05.groups.filter((group) => group.sessionIds.includes("summary:run-id")).length, 1);
+
+// V06: empty / control-char group name → reject; previous state unchanged
+const v06Previous = structuredClone(v04);
+const v06Empty = assignSessionToGroup(v04, "summary:run-id", "   ");
+const v06Control = assignSessionToGroup(v04, "summary:run-id", "bad\u0007name");
+assert.equal(v06Empty.ok, false);
+assert.equal(v06Control.ok, false);
+assert.deepEqual(v04, v06Previous);
+assert.equal(groupNameForSession(v04, "summary:run-id"), "release");
+
+// V07: extra JSON key / schema_version ≠ 1 → reject
+assert.throws(() => parseAgentVaultOrganizeJson('{"schema_version":1,"archivedIds":[],"groups":[],"forks":[],"extra":true}'));
+assert.throws(() => parseAgentVaultOrganizeJson('{"schema_version":2,"archivedIds":[],"groups":[],"forks":[]}'));
+assert.throws(() => parseAgentVaultOrganizeJson('{"schema_version":1,"archivedIds":[],"groups":[{"id":"grp_01","name":"release","sessionIds":["summary:run-id"],"extra":1}],"forks":[]}'));
+assert.throws(() => parseAgentVaultOrganizeJson('{"schema_version":1,"archivedIds":[],"groups":[],"forks":[{"id":"fork_01","fromId":"summary:run-id","workspaceKey":"C:/proj","extra":1}]}'));
+assert.throws(() => parseAgentVaultOrganizeJson("[]"));
+assert.throws(() => parseAgentVaultOrganizeJson("{"));
+const v07Previous = structuredClone(v04);
+const v07Loaded = loadAgentVaultOrganize('{"schema_version":1,"archivedIds":[],"groups":[],"forks":[],"extra":true}', v04);
+assert.equal(v07Loaded.error.includes("rejected"), true);
+assert.deepEqual(v07Loaded.state, v07Previous);
+
+// V08: fork record → fromId preserved; does not archive source
+const v08 = assertOk(recordFork(emptyAgentVaultOrganize(), "summary:run-id", "C:/proj"));
+assert.equal(v08.forks.length, 1);
+assert.equal(v08.forks[0].fromId, "summary:run-id");
+assert.equal(v08.forks[0].workspaceKey, "C:/proj");
+assert.match(v08.forks[0].id, /^fork_[A-Za-z0-9]+$/);
+assert.equal(isArchived(v08, "summary:run-id"), false);
+assert.deepEqual(visibleVaultEntryIds(entries, v08, false), ["summary:run-id", "worker:w1"]);
+
+// V09: resume command strings → isResumeCommand true
+const claudeResume = buildAgentVaultResumeCommand("claude", "run-id");
+const codexResume = buildAgentVaultResumeCommand("codex", "run-id");
+const opencodeResume = buildAgentVaultResumeCommand("opencode", "run-id");
+assert.equal(isResumeCommand(claudeResume), true);
+assert.equal(isResumeCommand(codexResume), true);
+assert.equal(isResumeCommand(opencodeResume), true);
+assert.equal(isResumeCommand("claude --resume"), true);
+assert.equal(isResumeCommand("codex resume"), true);
+assert.equal(isResumeCommand("opencode --session"), true);
+
+// V10: fork launch command → isResumeCommand false; must not include resume flags
+for (const provider of ["claude", "codex", "opencode"]) {
+  const forkCommand = buildAgentVaultForkLaunchCommand(provider);
+  assert.equal(isResumeCommand(forkCommand), false, `${provider} fork must not be a resume command`);
+  assert.equal(forkCommand.includes("--resume"), false);
+  assert.equal(/\bcodex\s+resume\b/.test(forkCommand), false);
+  assert.equal(forkCommand.includes("--session"), false);
+  assert.equal(forkCommand, provider);
+}
+
+// V11: stale archived id → no fake card; other entries unchanged
+const v11 = parseAgentVaultOrganizeJson(JSON.stringify({
+  schema_version: 1,
+  archivedIds: ["summary:gone", "summary:run-id"],
+  groups: [],
+  forks: [],
+}));
+assert.deepEqual(visibleVaultEntryIds(entries, v11, false), ["worker:w1"]);
+assert.deepEqual(visibleVaultEntryIds(entries, v11, true), ["summary:run-id", "worker:w1"]);
+assert.equal(visibleVaultEntryIds(entries, v11, true).includes("summary:gone"), false);
+
+// V12: serializer round-trip → only the keys above
+const v12State = {
+  schema_version: 1,
+  archivedIds: ["summary:run-id"],
+  groups: [{ id: "grp_01", name: "release", sessionIds: ["summary:run-id"] }],
+  forks: [{ id: "fork_01", fromId: "summary:run-id", workspaceKey: "C:/proj" }],
+};
+const v12Json = serializeAgentVaultOrganize(v12State);
+const v12Parsed = JSON.parse(v12Json);
+assert.deepEqual(Object.keys(v12Parsed), ["schema_version", "archivedIds", "groups", "forks"]);
+assert.deepEqual(Object.keys(v12Parsed.groups[0]), ["id", "name", "sessionIds"]);
+assert.deepEqual(Object.keys(v12Parsed.forks[0]), ["id", "fromId", "workspaceKey"]);
+assert.deepEqual(parseAgentVaultOrganizeJson(v12Json), v12State);
+
+const mainSource = await readFile(path.resolve("src/main.ts"), "utf8");
+assert.match(mainSource, /from "\.\/agentVaultOrganize"/);
+assert.match(mainSource, /AGENT_VAULT_ORGANIZE_STORAGE_KEY|winsmux\.agent-vault\.organize\.v1/);
+assert.match(mainSource, /Show archived/);
+assert.match(mainSource, /アーカイブを表示/);
+assert.match(mainSource, /getLanguageText\("Archive", "アーカイブ"\)/);
+assert.match(mainSource, /getLanguageText\("Unarchive", "アーカイブ解除"\)/);
+assert.match(mainSource, /getLanguageText\("Group", "グループ"\)/);
+assert.match(mainSource, /getLanguageText\("Fork", "フォーク"\)/);
+assert.match(mainSource, /forkAgentVaultSession/);
+assert.match(mainSource, /Forked from/);
+assert.match(mainSource, /buildAgentVaultForkLaunchCommand/);
+assert.match(mainSource, /isResumeCommand/);
+assert.doesNotMatch(mainSource, /desktop_write_.*organize|writeDesktopOrganize|\.winsmux\/.*organize/i);
+
+const forbiddenFirstRun = [
+  "src/firstRunOnboarding.ts",
+  "src/firstRunWizard.ts",
+  "scripts/first-run-onboarding-check.mjs",
+];
+void forbiddenFirstRun;
+
+console.log("agent-vault-organize-check: ok");

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -614,6 +614,7 @@ struct SinglePty {
     generation: u64,
     cols: u16,
     rows: u16,
+    cwd: PathBuf,
 }
 
 struct PtyManager {
@@ -1186,7 +1187,7 @@ async fn pty_json_rpc(
 
 #[tauri::command]
 async fn pty_spawn(app: AppHandle, pane_id: String, cols: u16, rows: u16) -> Result<(), String> {
-    spawn_pty(&app, pane_id, cols, rows, None, "pty.spawn")
+    spawn_pty(&app, pane_id, cols, rows, None, None, "pty.spawn")
 }
 
 #[tauri::command]
@@ -1224,6 +1225,7 @@ fn spawn_pty(
     cols: u16,
     rows: u16,
     startup_input: Option<String>,
+    cwd: Option<String>,
     reason: &str,
 ) -> Result<(), String> {
     let manager = app.state::<PtyManager>();
@@ -1235,7 +1237,8 @@ fn spawn_pty(
     }
 
     let generation = manager.next_generation.fetch_add(1, Ordering::SeqCst);
-    let (single, reader, output_history, alive) = create_single_pty(cols, rows, generation)?;
+    let (single, reader, output_history, alive) =
+        create_single_pty(cols, rows, generation, cwd.as_deref())?;
 
     {
         let mut panes = manager.panes.lock().map_err(|e| e.to_string())?;
@@ -1318,7 +1321,31 @@ fn build_pty_command(workspace_dir: &Path) -> CommandBuilder {
     cmd
 }
 
-fn create_single_pty(cols: u16, rows: u16, generation: u64) -> Result<SinglePtyParts, String> {
+fn resolve_pty_workspace_dir(cwd: Option<&str>) -> Result<PathBuf, String> {
+    let trimmed = cwd.map(str::trim).filter(|value| !value.is_empty());
+    let Some(raw) = trimmed else {
+        return resolve_repo_root();
+    };
+    let path = PathBuf::from(raw);
+    if !path.is_absolute() {
+        return Err(format!(
+            "pty.spawn cwd must be an existing absolute directory: {raw}"
+        ));
+    }
+    match std::fs::metadata(&path) {
+        Ok(meta) if meta.is_dir() => Ok(path),
+        _ => Err(format!(
+            "pty.spawn cwd must be an existing absolute directory: {raw}"
+        )),
+    }
+}
+
+fn create_single_pty(
+    cols: u16,
+    rows: u16,
+    generation: u64,
+    cwd: Option<&str>,
+) -> Result<SinglePtyParts, String> {
     let pty_system = native_pty_system();
 
     let pair = pty_system
@@ -1330,7 +1357,7 @@ fn create_single_pty(cols: u16, rows: u16, generation: u64) -> Result<SinglePtyP
         })
         .map_err(|e| format!("Failed to open PTY: {e}"))?;
 
-    let workspace_dir = resolve_repo_root()?;
+    let workspace_dir = resolve_pty_workspace_dir(cwd)?;
     let cmd = build_pty_command(&workspace_dir);
 
     let child = pair
@@ -1359,6 +1386,7 @@ fn create_single_pty(cols: u16, rows: u16, generation: u64) -> Result<SinglePtyP
         generation,
         cols,
         rows,
+        cwd: workspace_dir,
     };
 
     Ok((single, reader, output_history, alive))
@@ -1724,15 +1752,20 @@ fn submit_operator_text(
 
 fn respawn_pty(app: &AppHandle, pane_id: &str) -> Result<(), String> {
     let manager = app.state::<PtyManager>();
-    let (cols, rows) = {
+    let (cols, rows, cwd) = {
         let panes = manager.panes.lock().map_err(|e| e.to_string())?;
         let entry = panes
             .get(pane_id)
             .ok_or_else(|| format!("Pane {} not found", pane_id))?;
-        (entry.cols, entry.rows)
+        (
+            entry.cols,
+            entry.rows,
+            entry.cwd.to_string_lossy().into_owned(),
+        )
     };
     let generation = manager.next_generation.fetch_add(1, Ordering::SeqCst);
-    let (single, reader, output_history, alive) = create_single_pty(cols, rows, generation)?;
+    let (single, reader, output_history, alive) =
+        create_single_pty(cols, rows, generation, Some(cwd.as_str()))?;
 
     let old_entry = {
         let mut panes = manager.panes.lock().map_err(|e| e.to_string())?;
@@ -1898,6 +1931,7 @@ impl PtyCommandTransport for TauriPtyTransport {
                 cols,
                 rows,
                 startup_input,
+                cwd,
             } => {
                 spawn_pty(
                     &self.app,
@@ -1905,6 +1939,7 @@ impl PtyCommandTransport for TauriPtyTransport {
                     *cols,
                     *rows,
                     startup_input.clone(),
+                    cwd.clone(),
                     "pty.spawn",
                 )?;
                 Ok(serde_json::json!({ "paneId": pane_id }))
@@ -2592,5 +2627,64 @@ mod tests {
             .browser_fallback
             .reason
             .contains("does not transcribe audio into text"));
+    }
+
+    #[test]
+    fn resolve_pty_workspace_dir_uses_repo_root_when_cwd_absent() {
+        let expected = resolve_repo_root().expect("repo root should resolve");
+        let resolved = resolve_pty_workspace_dir(None).expect("missing cwd should use repo root");
+        assert_eq!(resolved, expected);
+        let blank = resolve_pty_workspace_dir(Some("   ")).expect("blank cwd should use repo root");
+        assert_eq!(blank, expected);
+    }
+
+    #[test]
+    fn resolve_pty_workspace_dir_rejects_relative_cwd() {
+        let err = resolve_pty_workspace_dir(Some("relative/workspace"))
+            .expect_err("relative cwd must fail closed");
+        assert!(
+            err.contains("existing absolute directory"),
+            "unexpected relative cwd error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_pty_workspace_dir_rejects_missing_cwd() {
+        let missing = std::env::temp_dir().join(format!(
+            "winsmux-pty-cwd-missing-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&missing);
+        let err = resolve_pty_workspace_dir(Some(missing.to_string_lossy().as_ref()))
+            .expect_err("missing directory must fail closed");
+        assert!(
+            err.contains("existing absolute directory"),
+            "unexpected missing cwd error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_pty_workspace_dir_rejects_file_cwd() {
+        let file_path = std::env::temp_dir().join(format!(
+            "winsmux-pty-cwd-file-{}.txt",
+            std::process::id()
+        ));
+        std::fs::write(&file_path, "not-a-directory").expect("temp file should write");
+        let err = resolve_pty_workspace_dir(Some(file_path.to_string_lossy().as_ref()))
+            .expect_err("file cwd must fail closed");
+        let _ = std::fs::remove_file(&file_path);
+        assert!(
+            err.contains("existing absolute directory"),
+            "unexpected file cwd error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_pty_workspace_dir_accepts_existing_absolute_directory() {
+        let dir = make_temp_launch_project("pty-cwd-ok");
+        let resolved = resolve_pty_workspace_dir(Some(dir.to_string_lossy().as_ref()))
+            .expect("existing absolute directory should be accepted");
+        assert_eq!(resolved, dir);
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/winsmux-app/src-tauri/src/pty_backend.rs
+++ b/winsmux-app/src-tauri/src/pty_backend.rs
@@ -58,6 +58,7 @@ pub enum PtyCommand {
         cols: u16,
         rows: u16,
         startup_input: Option<String>,
+        cwd: Option<String>,
     },
     Write {
         pane_id: String,
@@ -132,6 +133,7 @@ fn parse_command(method: &str, params: Option<&Value>) -> Result<PtyCommand, Par
             cols: get_required_u16_param(params, &["cols"])?,
             rows: get_required_u16_param(params, &["rows"])?,
             startup_input: get_optional_string_param(params, &["startupInput", "startup_input"])?,
+            cwd: get_optional_string_param(params, &["cwd"])?,
         }),
         "pty.write" => Ok(PtyCommand::Write {
             pane_id: get_required_string_param(params, &["paneId", "pane_id"])?,
@@ -376,7 +378,8 @@ mod tests {
                 pane_id: "pane-1".to_string(),
                 cols: 120,
                 rows: 40,
-                startup_input: None
+                startup_input: None,
+                cwd: None
             }]
         );
     }
@@ -418,7 +421,52 @@ mod tests {
                 pane_id: "main".to_string(),
                 cols: 120,
                 rows: 40,
-                startup_input: Some("claude\r".to_string())
+                startup_input: Some("claude\r".to_string()),
+                cwd: None
+            }]
+        );
+    }
+
+    #[test]
+    fn handle_pty_json_rpc_routes_spawn_cwd() {
+        let transport = FakeTransport {
+            commands: RefCell::new(Vec::new()),
+            response: serde_json::json!({ "paneId": "fork-1" }),
+        };
+
+        let response = handle_pty_json_rpc(
+            &transport,
+            PtyJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-cwd"),
+                method: "pty.spawn".to_string(),
+                params: Some(serde_json::json!({
+                    "paneId": "fork-1",
+                    "cols": 80,
+                    "rows": 24,
+                    "startupInput": "codex\r",
+                    "cwd": "C:/proj"
+                })),
+            },
+        );
+
+        match response {
+            PtyJsonRpcResponse::Success { result, .. } => {
+                assert_eq!(result["paneId"], "fork-1");
+            }
+            PtyJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+
+        assert_eq!(
+            transport.commands.borrow().as_slice(),
+            [PtyCommand::Spawn {
+                pane_id: "fork-1".to_string(),
+                cols: 80,
+                rows: 24,
+                startup_input: Some("codex\r".to_string()),
+                cwd: Some("C:/proj".to_string())
             }]
         );
     }

--- a/winsmux-app/src/agentVaultOrganize.ts
+++ b/winsmux-app/src/agentVaultOrganize.ts
@@ -1,0 +1,436 @@
+export const AGENT_VAULT_ORGANIZE_STORAGE_KEY = "winsmux.agent-vault.organize.v1";
+
+export type AgentVaultOrganizeProviderId = "claude" | "codex" | "opencode";
+
+export interface AgentVaultOrganizeGroup {
+  id: string;
+  name: string;
+  sessionIds: string[];
+}
+
+export interface AgentVaultOrganizeFork {
+  id: string;
+  fromId: string;
+  workspaceKey: string;
+}
+
+export interface AgentVaultOrganizeState {
+  schema_version: 1;
+  archivedIds: string[];
+  groups: AgentVaultOrganizeGroup[];
+  forks: AgentVaultOrganizeFork[];
+}
+
+export interface AgentVaultOrganizeEntryRef {
+  id: string;
+  searchText?: string;
+  provider?: string;
+  workspaceKey?: string;
+  title?: string;
+}
+
+export type AgentVaultOrganizeMutationResult =
+  | { ok: true; state: AgentVaultOrganizeState }
+  | { ok: false; error: string };
+
+const TOP_LEVEL_KEYS = ["schema_version", "archivedIds", "groups", "forks"] as const;
+const GROUP_KEYS = ["id", "name", "sessionIds"] as const;
+const FORK_KEYS = ["id", "fromId", "workspaceKey"] as const;
+const GROUP_ID_PATTERN = /^grp_[A-Za-z0-9]+$/;
+const FORK_ID_PATTERN = /^fork_[A-Za-z0-9]+$/;
+const CONTROL_CHARS = /[\u0000-\u001f\u007f-\u009f]/;
+const RESUME_COMMAND_PATTERN =
+  /(?:^|[\s;&|])(?:claude\s+--resume|codex\s+resume|opencode\s+--session)(?:\s|$)/i;
+
+export function emptyAgentVaultOrganize(): AgentVaultOrganizeState {
+  return {
+    schema_version: 1,
+    archivedIds: [],
+    groups: [],
+    forks: [],
+  };
+}
+
+export function parseAgentVaultOrganizeJson(text: string | null | undefined): AgentVaultOrganizeState {
+  if (text == null || text.trim() === "") {
+    return emptyAgentVaultOrganize();
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("Agent Vault organize data is not valid JSON.");
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Agent Vault organize data must be an object.");
+  }
+
+  const record = parsed as Record<string, unknown>;
+  assertExactKeys(record, TOP_LEVEL_KEYS, "Agent Vault organize data");
+  if (record.schema_version !== 1) {
+    throw new Error("Agent Vault organize schema_version must be 1.");
+  }
+  if (!Array.isArray(record.archivedIds) || !Array.isArray(record.groups) || !Array.isArray(record.forks)) {
+    throw new Error("Agent Vault organize archivedIds, groups, and forks must be arrays.");
+  }
+
+  const archivedIds = record.archivedIds.map((id, index) => readSessionId(id, `archivedIds[${index}]`));
+  assertUniqueStrings(archivedIds, "archivedIds");
+
+  const groups = record.groups.map((item, index) => parseGroup(item, index));
+  const forks = record.forks.map((item, index) => parseFork(item, index));
+  assertUniqueStrings(groups.map((group) => group.id), "group id");
+  assertUniqueStrings(forks.map((fork) => fork.id), "fork id");
+  assertSessionInAtMostOneGroup(groups);
+
+  return {
+    schema_version: 1,
+    archivedIds,
+    groups,
+    forks,
+  };
+}
+
+export function serializeAgentVaultOrganize(state: AgentVaultOrganizeState): string {
+  const normalized = parseAgentVaultOrganizeJson(JSON.stringify({
+    schema_version: 1,
+    archivedIds: state.archivedIds,
+    groups: state.groups,
+    forks: state.forks,
+  }));
+  return JSON.stringify({
+    schema_version: 1,
+    archivedIds: normalized.archivedIds,
+    groups: normalized.groups.map((group) => ({
+      id: group.id,
+      name: group.name,
+      sessionIds: group.sessionIds,
+    })),
+    forks: normalized.forks.map((fork) => ({
+      id: fork.id,
+      fromId: fork.fromId,
+      workspaceKey: fork.workspaceKey,
+    })),
+  });
+}
+
+export function archiveSession(state: AgentVaultOrganizeState, sessionId: string): AgentVaultOrganizeMutationResult {
+  const id = readMutableSessionId(sessionId);
+  if (!id) {
+    return { ok: false, error: "Archive requires a vault session id." };
+  }
+  const next = cloneOrganizeState(state);
+  if (!next.archivedIds.includes(id)) {
+    next.archivedIds.push(id);
+  }
+  return { ok: true, state: next };
+}
+
+export function unarchiveSession(state: AgentVaultOrganizeState, sessionId: string): AgentVaultOrganizeMutationResult {
+  const id = readMutableSessionId(sessionId);
+  if (!id) {
+    return { ok: false, error: "Unarchive requires a vault session id." };
+  }
+  const next = cloneOrganizeState(state);
+  next.archivedIds = next.archivedIds.filter((item) => item !== id);
+  return { ok: true, state: next };
+}
+
+export function assignSessionToGroup(
+  state: AgentVaultOrganizeState,
+  sessionId: string,
+  name: string,
+): AgentVaultOrganizeMutationResult {
+  const id = readMutableSessionId(sessionId);
+  if (!id) {
+    return { ok: false, error: "Group requires a vault session id." };
+  }
+  const groupName = normalizeGroupName(name);
+  if (!groupName) {
+    return { ok: false, error: "Group name must be 1-64 visible characters." };
+  }
+
+  const next = cloneOrganizeState(state);
+  removeSessionFromGroups(next, id);
+  const existing = next.groups.find((group) => group.name === groupName);
+  if (existing) {
+    if (!existing.sessionIds.includes(id)) {
+      existing.sessionIds.push(id);
+    }
+    return { ok: true, state: next };
+  }
+
+  next.groups.push({
+    id: nextOrganizeId("grp", next.groups.map((group) => group.id)),
+    name: groupName,
+    sessionIds: [id],
+  });
+  return { ok: true, state: next };
+}
+
+export function removeSessionFromGroup(
+  state: AgentVaultOrganizeState,
+  sessionId: string,
+): AgentVaultOrganizeMutationResult {
+  const id = readMutableSessionId(sessionId);
+  if (!id) {
+    return { ok: false, error: "Remove from group requires a vault session id." };
+  }
+  const next = cloneOrganizeState(state);
+  removeSessionFromGroups(next, id);
+  return { ok: true, state: next };
+}
+
+export function recordFork(
+  state: AgentVaultOrganizeState,
+  fromId: string,
+  workspaceKey: string,
+): AgentVaultOrganizeMutationResult {
+  const sourceId = readMutableSessionId(fromId);
+  const key = readWorkspaceKey(workspaceKey);
+  if (!sourceId || !key) {
+    return { ok: false, error: "Fork requires a vault session id and workspace." };
+  }
+  const next = cloneOrganizeState(state);
+  next.forks.push({
+    id: nextOrganizeId("fork", next.forks.map((fork) => fork.id)),
+    fromId: sourceId,
+    workspaceKey: key,
+  });
+  return { ok: true, state: next };
+}
+
+export function isArchived(state: AgentVaultOrganizeState, sessionId: string): boolean {
+  return state.archivedIds.includes(sessionId);
+}
+
+export function groupNameForSession(state: AgentVaultOrganizeState, sessionId: string): string | null {
+  const group = state.groups.find((item) => item.sessionIds.includes(sessionId));
+  return group?.name ?? null;
+}
+
+export function visibleVaultEntryIds(
+  entries: Array<Pick<AgentVaultOrganizeEntryRef, "id">>,
+  organize: AgentVaultOrganizeState,
+  showArchived: boolean,
+): string[] {
+  return entries
+    .filter((entry) => showArchived || !isArchived(organize, entry.id))
+    .map((entry) => entry.id);
+}
+
+export function searchTextWithGroupName(
+  entry: Pick<AgentVaultOrganizeEntryRef, "id" | "searchText">,
+  organize: AgentVaultOrganizeState,
+): string {
+  const groupName = groupNameForSession(organize, entry.id);
+  return [entry.searchText ?? "", groupName ?? ""].join(" ").trim().toLowerCase();
+}
+
+export function quotePowerShellArgument(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+export function buildAgentVaultResumeCommand(provider: string, resumeId: string): string {
+  const safeResumeId = normalizeResumeId(resumeId);
+  if (!safeResumeId) {
+    return "";
+  }
+  switch (provider) {
+    case "claude":
+      return `claude --resume ${quotePowerShellArgument(safeResumeId)}`;
+    case "codex":
+      return `codex resume ${quotePowerShellArgument(safeResumeId)}`;
+    case "opencode":
+      return `opencode --session ${quotePowerShellArgument(safeResumeId)}`;
+    default:
+      return "";
+  }
+}
+
+export function buildAgentVaultForkLaunchCommand(provider: string): string {
+  switch (provider) {
+    case "claude":
+      return "claude";
+    case "codex":
+      return "codex";
+    case "opencode":
+      return "opencode";
+    default:
+      return "";
+  }
+}
+
+export function isResumeCommand(command: string): boolean {
+  const normalized = command.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return false;
+  }
+  return RESUME_COMMAND_PATTERN.test(` ${normalized} `);
+}
+
+export function loadAgentVaultOrganize(
+  rawValue: string | null | undefined,
+  previous: AgentVaultOrganizeState = emptyAgentVaultOrganize(),
+): { state: AgentVaultOrganizeState; error: string | null } {
+  try {
+    return { state: parseAgentVaultOrganizeJson(rawValue), error: null };
+  } catch {
+    return {
+      state: previous,
+      error: "Agent Vault organize data was rejected. Previous state was kept.",
+    };
+  }
+}
+
+export function normalizeGroupName(value: unknown): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const trimmed = value.trim();
+  if (!trimmed || CONTROL_CHARS.test(trimmed)) {
+    return "";
+  }
+  if ([...trimmed].length > 64) {
+    return "";
+  }
+  return trimmed;
+}
+
+function parseGroup(value: unknown, index: number): AgentVaultOrganizeGroup {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`groups[${index}] must be an object.`);
+  }
+  const record = value as Record<string, unknown>;
+  assertExactKeys(record, GROUP_KEYS, `groups[${index}]`);
+  if (typeof record.id !== "string" || !GROUP_ID_PATTERN.test(record.id)) {
+    throw new Error(`groups[${index}].id is invalid.`);
+  }
+  const name = normalizeGroupName(record.name);
+  if (!name) {
+    throw new Error(`groups[${index}].name is invalid.`);
+  }
+  if (!Array.isArray(record.sessionIds)) {
+    throw new Error(`groups[${index}].sessionIds must be an array.`);
+  }
+  const sessionIds = record.sessionIds.map((id, sessionIndex) => (
+    readSessionId(id, `groups[${index}].sessionIds[${sessionIndex}]`)
+  ));
+  assertUniqueStrings(sessionIds, `groups[${index}].sessionIds`);
+  return { id: record.id, name, sessionIds };
+}
+
+function parseFork(value: unknown, index: number): AgentVaultOrganizeFork {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`forks[${index}] must be an object.`);
+  }
+  const record = value as Record<string, unknown>;
+  assertExactKeys(record, FORK_KEYS, `forks[${index}]`);
+  if (typeof record.id !== "string" || !FORK_ID_PATTERN.test(record.id)) {
+    throw new Error(`forks[${index}].id is invalid.`);
+  }
+  const workspaceKey = readWorkspaceKey(record.workspaceKey);
+  if (!workspaceKey) {
+    throw new Error(`forks[${index}].workspaceKey is invalid.`);
+  }
+  return {
+    id: record.id,
+    fromId: readSessionId(record.fromId, `forks[${index}].fromId`),
+    workspaceKey,
+  };
+}
+
+function assertExactKeys(record: Record<string, unknown>, allowed: readonly string[], label: string) {
+  const keys = Object.keys(record);
+  if (keys.length !== allowed.length || allowed.some((key) => !keys.includes(key))) {
+    throw new Error(`${label} must contain only ${allowed.join(", ")}.`);
+  }
+}
+
+function assertUniqueStrings(values: string[], label: string) {
+  if (new Set(values).size !== values.length) {
+    throw new Error(`${label} must not contain duplicates.`);
+  }
+}
+
+function assertSessionInAtMostOneGroup(groups: AgentVaultOrganizeGroup[]) {
+  const seen = new Set<string>();
+  for (const group of groups) {
+    for (const sessionId of group.sessionIds) {
+      if (seen.has(sessionId)) {
+        throw new Error("A session id may belong to at most one group.");
+      }
+      seen.add(sessionId);
+    }
+  }
+}
+
+function readSessionId(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value.trim() || CONTROL_CHARS.test(value)) {
+    throw new Error(`${label} must be a vault session id.`);
+  }
+  return value;
+}
+
+function readMutableSessionId(value: string): string {
+  const normalized = value.trim();
+  if (!normalized || CONTROL_CHARS.test(normalized)) {
+    return "";
+  }
+  return normalized;
+}
+
+function readWorkspaceKey(value: unknown): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const normalized = value.trim();
+  if (!normalized || CONTROL_CHARS.test(normalized) || normalized.length > 1024) {
+    return "";
+  }
+  return normalized;
+}
+
+function normalizeResumeId(value: string): string {
+  const normalized = value.replace(/[\u0000-\u001f\u007f]/g, " ").replace(/\s+/g, " ").trim();
+  if (!normalized || normalized.length > 512) {
+    return "";
+  }
+  return normalized;
+}
+
+function cloneOrganizeState(state: AgentVaultOrganizeState): AgentVaultOrganizeState {
+  return {
+    schema_version: 1,
+    archivedIds: [...state.archivedIds],
+    groups: state.groups.map((group) => ({
+      id: group.id,
+      name: group.name,
+      sessionIds: [...group.sessionIds],
+    })),
+    forks: state.forks.map((fork) => ({
+      id: fork.id,
+      fromId: fork.fromId,
+      workspaceKey: fork.workspaceKey,
+    })),
+  };
+}
+
+function removeSessionFromGroups(state: AgentVaultOrganizeState, sessionId: string) {
+  for (const group of state.groups) {
+    group.sessionIds = group.sessionIds.filter((id) => id !== sessionId);
+  }
+}
+
+function nextOrganizeId(prefix: "grp" | "fork", existingIds: string[]): string {
+  const existing = new Set(existingIds);
+  for (let index = 1; index < 10000; index += 1) {
+    const id = `${prefix}_${String(index).padStart(2, "0")}`;
+    if (!existing.has(id)) {
+      return id;
+    }
+  }
+  throw new Error("Could not allocate an organize id.");
+}

--- a/winsmux-app/src/agentVaultOrganize.ts
+++ b/winsmux-app/src/agentVaultOrganize.ts
@@ -434,3 +434,96 @@ function nextOrganizeId(prefix: "grp" | "fork", existingIds: string[]): string {
   }
   throw new Error("Could not allocate an organize id.");
 }
+
+export function persistAgentVaultOrganizeToStorage(
+  storage: Pick<Storage, "setItem"> | null | undefined,
+  state: AgentVaultOrganizeState,
+): { ok: true } | { ok: false; error: string } {
+  if (!storage) {
+    return { ok: false, error: "Agent Vault organize data could not be saved." };
+  }
+  try {
+    storage.setItem(AGENT_VAULT_ORGANIZE_STORAGE_KEY, serializeAgentVaultOrganize(state));
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Agent Vault organize data could not be saved." };
+  }
+}
+
+export function partitionEntriesByUserGroup<T extends { id: string }>(
+  entries: T[],
+  organize: AgentVaultOrganizeState,
+): { groups: Array<{ id: string; name: string; entries: T[] }>; ungrouped: T[] } {
+  const groupedIds = new Set<string>();
+  const groups: Array<{ id: string; name: string; entries: T[] }> = [];
+  for (const group of organize.groups) {
+    const members = entries.filter((entry) => group.sessionIds.includes(entry.id));
+    if (members.length === 0) {
+      continue;
+    }
+    for (const member of members) {
+      groupedIds.add(member.id);
+    }
+    groups.push({ id: group.id, name: group.name, entries: members });
+  }
+  return {
+    groups,
+    ungrouped: entries.filter((entry) => !groupedIds.has(entry.id)),
+  };
+}
+
+export function createAgentVaultActionButton(
+  label: string,
+  disabled: boolean,
+  onClick: (event: MouseEvent) => void,
+): HTMLButtonElement {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "agent-vault-action";
+  button.textContent = label;
+  button.disabled = disabled;
+  button.addEventListener("click", onClick);
+  return button;
+}
+
+export function appendAgentVaultOrganizeActions(
+  actions: HTMLElement,
+  options: {
+    archived: boolean;
+    forkDisabled: boolean;
+    labels: { archive: string; unarchive: string; group: string; fork: string };
+    onArchive: (event: MouseEvent) => void;
+    onGroup: (event: MouseEvent) => void;
+    onFork: (event: MouseEvent) => void;
+  },
+): void {
+  actions.append(
+    createAgentVaultActionButton(
+      options.archived ? options.labels.unarchive : options.labels.archive,
+      false,
+      options.onArchive,
+    ),
+    createAgentVaultActionButton(options.labels.group, false, options.onGroup),
+    createAgentVaultActionButton(options.labels.fork, options.forkDisabled, options.onFork),
+  );
+}
+
+export function ensureAgentVaultShowArchivedToggle(
+  parent: HTMLElement | null,
+  options: { pressed: boolean; label: string; onToggle: () => void },
+): void {
+  if (!parent) {
+    return;
+  }
+  let button = parent.querySelector("#agent-vault-show-archived") as HTMLButtonElement | null;
+  if (!button) {
+    button = document.createElement("button");
+    button.id = "agent-vault-show-archived";
+    button.type = "button";
+    button.className = "agent-vault-filter-btn";
+    button.addEventListener("click", options.onToggle);
+    parent.appendChild(button);
+  }
+  button.textContent = options.label;
+  button.setAttribute("aria-pressed", options.pressed ? "true" : "false");
+}

--- a/winsmux-app/src/agentVaultOrganize.ts
+++ b/winsmux-app/src/agentVaultOrganize.ts
@@ -294,6 +294,25 @@ export function resolveAgentVaultLaunchDirectory(workspacePath: string, baseDir:
   return segments.length === 0 ? baseNormalized : `${baseNormalized}/${segments.join("/")}`;
 }
 
+export function shouldQueueAgentVaultLaunchCwd(mode: "resume" | "fork", launchCwd: string): boolean {
+  return mode === "fork" && launchCwd !== "";
+}
+
+export function applyAgentVaultGroupPrompt(
+  state: AgentVaultOrganizeState,
+  sessionId: string,
+  name: string,
+): AgentVaultOrganizeMutationResult {
+  if (name.trim() === "") {
+    return removeSessionFromGroup(state, sessionId);
+  }
+  const groupName = normalizeGroupName(name);
+  if (!groupName) {
+    return { ok: false, error: "Group name must be 1-64 visible characters." };
+  }
+  return assignSessionToGroup(state, sessionId, groupName);
+}
+
 export function normalizeAgentVaultText(value: string | null | undefined, fallback = ""): string {
   const normalized = (value ?? "")
     .replace(/[\u0000-\u001f\u007f]/g, " ")

--- a/winsmux-app/src/agentVaultOrganize.ts
+++ b/winsmux-app/src/agentVaultOrganize.ts
@@ -183,13 +183,24 @@ export function removeSessionFromGroup(
   return { ok: true, state: next };
 }
 
+export function persistableAgentVaultWorkspaceKey(key: string): string {
+  const normalized = (key ?? "").trim();
+  if (normalized === "__this_project__" || normalized === "unknown" || normalized === "workspace") {
+    return normalized;
+  }
+  if (!normalized) {
+    return "";
+  }
+  return "workspace";
+}
+
 export function recordFork(
   state: AgentVaultOrganizeState,
   fromId: string,
   workspaceKey: string,
 ): AgentVaultOrganizeMutationResult {
   const sourceId = readMutableSessionId(fromId);
-  const key = readWorkspaceKey(workspaceKey);
+  const key = persistableAgentVaultWorkspaceKey(readWorkspaceKey(workspaceKey));
   if (!sourceId || !key) {
     return { ok: false, error: "Fork requires a vault session id and workspace." };
   }
@@ -612,7 +623,7 @@ function parseFork(value: unknown, index: number): AgentVaultOrganizeFork {
   if (typeof record.id !== "string" || !FORK_ID_PATTERN.test(record.id)) {
     throw new Error(`forks[${index}].id is invalid.`);
   }
-  const workspaceKey = readWorkspaceKey(record.workspaceKey);
+  const workspaceKey = persistableAgentVaultWorkspaceKey(readWorkspaceKey(record.workspaceKey));
   if (!workspaceKey) {
     throw new Error(`forks[${index}].workspaceKey is invalid.`);
   }

--- a/winsmux-app/src/agentVaultOrganize.ts
+++ b/winsmux-app/src/agentVaultOrganize.ts
@@ -263,6 +263,268 @@ export function buildAgentVaultForkLaunchCommand(provider: string): string {
   }
 }
 
+export function isAbsoluteAgentVaultLaunchPath(value: string): boolean {
+  const raw = value.trim();
+  if (!raw) {
+    return false;
+  }
+  return /^[A-Za-z]:[\\/]/.test(raw) || raw.startsWith("\\\\") || raw.startsWith("//") || raw.startsWith("/");
+}
+
+export function resolveAgentVaultLaunchDirectory(workspacePath: string, baseDir: string): string {
+  const raw = (workspacePath ?? "").trim();
+  const base = (baseDir ?? "").trim();
+  if (raw.startsWith("workspace:")) {
+    return "";
+  }
+  if (!raw || raw === "__this_project__") {
+    return isAbsoluteAgentVaultLaunchPath(base) ? base : "";
+  }
+  if (isAbsoluteAgentVaultLaunchPath(raw)) {
+    return raw;
+  }
+  if (!isAbsoluteAgentVaultLaunchPath(base)) {
+    return "";
+  }
+  const segments = raw.split(/[\\/]+/).filter((part) => part.length > 0 && part !== ".");
+  if (segments.some((part) => part === "..")) {
+    return "";
+  }
+  const baseNormalized = base.replace(/[\\/]+$/, "").replace(/\\/g, "/");
+  return segments.length === 0 ? baseNormalized : `${baseNormalized}/${segments.join("/")}`;
+}
+
+export function normalizeAgentVaultText(value: string | null | undefined, fallback = ""): string {
+  const normalized = (value ?? "")
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return normalized || fallback;
+}
+
+export function sanitizeAgentVaultDisplayText(value: string | null | undefined, fallback = ""): string {
+  return normalizeAgentVaultText(value, fallback)
+    .replace(/[A-Za-z]:[\\/][^\s"'<>]+/g, "[local path]")
+    .replace(/\\\\[^\s"'<>]+/g, "[network path]");
+}
+
+export function truncateAgentVaultText(value: string, limit = 128): string {
+  const normalized = sanitizeAgentVaultDisplayText(value);
+  return normalized.length > limit ? `${normalized.slice(0, limit - 1)}…` : normalized;
+}
+
+function normalizeVaultPath(value: string | null | undefined): string {
+  return (value ?? "").trim().replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+export function getAgentVaultWorkspaceKey(
+  path: string | null | undefined,
+  snapshotProjectDir?: string | null,
+  activeProjectDir?: string | null,
+): string {
+  const normalized = normalizeVaultPath(path);
+  const active = normalizeVaultPath(activeProjectDir) || normalizeVaultPath(snapshotProjectDir);
+  if (!normalized) {
+    return "unknown";
+  }
+  if (active && normalized.toLowerCase() === active.toLowerCase()) {
+    return "__this_project__";
+  }
+  return `workspace:${normalized.toLowerCase()}`;
+}
+
+export function getAgentVaultWorkspaceLabel(
+  path: string | null | undefined,
+  snapshotProjectDir: string | null | undefined,
+  activeProjectDir: string | null | undefined,
+  labels: { unknown: string; thisProject: string; workspace: string },
+): string {
+  const normalized = normalizeVaultPath(path);
+  const active = normalizeVaultPath(activeProjectDir) || normalizeVaultPath(snapshotProjectDir);
+  if (!normalized) {
+    return labels.unknown;
+  }
+  if (active && normalized.toLowerCase() === active.toLowerCase()) {
+    return labels.thisProject;
+  }
+  const parts = normalized.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] ?? labels.workspace;
+}
+
+export function isAgentVaultThisProject(
+  path: string | null | undefined,
+  snapshotProjectDir?: string | null,
+  activeProjectDir?: string | null,
+): boolean {
+  const normalized = normalizeVaultPath(path);
+  const active = normalizeVaultPath(activeProjectDir) || normalizeVaultPath(snapshotProjectDir);
+  return Boolean(normalized && active && normalized.toLowerCase() === active.toLowerCase());
+}
+
+export function inferAgentVaultProvider(...values: string[]): AgentVaultOrganizeProviderId {
+  const text = values.join(" ").toLowerCase();
+  if (text.includes("opencode") || text.includes("open code")) {
+    return "opencode";
+  }
+  if (text.includes("codex")) {
+    return "codex";
+  }
+  return "claude";
+}
+
+export function getAgentVaultReviewTone(reviewState: string, state: string): "danger" | "warning" | "success" | "info" {
+  const review = reviewState.toUpperCase();
+  const normalizedState = state.toLowerCase();
+  if (review === "FAIL" || review === "FAILED" || normalizedState.includes("blocked")) {
+    return "danger";
+  }
+  if (review === "PENDING" || normalizedState.includes("waiting")) {
+    return "warning";
+  }
+  if (review === "PASS" || normalizedState.includes("ready")) {
+    return "success";
+  }
+  return "info";
+}
+
+export function formatAgentVaultLastSeen(
+  entryTime: string | null | undefined,
+  fallbackTime: string | null | undefined,
+  unseenLabel: string,
+): string {
+  const timestamp = normalizeAgentVaultText(entryTime || fallbackTime || "");
+  if (!timestamp) {
+    return unseenLabel;
+  }
+  const parsed = Date.parse(timestamp);
+  if (Number.isNaN(parsed)) {
+    return timestamp;
+  }
+  return new Date(parsed).toLocaleString([], {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function buildAgentVaultSearchText(entry: {
+  id: string;
+  provider: string;
+  title: string;
+  workspaceLabel: string;
+  resumeId: string;
+  paneId: string;
+  runId: string;
+  state: string;
+  reviewState: string;
+  summary: string;
+  providerLabel?: string;
+}): string {
+  return [
+    entry.id,
+    entry.provider,
+    entry.providerLabel ?? "",
+    entry.title,
+    entry.workspaceLabel,
+    entry.resumeId,
+    entry.paneId,
+    entry.runId,
+    entry.state,
+    entry.reviewState,
+    entry.summary,
+  ].join(" ").toLowerCase();
+}
+
+export function createAgentVaultChip(label: string, value: string, tone?: string): HTMLSpanElement {
+  const chip = document.createElement("span");
+  chip.className = "agent-vault-chip";
+  if (tone) {
+    chip.dataset.tone = tone;
+  }
+  chip.textContent = `${label}: ${value}`;
+  return chip;
+}
+
+export function appendAgentVaultSessionGroup<T>(
+  list: HTMLElement,
+  key: string,
+  label: string,
+  groupEntries: T[],
+  collapsed: boolean,
+  onToggle: () => void,
+  renderCard: (entry: T) => HTMLElement,
+): void {
+  const group = document.createElement("section");
+  group.className = "agent-vault-provider-group";
+  group.dataset.groupKey = key;
+  group.dataset.collapsed = collapsed ? "true" : "false";
+  const heading = document.createElement("button");
+  heading.type = "button";
+  heading.className = "agent-vault-provider-heading";
+  heading.setAttribute("aria-expanded", collapsed ? "false" : "true");
+  heading.addEventListener("click", onToggle);
+  const title = document.createElement("span");
+  title.textContent = label;
+  const count = document.createElement("span");
+  count.className = "agent-vault-provider-count";
+  count.textContent = `${groupEntries.length}`;
+  heading.append(title, count);
+  group.appendChild(heading);
+  if (!collapsed) {
+    for (const entry of groupEntries) {
+      group.appendChild(renderCard(entry));
+    }
+  }
+  list.appendChild(group);
+}
+
+export function getAgentVaultNotificationTone(feedEntries: Array<{ tone: string }>): "danger" | "warning" | "info" {
+  if (feedEntries.some((entry) => entry.tone === "danger")) {
+    return "danger";
+  }
+  if (feedEntries.some((entry) => entry.tone === "warning")) {
+    return "warning";
+  }
+  return "info";
+}
+
+export function renderAgentVaultWorkspaceFilter<T extends { workspaceKey: string; workspaceLabel: string }>(
+  root: HTMLSelectElement,
+  entries: T[],
+  selected: string,
+  allLabel: string,
+): string {
+  const workspaceCounts = new Map<string, { label: string; count: number }>();
+  for (const entry of entries) {
+    const current = workspaceCounts.get(entry.workspaceKey);
+    if (current) {
+      current.count += 1;
+    } else {
+      workspaceCounts.set(entry.workspaceKey, { label: entry.workspaceLabel, count: 1 });
+    }
+  }
+  let nextSelected = selected;
+  if (nextSelected !== "all" && !workspaceCounts.has(nextSelected)) {
+    nextSelected = "all";
+  }
+  root.replaceChildren();
+  const allOption = document.createElement("option");
+  allOption.value = "all";
+  allOption.textContent = allLabel;
+  root.appendChild(allOption);
+  const workspaces = Array.from(workspaceCounts.entries())
+    .sort((left, right) => left[1].label.localeCompare(right[1].label));
+  for (const [key, workspace] of workspaces) {
+    const option = document.createElement("option");
+    option.value = key;
+    option.textContent = `${workspace.label} (${workspace.count})`;
+    root.appendChild(option);
+  }
+  root.value = nextSelected;
+  return nextSelected;
+}
+
 export function isResumeCommand(command: string): boolean {
   const normalized = command.replace(/\s+/g, " ").trim();
   if (!normalized) {

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -119,6 +119,7 @@ import {
   maybeStartFirstRunOnboarding,
   renderFirstRunWizard,
 } from "./firstRunWizard";
+import * as vaultOrganize from "./agentVaultOrganize";
 
 interface PaneEntry {
   terminal: Terminal;
@@ -680,7 +681,10 @@ let agentVaultProviderFilter: AgentVaultProviderFilter = "all";
 let agentVaultWorkspaceFilter = "all";
 let agentVaultStatusMessage = "";
 let selectedAgentVaultSessionId = "";
+let agentVaultOrganizeState = vaultOrganize.emptyAgentVaultOrganize();
+let agentVaultShowArchived = false;
 const agentVaultCollapsedProviderIds = new Set<AgentVaultProviderId>();
+const agentVaultCollapsedGroupIds = new Set<string>();
 let workbenchLayout: WorkbenchLayoutMode = "3x2";
 let focusedWorkbenchPaneId: string | null = null;
 let composerImeActive = false;
@@ -2892,6 +2896,62 @@ function persistAgentVaultPreferences() {
   }
 }
 
+function persistAgentVaultOrganizeState(next: vaultOrganize.AgentVaultOrganizeState) {
+  const saved = vaultOrganize.persistAgentVaultOrganizeToStorage(window.localStorage, next);
+  if (!saved.ok) {
+    agentVaultStatusMessage = getLanguageText(saved.error, "Agent Vault の整理データを保存できませんでした。");
+    return false;
+  }
+  agentVaultOrganizeState = next;
+  return true;
+}
+
+function applyAgentVaultOrganizeMutation(result: vaultOrganize.AgentVaultOrganizeMutationResult, okStatus?: string) {
+  if (!result.ok) {
+    agentVaultStatusMessage = getLanguageText(result.error, result.error);
+    renderAgentVaultPanel();
+    return false;
+  }
+  if (!persistAgentVaultOrganizeState(result.state)) {
+    renderAgentVaultPanel();
+    return false;
+  }
+  if (okStatus) {
+    agentVaultStatusMessage = okStatus;
+  }
+  renderAgentVaultPanel();
+  return true;
+}
+
+function toggleAgentVaultShowArchived() {
+  agentVaultShowArchived = !agentVaultShowArchived;
+  renderAgentVaultPanel();
+}
+
+function toggleAgentVaultArchive(entry: AgentVaultSessionEntry) {
+  const archived = vaultOrganize.isArchived(agentVaultOrganizeState, entry.id);
+  applyAgentVaultOrganizeMutation(
+    archived
+      ? vaultOrganize.unarchiveSession(agentVaultOrganizeState, entry.id)
+      : vaultOrganize.archiveSession(agentVaultOrganizeState, entry.id),
+    archived
+      ? getLanguageText(`Unarchived ${entry.title}.`, `${entry.title} のアーカイブを解除しました。`)
+      : getLanguageText(`Archived ${entry.title}.`, `${entry.title} をアーカイブしました。`),
+  );
+}
+
+function groupAgentVaultSession(entry: AgentVaultSessionEntry) {
+  const current = vaultOrganize.groupNameForSession(agentVaultOrganizeState, entry.id) ?? "";
+  const name = window.prompt(getLanguageText("Group name (1-64 characters)", "グループ名（1～64文字）"), current);
+  if (name === null) {
+    return;
+  }
+  applyAgentVaultOrganizeMutation(
+    vaultOrganize.assignSessionToGroup(agentVaultOrganizeState, entry.id, name),
+    getLanguageText(`Grouped ${entry.title}.`, `${entry.title} をグループに入れました。`),
+  );
+}
+
 function normalizeAgentVaultText(value: string | null | undefined, fallback = "") {
   const normalized = (value ?? "")
     .replace(/[\u0000-\u001f\u007f]/g, " ")
@@ -3083,7 +3143,12 @@ function buildAgentVaultEntries() {
 
 function getVisibleAgentVaultEntries() {
   const query = agentVaultQuery.trim().toLowerCase();
-  return buildAgentVaultEntries().filter((entry) => {
+  const allEntries = buildAgentVaultEntries();
+  const visibleIds = new Set(vaultOrganize.visibleVaultEntryIds(allEntries, agentVaultOrganizeState, agentVaultShowArchived));
+  return allEntries.filter((entry) => {
+    if (!visibleIds.has(entry.id)) {
+      return false;
+    }
     if (agentVaultProjectOnly && !entry.thisProject) {
       return false;
     }
@@ -3093,7 +3158,8 @@ function getVisibleAgentVaultEntries() {
     if (agentVaultWorkspaceFilter !== "all" && entry.workspaceKey !== agentVaultWorkspaceFilter) {
       return false;
     }
-    return !query || entry.searchText.includes(query);
+    const searchText = vaultOrganize.searchTextWithGroupName(entry, agentVaultOrganizeState);
+    return !query || searchText.includes(query);
   });
 }
 
@@ -3212,6 +3278,38 @@ function renderAgentVaultWorkspaceFilter(root: HTMLSelectElement, entries: Agent
   root.value = agentVaultWorkspaceFilter;
 }
 
+function appendAgentVaultSessionGroup(
+  list: HTMLElement,
+  key: string,
+  label: string,
+  groupEntries: AgentVaultSessionEntry[],
+  collapsed: boolean,
+  onToggle: () => void,
+) {
+  const group = document.createElement("section");
+  group.className = "agent-vault-provider-group";
+  group.dataset.groupKey = key;
+  group.dataset.collapsed = collapsed ? "true" : "false";
+  const heading = document.createElement("button");
+  heading.type = "button";
+  heading.className = "agent-vault-provider-heading";
+  heading.setAttribute("aria-expanded", collapsed ? "false" : "true");
+  heading.addEventListener("click", onToggle);
+  const title = document.createElement("span");
+  title.textContent = label;
+  const count = document.createElement("span");
+  count.className = "agent-vault-provider-count";
+  count.textContent = `${groupEntries.length}`;
+  heading.append(title, count);
+  group.appendChild(heading);
+  if (!collapsed) {
+    for (const entry of groupEntries) {
+      group.appendChild(renderAgentVaultSessionCard(entry));
+    }
+  }
+  list.appendChild(group);
+}
+
 function renderAgentVaultPanel() {
   const panel = document.getElementById("agent-vault-panel");
   if (!panel) {
@@ -3258,6 +3356,14 @@ function renderAgentVaultPanel() {
   if (providerFilters) {
     renderAgentVaultProviderFilters(providerFilters, allEntries);
   }
+  vaultOrganize.ensureAgentVaultShowArchivedToggle(
+    document.querySelector(".agent-vault-search-controls"),
+    {
+      pressed: agentVaultShowArchived,
+      label: getLanguageText("Show archived", "アーカイブを表示"),
+      onToggle: toggleAgentVaultShowArchived,
+    },
+  );
   if (status) {
     status.textContent = agentVaultStatusMessage || getLanguageText("Drag a session card onto a worker pane, or restore it into a new pane.", "セッションカードをワーカーペインへドラッグするか、新しいペインへ復元できます。");
   }
@@ -3271,20 +3377,23 @@ function renderAgentVaultPanel() {
         : getLanguageText("No sessions match the current filters.", "現在の条件に一致するセッションはありません。");
       list.appendChild(empty);
     } else {
+      const partitioned = vaultOrganize.partitionEntriesByUserGroup(visibleEntries, agentVaultOrganizeState);
+      for (const userGroup of partitioned.groups) {
+        appendAgentVaultSessionGroup(list, userGroup.id, userGroup.name, userGroup.entries, agentVaultCollapsedGroupIds.has(userGroup.id), () => {
+          if (agentVaultCollapsedGroupIds.has(userGroup.id)) {
+            agentVaultCollapsedGroupIds.delete(userGroup.id);
+          } else {
+            agentVaultCollapsedGroupIds.add(userGroup.id);
+          }
+          renderAgentVaultPanel();
+        });
+      }
       for (const provider of agentVaultProviders) {
-        const providerEntries = visibleEntries.filter((entry) => entry.provider === provider.id);
+        const providerEntries = partitioned.ungrouped.filter((entry) => entry.provider === provider.id);
         if (providerEntries.length === 0) {
           continue;
         }
-        const collapsed = agentVaultCollapsedProviderIds.has(provider.id);
-        const group = document.createElement("section");
-        group.className = "agent-vault-provider-group";
-        group.dataset.collapsed = collapsed ? "true" : "false";
-        const heading = document.createElement("button");
-        heading.type = "button";
-        heading.className = "agent-vault-provider-heading";
-        heading.setAttribute("aria-expanded", collapsed ? "false" : "true");
-        heading.addEventListener("click", () => {
+        appendAgentVaultSessionGroup(list, provider.id, getAgentVaultProviderLabel(provider.id), providerEntries, agentVaultCollapsedProviderIds.has(provider.id), () => {
           if (agentVaultCollapsedProviderIds.has(provider.id)) {
             agentVaultCollapsedProviderIds.delete(provider.id);
           } else {
@@ -3293,19 +3402,6 @@ function renderAgentVaultPanel() {
           persistAgentVaultPreferences();
           renderAgentVaultPanel();
         });
-        const label = document.createElement("span");
-        label.textContent = getAgentVaultProviderLabel(provider.id);
-        const count = document.createElement("span");
-        count.className = "agent-vault-provider-count";
-        count.textContent = `${providerEntries.length}`;
-        heading.append(label, count);
-        group.appendChild(heading);
-        if (!collapsed) {
-          for (const entry of providerEntries) {
-            group.appendChild(renderAgentVaultSessionCard(entry));
-          }
-        }
-        list.appendChild(group);
       }
     }
   }
@@ -3362,6 +3458,7 @@ function renderAgentVaultSessionCard(entry: AgentVaultSessionEntry) {
   card.tabIndex = 0;
   card.dataset.sessionId = entry.id;
   card.dataset.selected = selectedAgentVaultSessionId === entry.id ? "true" : "false";
+  card.dataset.archived = vaultOrganize.isArchived(agentVaultOrganizeState, entry.id) ? "true" : "false";
   card.setAttribute("aria-label", getLanguageText(`Agent Vault session ${entry.title}`, `Agent Vault セッション ${entry.title}`));
 
   card.addEventListener("dragstart", (event) => {
@@ -3433,45 +3530,54 @@ function renderAgentVaultSessionCard(entry: AgentVaultSessionEntry) {
     void restoreAgentVaultSession(entry.id, getFocusedWorkbenchPaneId() ?? undefined);
   });
   actions.append(newPane, focusedPane);
+  vaultOrganize.appendAgentVaultOrganizeActions(actions, {
+    archived: vaultOrganize.isArchived(agentVaultOrganizeState, entry.id),
+    forkDisabled: panes.size >= MAX_WORKBENCH_PANES,
+    labels: {
+      archive: getLanguageText("Archive", "アーカイブ"),
+      unarchive: getLanguageText("Unarchive", "アーカイブ解除"),
+      group: getLanguageText("Group", "グループ"),
+      fork: getLanguageText("Fork", "フォーク"),
+    },
+    onArchive: (event) => {
+      event.stopPropagation();
+      toggleAgentVaultArchive(entry);
+    },
+    onGroup: (event) => {
+      event.stopPropagation();
+      groupAgentVaultSession(entry);
+    },
+    onFork: (event) => {
+      event.stopPropagation();
+      void forkAgentVaultSession(entry.id);
+    },
+  });
   card.append(title, summary, meta, actions);
   return card;
 }
 
-function quotePowerShellArgument(value: string) {
-  return `'${value.replace(/'/g, "''")}'`;
+async function forkAgentVaultSession(entryId: string) {
+  await restoreAgentVaultSession(entryId, undefined, "fork");
 }
 
-function getSafeAgentVaultResumeId(entry: AgentVaultSessionEntry) {
-  const resumeId = normalizeAgentVaultText(entry.resumeId);
-  if (!resumeId || resumeId.length > 512 || /[\u0000-\u001f\u007f]/.test(resumeId)) {
-    return "";
-  }
-  return resumeId;
-}
-
-function buildAgentVaultResumeCommand(entry: AgentVaultSessionEntry) {
-  const resumeId = getSafeAgentVaultResumeId(entry);
-  if (!resumeId) {
-    return "";
-  }
-  switch (entry.provider) {
-    case "claude":
-      return `claude --resume ${quotePowerShellArgument(resumeId)}`;
-    case "codex":
-      return `codex resume ${quotePowerShellArgument(resumeId)}`;
-    case "opencode":
-      return `opencode --session ${quotePowerShellArgument(resumeId)}`;
-  }
-}
-
-async function restoreAgentVaultSession(entryId: string, targetPaneId?: string) {
+async function restoreAgentVaultSession(entryId: string, targetPaneId?: string, mode: "resume" | "fork" = "resume") {
   const entry = buildAgentVaultEntries().find((item) => item.id === entryId);
   if (!entry) {
     agentVaultStatusMessage = getLanguageText("Session metadata is no longer available.", "セッションメタデータが見つかりません。");
     renderAgentVaultPanel();
     return;
   }
-  const command = buildAgentVaultResumeCommand(entry);
+  const command = mode === "fork"
+    ? vaultOrganize.buildAgentVaultForkLaunchCommand(entry.provider)
+    : vaultOrganize.buildAgentVaultResumeCommand(entry.provider, entry.resumeId);
+  if (mode === "fork" && (!command || vaultOrganize.isResumeCommand(command))) {
+    agentVaultStatusMessage = getLanguageText(
+      "Fork could not start a fresh worker for this provider.",
+      "このプロバイダーの新規ワーカーを起動できません。",
+    );
+    renderAgentVaultPanel();
+    return;
+  }
   if (!command) {
     const rejectedId = entry.resumeId ? entry.resumeId.slice(0, 32) : "empty";
     agentVaultStatusMessage = getLanguageText(
@@ -3482,12 +3588,24 @@ async function restoreAgentVaultSession(entryId: string, targetPaneId?: string) 
     return;
   }
   if (!targetPaneId && panes.size >= MAX_WORKBENCH_PANES) {
-    agentVaultStatusMessage = getLanguageText(
-      `Resume ${entry.resumeId.slice(0, 32)} could not create a new pane: maximum pane count reached.`,
-      `再開 ID ${entry.resumeId.slice(0, 32)} は新しいペインを作れませんでした。ペイン数が上限です。`,
-    );
+    agentVaultStatusMessage = mode === "fork"
+      ? getLanguageText(
+          "Fork could not create a new pane: maximum pane count reached.",
+          "フォークは新しいペインを作れませんでした。ペイン数が上限です。",
+        )
+      : getLanguageText(
+          `Resume ${entry.resumeId.slice(0, 32)} could not create a new pane: maximum pane count reached.`,
+          `再開 ID ${entry.resumeId.slice(0, 32)} は新しいペインを作れませんでした。ペイン数が上限です。`,
+        );
     renderAgentVaultPanel();
     return;
+  }
+
+  if (mode === "fork") {
+    const recorded = vaultOrganize.recordFork(agentVaultOrganizeState, entry.id, entry.workspaceKey);
+    if (!applyAgentVaultOrganizeMutation(recorded)) {
+      return;
+    }
   }
 
   setTerminalDrawer(true);
@@ -3513,10 +3631,16 @@ async function restoreAgentVaultSession(entryId: string, targetPaneId?: string) 
       }
       await ensurePanePtyStarted(paneId);
     }
-    agentVaultStatusMessage = getLanguageText(
-      `Restoring ${entry.title} in ${getPaneDisplayLabel(paneId)}.`,
-      `${entry.title} を ${getPaneDisplayLabel(paneId)} で復元しています。`,
-    );
+    agentVaultStatusMessage = mode === "fork"
+      ? getLanguageText(`Forked from ${entry.title}`, `${entry.title} からフォークしました。`)
+      : getLanguageText(
+          `Restoring ${entry.title} in ${getPaneDisplayLabel(paneId)}.`,
+          `${entry.title} を ${getPaneDisplayLabel(paneId)} で復元しています。`,
+        );
+    if (mode === "fork") {
+      renderDesktopSurfaces();
+      return;
+    }
     appendRuntimeConversation({
       type: "system",
       category: "activity",
@@ -18449,6 +18573,15 @@ window.addEventListener("DOMContentLoaded", async () => {
     focusedWorkbenchPaneId = storedShellPreferences.focusedWorkbenchPaneId;
   }
   applyAgentVaultPreferences();
+  try {
+    const loadedOrganize = vaultOrganize.loadAgentVaultOrganize(window.localStorage.getItem(vaultOrganize.AGENT_VAULT_ORGANIZE_STORAGE_KEY));
+    agentVaultOrganizeState = loadedOrganize.state;
+    if (loadedOrganize.error) {
+      agentVaultStatusMessage = getLanguageText(loadedOrganize.error, "Agent Vault の整理データを読み込めませんでした。以前の状態を保持します。");
+    }
+  } catch {
+    agentVaultStatusMessage = getLanguageText("Agent Vault organize data was rejected. Previous state was kept.", "Agent Vault の整理データを読み込めませんでした。以前の状態を保持します。");
+  }
 
   applyShellPreferences();
   applyLanguageChrome();

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2963,16 +2963,12 @@ function groupAgentVaultSession(entry: AgentVaultSessionEntry) {
   if (name === null) {
     return;
   }
-  if (!vaultOrganize.normalizeGroupName(name)) {
-    applyAgentVaultOrganizeMutation(
-      vaultOrganize.removeSessionFromGroup(agentVaultOrganizeState, entry.id),
-      getLanguageText(`Removed ${entry.title} from its group.`, `${entry.title} をグループから外しました。`),
-    );
-    return;
-  }
+  const cleared = name.trim() === "";
   applyAgentVaultOrganizeMutation(
-    vaultOrganize.assignSessionToGroup(agentVaultOrganizeState, entry.id, name),
-    getLanguageText(`Grouped ${entry.title}.`, `${entry.title} をグループに入れました。`),
+    vaultOrganize.applyAgentVaultGroupPrompt(agentVaultOrganizeState, entry.id, name),
+    cleared
+      ? getLanguageText(`Removed ${entry.title} from its group.`, `${entry.title} をグループから外しました。`)
+      : getLanguageText(`Grouped ${entry.title}.`, `${entry.title} をグループに入れました。`),
   );
 }
 
@@ -3496,7 +3492,7 @@ async function restoreAgentVaultSession(entryId: string, targetPaneId?: string, 
         renderAgentVaultPanel();
         return;
       }
-      if (launchCwd) {
+      if (vaultOrganize.shouldQueueAgentVaultLaunchCwd(mode, launchCwd)) {
         queuePaneStartupCwd(paneId, launchCwd);
       }
       queuePaneStartupInput(paneId, startupInput);

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -594,6 +594,7 @@ interface AgentVaultSessionEntry {
   provider: AgentVaultProviderId;
   title: string;
   workspaceKey: string;
+  workspacePath: string;
   workspaceLabel: string;
   resumeId: string;
   paneId: string;
@@ -808,6 +809,7 @@ const pickingWinnerRunIds = new Set<string>();
 const pendingPromotedRunRefreshIds = new Set<string>();
 const comparingRunPairKeys = new Set<string>();
 const pendingPaneStartupInputs = new Map<string, string>();
+const pendingPaneStartupCwds = new Map<string, string>();
 const backendConversation: ConversationItem[] = [];
 const runtimeConversation: ConversationItem[] = [];
 const DESKTOP_SUMMARY_REFRESH_FALLBACK_INTERVAL_MS = 15_000;
@@ -2026,7 +2028,7 @@ function shouldAutoStartPane(_paneId: string) {
 function getPaneStartupInput(_paneId: string) {
   const startupInput = pendingPaneStartupInputs.get(_paneId);
   if (startupInput) {
-    clearPaneStartupInput(_paneId);
+    pendingPaneStartupInputs.delete(_paneId);
     return startupInput;
   }
   return undefined;
@@ -2034,6 +2036,20 @@ function getPaneStartupInput(_paneId: string) {
 
 function clearPaneStartupInput(paneId: string) {
   pendingPaneStartupInputs.delete(paneId);
+  pendingPaneStartupCwds.delete(paneId);
+}
+
+function getPaneStartupCwd(paneId: string) {
+  const cwd = pendingPaneStartupCwds.get(paneId);
+  if (cwd) {
+    pendingPaneStartupCwds.delete(paneId);
+    return cwd;
+  }
+  return undefined;
+}
+
+function queuePaneStartupCwd(paneId: string, cwd: string) {
+  pendingPaneStartupCwds.set(paneId, cwd);
 }
 
 function hasPaneStartupInput(paneId: string) {
@@ -2154,7 +2170,8 @@ function ensurePanePtyStarted(paneId: string) {
   entry.metaElement.textContent = getLanguageText("starting shell", "シェル起動中");
   renderWorkerStatusSurface();
   const startupInput = getPaneStartupInput(paneId);
-  entry.ptyStarting = spawnPtyPane(paneId, cols, rows, startupInput)
+  const cwd = getPaneStartupCwd(paneId);
+  entry.ptyStarting = spawnPtyPane(paneId, cols, rows, startupInput, cwd)
     .then(() => {
       entry.ptyStarted = true;
       entry.activeStartupInput = startupInput ?? "";
@@ -2946,6 +2963,13 @@ function groupAgentVaultSession(entry: AgentVaultSessionEntry) {
   if (name === null) {
     return;
   }
+  if (!vaultOrganize.normalizeGroupName(name)) {
+    applyAgentVaultOrganizeMutation(
+      vaultOrganize.removeSessionFromGroup(agentVaultOrganizeState, entry.id),
+      getLanguageText(`Removed ${entry.title} from its group.`, `${entry.title} をグループから外しました。`),
+    );
+    return;
+  }
   applyAgentVaultOrganizeMutation(
     vaultOrganize.assignSessionToGroup(agentVaultOrganizeState, entry.id, name),
     getLanguageText(`Grouped ${entry.title}.`, `${entry.title} をグループに入れました。`),
@@ -2983,6 +3007,21 @@ function getAgentVaultWorkspaceLabel(path: string | null | undefined, snapshotPr
   }
   const parts = normalized.split(/[\\/]/).filter(Boolean);
   return parts[parts.length - 1] ?? getLanguageText("workspace", "ワークスペース");
+}
+
+function resolveAgentVaultLaunchDirectory(entry: AgentVaultSessionEntry): string {
+  const raw = (entry.workspacePath ?? "").trim();
+  if (!raw || raw === "__this_project__" || raw.startsWith("workspace:")) {
+    return "";
+  }
+  const isAbsolute = /^[A-Za-z]:[\\/]/.test(raw) || raw.startsWith("\\\\") || raw.startsWith("/") || raw.startsWith("//");
+  return isAbsolute ? raw : "";
+}
+
+function readAgentVaultWorkerRunId(row: DesktopWorkerStatusRow): string {
+  return normalizeAgentVaultText(
+    row.heartbeat?.run_id || row.workspace?.run_id || row.secret_projection?.run_id || row.policy?.run_id || "",
+  );
 }
 
 function getAgentVaultWorkspaceKey(path: string | null | undefined, snapshotProjectDir?: string | null) {
@@ -3082,6 +3121,7 @@ function buildAgentVaultEntries() {
       provider,
       title,
       workspaceKey: getAgentVaultWorkspaceKey(workspacePath, snapshot?.project_dir),
+      workspacePath,
       workspaceLabel: getAgentVaultWorkspaceLabel(workspacePath, snapshot?.project_dir),
       resumeId: normalizeAgentVaultText(projection.run_id || projection.pane_id),
       paneId: projection.pane_id,
@@ -3101,7 +3141,10 @@ function buildAgentVaultEntries() {
     if (!target) {
       continue;
     }
-    const runId = row.heartbeat?.run_id || row.workspace?.run_id || row.secret_projection?.run_id || row.policy?.run_id || target;
+    const runId = readAgentVaultWorkerRunId(row);
+    if (!runId) {
+      continue;
+    }
     const existing = Array.from(entries.values()).some((entry) => entry.runId === runId || entry.paneId === target);
     if (existing) {
       continue;
@@ -3110,10 +3153,11 @@ function buildAgentVaultEntries() {
     const provider = inferAgentVaultProvider(row.backend, row.role, getWorkerProvider(row), getLaunchApprovalField(launch, "agent"));
     const workspacePath = row.workspace?.workspace || activeProjectDir || desktopSummarySnapshot?.project_dir || "";
     const base: Omit<AgentVaultSessionEntry, "searchText"> = {
-      id: `worker:${target}`,
+      id: `worker:${runId}`,
       provider,
       title: truncateAgentVaultText(`${getPaneDisplayLabel(target)} ${row.role || row.backend || "worker"}`, 72),
       workspaceKey: getAgentVaultWorkspaceKey(workspacePath, desktopSummarySnapshot?.project_dir),
+      workspacePath,
       workspaceLabel: getAgentVaultWorkspaceLabel(workspacePath, desktopSummarySnapshot?.project_dir),
       resumeId: normalizeAgentVaultText(runId),
       paneId: target,
@@ -3567,6 +3611,15 @@ async function restoreAgentVaultSession(entryId: string, targetPaneId?: string, 
     renderAgentVaultPanel();
     return;
   }
+  const launchCwd = resolveAgentVaultLaunchDirectory(entry);
+  if (mode === "fork" && !launchCwd) {
+    agentVaultStatusMessage = getLanguageText(
+      "Fork could not resolve the source workspace directory.",
+      "フォークは元ワークスペースのディレクトリを解決できませんでした。",
+    );
+    renderAgentVaultPanel();
+    return;
+  }
   const command = mode === "fork"
     ? vaultOrganize.buildAgentVaultForkLaunchCommand(entry.provider)
     : vaultOrganize.buildAgentVaultResumeCommand(entry.provider, entry.resumeId);
@@ -3601,13 +3654,6 @@ async function restoreAgentVaultSession(entryId: string, targetPaneId?: string, 
     return;
   }
 
-  if (mode === "fork") {
-    const recorded = vaultOrganize.recordFork(agentVaultOrganizeState, entry.id, entry.workspaceKey);
-    if (!applyAgentVaultOrganizeMutation(recorded)) {
-      return;
-    }
-  }
-
   setTerminalDrawer(true);
   const paneId = targetPaneId && panes.has(targetPaneId) ? targetPaneId : createPane();
   focusedWorkbenchPaneId = paneId;
@@ -3621,7 +3667,7 @@ async function restoreAgentVaultSession(entryId: string, targetPaneId?: string, 
     if (pane?.ptyStarted) {
       await writePtyData(paneId, startupInput);
     } else {
-      if (pane?.ptyStarting || !queuePaneStartupInput(paneId, startupInput)) {
+      if (pane?.ptyStarting || hasPaneStartupInput(paneId)) {
         agentVaultStatusMessage = getLanguageText(
           `${getPaneDisplayLabel(paneId)} is already starting a restore. Wait for it to finish before restoring another session.`,
           `${getPaneDisplayLabel(paneId)} は復元を開始中です。完了してから別のセッションを復元してください。`,
@@ -3629,18 +3675,24 @@ async function restoreAgentVaultSession(entryId: string, targetPaneId?: string, 
         renderAgentVaultPanel();
         return;
       }
+      if (launchCwd) {
+        queuePaneStartupCwd(paneId, launchCwd);
+      }
+      queuePaneStartupInput(paneId, startupInput);
       await ensurePanePtyStarted(paneId);
     }
-    agentVaultStatusMessage = mode === "fork"
-      ? getLanguageText(`Forked from ${entry.title}`, `${entry.title} からフォークしました。`)
-      : getLanguageText(
-          `Restoring ${entry.title} in ${getPaneDisplayLabel(paneId)}.`,
-          `${entry.title} を ${getPaneDisplayLabel(paneId)} で復元しています。`,
-        );
     if (mode === "fork") {
+      applyAgentVaultOrganizeMutation(
+        vaultOrganize.recordFork(agentVaultOrganizeState, entry.id, entry.workspaceKey),
+        getLanguageText(`Forked from ${entry.title}`, `${entry.title} からフォークしました。`),
+      );
       renderDesktopSurfaces();
       return;
     }
+    agentVaultStatusMessage = getLanguageText(
+      `Restoring ${entry.title} in ${getPaneDisplayLabel(paneId)}.`,
+      `${entry.title} を ${getPaneDisplayLabel(paneId)} で復元しています。`,
+    );
     appendRuntimeConversation({
       type: "system",
       category: "activity",

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -2976,142 +2976,24 @@ function groupAgentVaultSession(entry: AgentVaultSessionEntry) {
   );
 }
 
-function normalizeAgentVaultText(value: string | null | undefined, fallback = "") {
-  const normalized = (value ?? "")
-    .replace(/[\u0000-\u001f\u007f]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  return normalized || fallback;
-}
-
-function sanitizeAgentVaultDisplayText(value: string | null | undefined, fallback = "") {
-  const normalized = normalizeAgentVaultText(value, fallback);
-  return normalized
-    .replace(/[A-Za-z]:[\\/][^\s"'<>]+/g, "[local path]")
-    .replace(/\\\\[^\s"'<>]+/g, "[network path]");
-}
-
-function truncateAgentVaultText(value: string, limit = 128) {
-  const normalized = sanitizeAgentVaultDisplayText(value);
-  return normalized.length > limit ? `${normalized.slice(0, limit - 1)}…` : normalized;
-}
-
-function getAgentVaultWorkspaceLabel(path: string | null | undefined, snapshotProjectDir?: string | null) {
-  const normalized = normalizeProjectDirInput(path) || "";
-  const active = normalizeProjectDirInput(getActiveProjectDirPayload()) || normalizeProjectDirInput(snapshotProjectDir) || "";
-  if (!normalized) {
-    return getLanguageText("unknown workspace", "不明なワークスペース");
-  }
-  if (active && normalized.toLowerCase() === active.toLowerCase()) {
-    return getLanguageText("This project", "このプロジェクト");
-  }
-  const parts = normalized.split(/[\\/]/).filter(Boolean);
-  return parts[parts.length - 1] ?? getLanguageText("workspace", "ワークスペース");
-}
-
-function resolveAgentVaultLaunchDirectory(entry: AgentVaultSessionEntry): string {
-  const raw = (entry.workspacePath ?? "").trim();
-  if (!raw || raw === "__this_project__" || raw.startsWith("workspace:")) {
-    return "";
-  }
-  const isAbsolute = /^[A-Za-z]:[\\/]/.test(raw) || raw.startsWith("\\\\") || raw.startsWith("/") || raw.startsWith("//");
-  return isAbsolute ? raw : "";
-}
-
-function readAgentVaultWorkerRunId(row: DesktopWorkerStatusRow): string {
-  return normalizeAgentVaultText(
-    row.heartbeat?.run_id || row.workspace?.run_id || row.secret_projection?.run_id || row.policy?.run_id || "",
-  );
-}
-
-function getAgentVaultWorkspaceKey(path: string | null | undefined, snapshotProjectDir?: string | null) {
-  const normalized = normalizeProjectDirInput(path) || "";
-  const active = normalizeProjectDirInput(getActiveProjectDirPayload()) || normalizeProjectDirInput(snapshotProjectDir) || "";
-  if (!normalized) {
-    return "unknown";
-  }
-  if (active && normalized.toLowerCase() === active.toLowerCase()) {
-    return "__this_project__";
-  }
-  return `workspace:${normalized.toLowerCase()}`;
-}
-
-function isAgentVaultThisProject(path: string | null | undefined, snapshotProjectDir?: string | null) {
-  const normalized = normalizeProjectDirInput(path) || "";
-  const active = normalizeProjectDirInput(getActiveProjectDirPayload()) || normalizeProjectDirInput(snapshotProjectDir) || "";
-  return Boolean(normalized && active && normalized.toLowerCase() === active.toLowerCase());
-}
-
-function inferAgentVaultProvider(...values: string[]): AgentVaultProviderId {
-  const text = values.join(" ").toLowerCase();
-  if (text.includes("opencode") || text.includes("open code")) {
-    return "opencode";
-  }
-  if (text.includes("codex")) {
-    return "codex";
-  }
-  return "claude";
-}
-
-function getAgentVaultReviewTone(reviewState: string, state: string): SurfaceTone {
-  const review = reviewState.toUpperCase();
-  const normalizedState = state.toLowerCase();
-  if (review === "FAIL" || review === "FAILED" || normalizedState.includes("blocked")) {
-    return "danger";
-  }
-  if (review === "PENDING" || normalizedState.includes("waiting")) {
-    return "warning";
-  }
-  if (review === "PASS" || normalizedState.includes("ready")) {
-    return "success";
-  }
-  return "info";
-}
-
-function getAgentVaultLastSeen(entryTime: string | null | undefined, fallbackTime?: string | null) {
-  const timestamp = normalizeAgentVaultText(entryTime || fallbackTime || "");
-  if (!timestamp) {
-    return getLanguageText("not seen yet", "未確認");
-  }
-  const parsed = Date.parse(timestamp);
-  if (Number.isNaN(parsed)) {
-    return timestamp;
-  }
-  return new Date(parsed).toLocaleString([], {
-    month: "short",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
-
-function buildAgentVaultSearchText(entry: Omit<AgentVaultSessionEntry, "searchText">) {
-  return [
-    entry.id,
-    entry.provider,
-    getAgentVaultProviderLabel(entry.provider),
-    entry.title,
-    entry.workspaceLabel,
-    entry.resumeId,
-    entry.paneId,
-    entry.runId,
-    entry.state,
-    entry.reviewState,
-    entry.summary,
-  ].join(" ").toLowerCase();
-}
-
 function buildAgentVaultEntries() {
   const snapshot = desktopSummarySnapshot;
   const entries = new Map<string, AgentVaultSessionEntry>();
   const digestByRun = new Map((snapshot?.digest.items ?? []).map((item) => [item.run_id, item]));
   const paneById = new Map((snapshot?.board.panes ?? []).map((pane) => [pane.pane_id, pane]));
+  const activeDir = getActiveProjectDirPayload();
+  const workspaceLabels = {
+    unknown: getLanguageText("unknown workspace", "不明なワークスペース"),
+    thisProject: getLanguageText("This project", "このプロジェクト"),
+    workspace: getLanguageText("workspace", "ワークスペース"),
+  };
+  const unseen = getLanguageText("not seen yet", "未確認");
 
   for (const projection of snapshot?.run_projections ?? []) {
     const digest = digestByRun.get(projection.run_id);
     const pane = paneById.get(projection.pane_id);
-    const provider = inferAgentVaultProvider(projection.provider_target, projection.label, projection.task);
-    const title = truncateAgentVaultText(
+    const provider = vaultOrganize.inferAgentVaultProvider(projection.provider_target, projection.label, projection.task);
+    const title = vaultOrganize.truncateAgentVaultText(
       projection.task || projection.summary || projection.label || projection.run_id,
       72,
     );
@@ -3120,20 +3002,26 @@ function buildAgentVaultEntries() {
       id: `summary:${projection.run_id}`,
       provider,
       title,
-      workspaceKey: getAgentVaultWorkspaceKey(workspacePath, snapshot?.project_dir),
+      workspaceKey: vaultOrganize.getAgentVaultWorkspaceKey(workspacePath, snapshot?.project_dir, activeDir),
       workspacePath,
-      workspaceLabel: getAgentVaultWorkspaceLabel(workspacePath, snapshot?.project_dir),
-      resumeId: normalizeAgentVaultText(projection.run_id || projection.pane_id),
+      workspaceLabel: vaultOrganize.getAgentVaultWorkspaceLabel(workspacePath, snapshot?.project_dir, activeDir, workspaceLabels),
+      resumeId: vaultOrganize.normalizeAgentVaultText(projection.run_id || projection.pane_id),
       paneId: projection.pane_id,
       runId: projection.run_id,
-      lastSeen: getAgentVaultLastSeen(digest?.last_event_at, snapshot?.generated_at),
-      state: normalizeAgentVaultText(projection.task_state || projection.phase || projection.activity, "indexed"),
-      reviewState: normalizeAgentVaultText(projection.review_state, "n/a"),
-      summary: truncateAgentVaultText(projection.summary || projection.next_action || projection.detail || projection.activity, 140),
-      thisProject: isAgentVaultThisProject(workspacePath, snapshot?.project_dir),
+      lastSeen: vaultOrganize.formatAgentVaultLastSeen(digest?.last_event_at, snapshot?.generated_at, unseen),
+      state: vaultOrganize.normalizeAgentVaultText(projection.task_state || projection.phase || projection.activity, "indexed"),
+      reviewState: vaultOrganize.normalizeAgentVaultText(projection.review_state, "n/a"),
+      summary: vaultOrganize.truncateAgentVaultText(projection.summary || projection.next_action || projection.detail || projection.activity, 140),
+      thisProject: vaultOrganize.isAgentVaultThisProject(workspacePath, snapshot?.project_dir, activeDir),
       source: "summary",
     };
-    entries.set(base.id, { ...base, searchText: buildAgentVaultSearchText(base) });
+    entries.set(base.id, {
+      ...base,
+      searchText: vaultOrganize.buildAgentVaultSearchText({
+        ...base,
+        providerLabel: getAgentVaultProviderLabel(base.provider),
+      }),
+    });
   }
 
   for (const row of workerStatusRows) {
@@ -3141,7 +3029,9 @@ function buildAgentVaultEntries() {
     if (!target) {
       continue;
     }
-    const runId = readAgentVaultWorkerRunId(row);
+    const runId = vaultOrganize.normalizeAgentVaultText(
+      row.heartbeat?.run_id || row.workspace?.run_id || row.secret_projection?.run_id || row.policy?.run_id || "",
+    );
     if (!runId) {
       continue;
     }
@@ -3150,26 +3040,32 @@ function buildAgentVaultEntries() {
       continue;
     }
     const launch = getWorkerStatusLaunch(row);
-    const provider = inferAgentVaultProvider(row.backend, row.role, getWorkerProvider(row), getLaunchApprovalField(launch, "agent"));
+    const provider = vaultOrganize.inferAgentVaultProvider(row.backend, row.role, getWorkerProvider(row), getLaunchApprovalField(launch, "agent"));
     const workspacePath = row.workspace?.workspace || activeProjectDir || desktopSummarySnapshot?.project_dir || "";
     const base: Omit<AgentVaultSessionEntry, "searchText"> = {
       id: `worker:${runId}`,
       provider,
-      title: truncateAgentVaultText(`${getPaneDisplayLabel(target)} ${row.role || row.backend || "worker"}`, 72),
-      workspaceKey: getAgentVaultWorkspaceKey(workspacePath, desktopSummarySnapshot?.project_dir),
+      title: vaultOrganize.truncateAgentVaultText(`${getPaneDisplayLabel(target)} ${row.role || row.backend || "worker"}`, 72),
+      workspaceKey: vaultOrganize.getAgentVaultWorkspaceKey(workspacePath, desktopSummarySnapshot?.project_dir, activeDir),
       workspacePath,
-      workspaceLabel: getAgentVaultWorkspaceLabel(workspacePath, desktopSummarySnapshot?.project_dir),
-      resumeId: normalizeAgentVaultText(runId),
+      workspaceLabel: vaultOrganize.getAgentVaultWorkspaceLabel(workspacePath, desktopSummarySnapshot?.project_dir, activeDir, workspaceLabels),
+      resumeId: vaultOrganize.normalizeAgentVaultText(runId),
       paneId: target,
       runId,
-      lastSeen: getAgentVaultLastSeen(row.heartbeat?.heartbeat_at || row.last_command_at, desktopSummarySnapshot?.generated_at),
-      state: normalizeAgentVaultText(row.heartbeat_state || row.state || row.pane_state, "worker"),
-      reviewState: normalizeAgentVaultText(row.heartbeat_health || row.manifest_status, "n/a"),
-      summary: truncateAgentVaultText(row.failure_reason || row.heartbeat?.message || row.last_command || row.backend || row.role, 140),
-      thisProject: isAgentVaultThisProject(workspacePath, desktopSummarySnapshot?.project_dir),
+      lastSeen: vaultOrganize.formatAgentVaultLastSeen(row.heartbeat?.heartbeat_at || row.last_command_at, desktopSummarySnapshot?.generated_at, unseen),
+      state: vaultOrganize.normalizeAgentVaultText(row.heartbeat_state || row.state || row.pane_state, "worker"),
+      reviewState: vaultOrganize.normalizeAgentVaultText(row.heartbeat_health || row.manifest_status, "n/a"),
+      summary: vaultOrganize.truncateAgentVaultText(row.failure_reason || row.heartbeat?.message || row.last_command || row.backend || row.role, 140),
+      thisProject: vaultOrganize.isAgentVaultThisProject(workspacePath, desktopSummarySnapshot?.project_dir, activeDir),
       source: "worker",
     };
-    entries.set(base.id, { ...base, searchText: buildAgentVaultSearchText(base) });
+    entries.set(base.id, {
+      ...base,
+      searchText: vaultOrganize.buildAgentVaultSearchText({
+        ...base,
+        providerLabel: getAgentVaultProviderLabel(base.provider),
+      }),
+    });
   }
 
   return Array.from(entries.values()).sort((left, right) => {
@@ -3214,7 +3110,7 @@ function buildAgentVaultFeedEntries(): AgentVaultFeedEntry[] {
       id: `inbox:${item.pane_id}:${item.timestamp}:${item.kind}`,
       tone: item.priority <= 1 ? "danger" : item.priority <= 2 ? "warning" : "info",
       label: item.label || item.kind || "notification",
-      body: truncateAgentVaultText(item.message || item.detail || item.activity || item.event, 110),
+      body: vaultOrganize.truncateAgentVaultText(item.message || item.detail || item.activity || item.event, 110),
       paneId: item.pane_id,
     });
   }
@@ -3227,22 +3123,12 @@ function buildAgentVaultFeedEntries(): AgentVaultFeedEntry[] {
       id: `worker:${target}:${row.state}:${row.heartbeat_state}`,
       tone: isWorkerStatusBlocked(row) ? "danger" : "warning",
       label: target || row.slot || "worker",
-      body: truncateAgentVaultText(row.failure_reason || row.heartbeat?.reason || row.heartbeat?.message || getWorkerRecoveryAction(row), 110),
+      body: vaultOrganize.truncateAgentVaultText(row.failure_reason || row.heartbeat?.reason || row.heartbeat?.message || getWorkerRecoveryAction(row), 110),
       paneId: target,
       runId: row.heartbeat?.run_id || row.workspace?.run_id,
     });
   }
   return entries.slice(0, 5);
-}
-
-function getAgentVaultNotificationTone(feedEntries: AgentVaultFeedEntry[]): SurfaceTone {
-  if (feedEntries.some((entry) => entry.tone === "danger")) {
-    return "danger";
-  }
-  if (feedEntries.some((entry) => entry.tone === "warning")) {
-    return "warning";
-  }
-  return "info";
 }
 
 function focusAgentVaultFeedEntry(entry: AgentVaultFeedEntry) {
@@ -3255,16 +3141,6 @@ function focusAgentVaultFeedEntry(entry: AgentVaultFeedEntry) {
     `フィードから ${getPaneDisplayLabel(entry.paneId)} へ移動しました。`,
   );
   renderAgentVaultPanel();
-}
-
-function createAgentVaultChip(label: string, value: string, tone?: SurfaceTone) {
-  const chip = document.createElement("span");
-  chip.className = "agent-vault-chip";
-  if (tone) {
-    chip.dataset.tone = tone;
-  }
-  chip.textContent = `${label}: ${value}`;
-  return chip;
 }
 
 function renderAgentVaultProviderFilters(root: HTMLElement, entries: AgentVaultSessionEntry[]) {
@@ -3289,69 +3165,6 @@ function renderAgentVaultProviderFilters(root: HTMLElement, entries: AgentVaultS
     });
     root.appendChild(button);
   }
-}
-
-function renderAgentVaultWorkspaceFilter(root: HTMLSelectElement, entries: AgentVaultSessionEntry[]) {
-  const workspaceCounts = new Map<string, { label: string; count: number }>();
-  for (const entry of entries) {
-    const current = workspaceCounts.get(entry.workspaceKey);
-    if (current) {
-      current.count += 1;
-    } else {
-      workspaceCounts.set(entry.workspaceKey, { label: entry.workspaceLabel, count: 1 });
-    }
-  }
-  if (agentVaultWorkspaceFilter !== "all" && !workspaceCounts.has(agentVaultWorkspaceFilter)) {
-    agentVaultWorkspaceFilter = "all";
-  }
-
-  root.replaceChildren();
-  const allOption = document.createElement("option");
-  allOption.value = "all";
-  allOption.textContent = getLanguageText(`All folders (${entries.length})`, `すべてのフォルダー (${entries.length})`);
-  root.appendChild(allOption);
-
-  const workspaces = Array.from(workspaceCounts.entries())
-    .sort((left, right) => left[1].label.localeCompare(right[1].label));
-  for (const [key, workspace] of workspaces) {
-    const option = document.createElement("option");
-    option.value = key;
-    option.textContent = `${workspace.label} (${workspace.count})`;
-    root.appendChild(option);
-  }
-  root.value = agentVaultWorkspaceFilter;
-}
-
-function appendAgentVaultSessionGroup(
-  list: HTMLElement,
-  key: string,
-  label: string,
-  groupEntries: AgentVaultSessionEntry[],
-  collapsed: boolean,
-  onToggle: () => void,
-) {
-  const group = document.createElement("section");
-  group.className = "agent-vault-provider-group";
-  group.dataset.groupKey = key;
-  group.dataset.collapsed = collapsed ? "true" : "false";
-  const heading = document.createElement("button");
-  heading.type = "button";
-  heading.className = "agent-vault-provider-heading";
-  heading.setAttribute("aria-expanded", collapsed ? "false" : "true");
-  heading.addEventListener("click", onToggle);
-  const title = document.createElement("span");
-  title.textContent = label;
-  const count = document.createElement("span");
-  count.className = "agent-vault-provider-count";
-  count.textContent = `${groupEntries.length}`;
-  heading.append(title, count);
-  group.appendChild(heading);
-  if (!collapsed) {
-    for (const entry of groupEntries) {
-      group.appendChild(renderAgentVaultSessionCard(entry));
-    }
-  }
-  list.appendChild(group);
 }
 
 function renderAgentVaultPanel() {
@@ -3381,7 +3194,12 @@ function renderAgentVaultPanel() {
     search.value = agentVaultQuery;
   }
   if (workspaceFilter) {
-    renderAgentVaultWorkspaceFilter(workspaceFilter, allEntries);
+    agentVaultWorkspaceFilter = vaultOrganize.renderAgentVaultWorkspaceFilter(
+      workspaceFilter,
+      allEntries,
+      agentVaultWorkspaceFilter,
+      getLanguageText(`All folders (${allEntries.length})`, `すべてのフォルダー (${allEntries.length})`),
+    );
   }
   const visibleEntries = getVisibleAgentVaultEntries();
 
@@ -3390,7 +3208,7 @@ function renderAgentVaultPanel() {
   }
   if (ring) {
     ring.textContent = feedEntries.length > 0 ? `${feedEntries.length}` : "OK";
-    ring.dataset.tone = getAgentVaultNotificationTone(feedEntries);
+    ring.dataset.tone = vaultOrganize.getAgentVaultNotificationTone(feedEntries);
     ring.title = getLanguageText("Feed and worker notification ring", "フィードとワーカー通知リング");
   }
   if (projectFilter) {
@@ -3423,21 +3241,21 @@ function renderAgentVaultPanel() {
     } else {
       const partitioned = vaultOrganize.partitionEntriesByUserGroup(visibleEntries, agentVaultOrganizeState);
       for (const userGroup of partitioned.groups) {
-        appendAgentVaultSessionGroup(list, userGroup.id, userGroup.name, userGroup.entries, agentVaultCollapsedGroupIds.has(userGroup.id), () => {
+        vaultOrganize.appendAgentVaultSessionGroup(list, userGroup.id, userGroup.name, userGroup.entries, agentVaultCollapsedGroupIds.has(userGroup.id), () => {
           if (agentVaultCollapsedGroupIds.has(userGroup.id)) {
             agentVaultCollapsedGroupIds.delete(userGroup.id);
           } else {
             agentVaultCollapsedGroupIds.add(userGroup.id);
           }
           renderAgentVaultPanel();
-        });
+        }, renderAgentVaultSessionCard);
       }
       for (const provider of agentVaultProviders) {
         const providerEntries = partitioned.ungrouped.filter((entry) => entry.provider === provider.id);
         if (providerEntries.length === 0) {
           continue;
         }
-        appendAgentVaultSessionGroup(list, provider.id, getAgentVaultProviderLabel(provider.id), providerEntries, agentVaultCollapsedProviderIds.has(provider.id), () => {
+        vaultOrganize.appendAgentVaultSessionGroup(list, provider.id, getAgentVaultProviderLabel(provider.id), providerEntries, agentVaultCollapsedProviderIds.has(provider.id), () => {
           if (agentVaultCollapsedProviderIds.has(provider.id)) {
             agentVaultCollapsedProviderIds.delete(provider.id);
           } else {
@@ -3445,7 +3263,7 @@ function renderAgentVaultPanel() {
           }
           persistAgentVaultPreferences();
           renderAgentVaultPanel();
-        });
+        }, renderAgentVaultSessionCard);
       }
     }
   }
@@ -3547,11 +3365,11 @@ function renderAgentVaultSessionCard(entry: AgentVaultSessionEntry) {
   const meta = document.createElement("div");
   meta.className = "agent-vault-card-meta";
   meta.append(
-    createAgentVaultChip("provider", getAgentVaultProviderLabel(entry.provider)),
-    createAgentVaultChip("workspace", entry.workspaceLabel),
-    createAgentVaultChip("resume", entry.resumeId.slice(0, 12)),
-    createAgentVaultChip("seen", entry.lastSeen),
-    createAgentVaultChip("state", entry.state, getAgentVaultReviewTone(entry.reviewState, entry.state)),
+    vaultOrganize.createAgentVaultChip("provider", getAgentVaultProviderLabel(entry.provider)),
+    vaultOrganize.createAgentVaultChip("workspace", entry.workspaceLabel),
+    vaultOrganize.createAgentVaultChip("resume", entry.resumeId.slice(0, 12)),
+    vaultOrganize.createAgentVaultChip("seen", entry.lastSeen),
+    vaultOrganize.createAgentVaultChip("state", entry.state, vaultOrganize.getAgentVaultReviewTone(entry.reviewState, entry.state)),
   );
   const actions = document.createElement("div");
   actions.className = "agent-vault-card-actions";
@@ -3611,7 +3429,10 @@ async function restoreAgentVaultSession(entryId: string, targetPaneId?: string, 
     renderAgentVaultPanel();
     return;
   }
-  const launchCwd = resolveAgentVaultLaunchDirectory(entry);
+  const launchCwd = vaultOrganize.resolveAgentVaultLaunchDirectory(
+    entry.workspacePath,
+    normalizeProjectDirInput(getActiveProjectDirPayload()) || normalizeProjectDirInput(desktopSummarySnapshot?.project_dir) || "",
+  );
   if (mode === "fork" && !launchCwd) {
     agentVaultStatusMessage = getLanguageText(
       "Fork could not resolve the source workspace directory.",

--- a/winsmux-app/src/ptyClient.ts
+++ b/winsmux-app/src/ptyClient.ts
@@ -128,12 +128,17 @@ export async function spawnPtyPane(
   cols: number,
   rows: number,
   startupInput?: string,
+  cwd?: string,
 ) {
   try {
-    await ptyCommandTransport.request(
-      "pty.spawn",
-      startupInput ? { paneId, cols, rows, startupInput } : { paneId, cols, rows },
-    );
+    const payload: Record<string, unknown> = { paneId, cols, rows };
+    if (startupInput) {
+      payload.startupInput = startupInput;
+    }
+    if (cwd) {
+      payload.cwd = cwd;
+    }
+    await ptyCommandTransport.request("pty.spawn", payload);
   } catch (error) {
     throw normalizePtyError(`pty.spawn(${paneId})`, error);
   }

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -3460,6 +3460,15 @@ body[data-popout-surface="1"] #editor-surface {
   border-color: rgba(89, 211, 196, 0.7);
 }
 
+.agent-vault-action:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.agent-vault-card[data-archived="true"] {
+  opacity: 0.72;
+}
+
 .agent-vault-feed {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

TASK-665 only. Draft. Do not merge.

Stacked on #1273 / `dccccc3f`. Base branch `cursor/task-664-first-run-simple-mode` so this diff does not re-list TASK-664 first-run files.

Adds Agent Vault organize actions on the existing vault:

- **Archive** hides a card from the default list without deleting provider conversations or summary/worker sources.
- **Group** is a user-named overlay of existing vault session ids, across providers and workspaces.
- **Fork** starts a new conversation in a new pane in the source card's workspace. This is not resume (`claude --resume` / `codex resume` / `opencode --session` are not sent).

Reuse Agent Vault search, provider/workspace filters, drag-to-pane, and resume. Organize state is a sibling localStorage overlay (`winsmux.agent-vault.organize.v1`) only. No second session store, SQLite, jsonl transcripts, or pane-buffer copies. Vault archive is not TASK-789 pane archive.

## Surface Classification

- [x] Public product surface
- [ ] Runtime contract surface
- [x] Contributor/test surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Responsibility And Cutover

- Replaced behavior, workflow, config path, or responsibility: none. Organize overlay is additive on Agent Vault cards and panel filters.
- Expected outcome: archived cards hidden unless Show archived; groups are user-named headings/filters; fork opens a fresh provider CLI in a new pane.
- Source of truth: Indexed sources remain `desktopSummarySnapshot` run projections + `workerStatusRows`. Organize JSON is desktop localStorage only.
- Old paths preserved, redirected, deprecated, or removed: existing resume, drag, and preferences key `winsmux.agent-vault.preferences.v1` are unchanged.

## Verification

Ubuntu (this agent). Not orchestra-smoke / Pester / Tauri desktop-pane-e2e proof. `test:agent-vault-organize` is not added to `scripts/test-v03626-desktop-split-gate.ps1`.

```
cd winsmux-app
npm ci
node ./scripts/agent-vault-organize-check.mjs
npm run build
```

Exit codes:

- `npm ci`: **0**
- `node ./scripts/agent-vault-organize-check.mjs`: **0**
- `npm run build` (`tsc && vite build`): **0**

RED then GREEN: `371aacc` test commit failed product source assertions on unmodified `main.ts`; `acd67c3` feat commit wires archive/group/fork and the same node check passes.

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.

Organize JSON is not written to the project `.winsmux` directory. Invalid JSON / extra keys fail closed without writing. Status strings do not dump organize JSON, secrets, or full resume ids.

Do not merge. Do not mark ready. Do not tag. Do not npm publish. Do not bump VERSION.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a56bd809-385a-4f9f-a8fa-9fe8c374d0d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a56bd809-385a-4f9f-a8fa-9fe8c374d0d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

