### PR TITLE
feat(app): add unread attention center from events --json (TASK-666)

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -191,6 +191,7 @@ $whitelistPatterns = @(
     'winsmux-app/src/teamProfileSettings.ts',
     'winsmux-app/src/firstRunOnboarding.ts',
     'winsmux-app/src/agentVaultOrganize.ts',
+    'winsmux-app/src/attentionCenter.ts',
     'winsmux-app/src/firstRunWizard.ts',
     'winsmux-app/src/workflowGate.ts',
     'winsmux-app/src/styles.css',

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -383,6 +383,7 @@
               <div id="agent-vault-provider-filters" class="agent-vault-filter-row" aria-label="Agent Vault provider filters"></div>
               <div id="agent-vault-drop-status" class="agent-vault-drop-status" role="status"></div>
               <div id="agent-vault-session-list" class="agent-vault-session-list"></div>
+              <section id="attention-center" class="attention-center" aria-label="Attention center"></section>
               <div id="agent-vault-feed" class="agent-vault-feed" aria-label="Agent Vault feed"></div>
             </section>
             <div id="context-panel-title" class="panel-title">Details</div>

--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -42,6 +42,7 @@
     "test:worker-start-planning": "node ./scripts/worker-start-planning-check.mjs",
     "test:first-run-onboarding": "node ./scripts/first-run-onboarding-check.mjs",
     "test:agent-vault-organize": "node ./scripts/agent-vault-organize-check.mjs",
+    "test:attention-center": "node ./scripts/attention-center-check.mjs",
     "test:source-graph": "node ./scripts/source-graph-check.mjs",
     "test:windows-context-menu": "pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/windows-context-menu-e2e.ps1",
     "test:viewport-harness": "npm run build && node ./scripts/viewport-harness.mjs",

--- a/winsmux-app/scripts/attention-center-check.mjs
+++ b/winsmux-app/scripts/attention-center-check.mjs
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+async function loadAttentionCenterModule() {
+  const sourcePath = path.resolve("src/attentionCenter.ts");
+  const source = await readFile(sourcePath, "utf8");
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: sourcePath,
+  });
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "winsmux-attention-center-"));
+  const modulePath = path.join(tempDir, "attentionCenter.mjs");
+  await writeFile(modulePath, transpiled.outputText, "utf8");
+
+  try {
+    return await import(pathToFileURL(modulePath).href);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const {
+  ATTENTION_CENTER_STORAGE_KEY,
+  COMPANION_WINSMUX_MISSING_STATUS,
+  alignAttentionCenterProject,
+  attentionFilterCounts,
+  attentionJumpTarget,
+  buildEventsCommandArgv,
+  classifyAttention,
+  emptyAttentionCenterState,
+  isCompanionWinsmuxMissingError,
+  isPaneBufferAuthority,
+  isPaneBufferEventSource,
+  loadAttentionCenterState,
+  markAllRead,
+  markEventRead,
+  nextLastSeenCursor,
+  parseAttentionCenterState,
+  parseEventsCommandJson,
+  readEventsCommandSnapshot,
+  serializeAttentionCenterState,
+  unreadEvents,
+} = await loadAttentionCenterModule();
+
+const attentionSource = await readFile(path.resolve("src/attentionCenter.ts"), "utf8");
+assert.doesNotMatch(
+  attentionSource,
+  /appendPaneOutputBuffer|capture-pane|capturePtyPane|outputBuffer|pty_capture/,
+);
+assert.equal(isPaneBufferAuthority("pty"), false);
+assert.equal(isPaneBufferAuthority("capture-pane"), false);
+assert.equal(isPaneBufferAuthority("resume"), false);
+assert.equal(isPaneBufferAuthority("appendPaneOutputBuffer"), false);
+assert.equal(isPaneBufferEventSource("pty"), true);
+assert.equal(isPaneBufferEventSource("capture-pane"), true);
+assert.equal(isPaneBufferEventSource("events --json"), false);
+
+// A01: empty wrapper → empty unread
+const a01 = parseEventsCommandJson('{"cursor":0,"events":[]}');
+assert.deepEqual(a01, { cursor: 0, events: [] });
+assert.deepEqual(unreadEvents(a01.events, 0), []);
+assert.deepEqual(attentionFilterCounts(a01.events, 0), {
+  unread: 0,
+  waiting: 0,
+  approval: 0,
+  failure: 0,
+});
+
+// A02: requires_action cursor 3, lastSeen 0 → unread + approval/failure from kind
+const a02Approval = {
+  type: "requires_action",
+  cursor: 3,
+  pane_id: "%2",
+  kind: "board.approval.requested",
+};
+const a02Failure = {
+  type: "requires_action",
+  cursor: 3,
+  pane_id: "%3",
+  kind: "pane.crashed",
+};
+const a02Snapshot = parseEventsCommandJson(JSON.stringify({
+  cursor: 4,
+  events: [a02Approval],
+}));
+assert.equal(unreadEvents(a02Snapshot.events, 0).length, 1);
+assert.equal(classifyAttention(a02Approval), "approval");
+assert.equal(classifyAttention(a02Failure), "failure");
+assert.equal(classifyAttention({ type: "requires_action", cursor: 3, kind: "operator.blocked" }), "waiting");
+assert.deepEqual(attentionFilterCounts(a02Snapshot.events, 0), {
+  unread: 1,
+  waiting: 0,
+  approval: 1,
+  failure: 0,
+});
+
+// A03: lastSeenCursor 3, same event cursor 3 → not unread
+assert.deepEqual(unreadEvents(a02Snapshot.events, 3), []);
+assert.equal(attentionFilterCounts(a02Snapshot.events, 3).unread, 0);
+
+// A04: message_received → waiting-to-collect / unread artifact
+const a04Event = { type: "message_received", cursor: 2, run_id: "run-1", task_id: "TASK-1" };
+const a04 = parseEventsCommandJson(JSON.stringify({ cursor: 3, events: [a04Event] }));
+assert.equal(classifyAttention(a04Event), "waiting");
+assert.equal(unreadEvents(a04.events, 0).length, 1);
+assert.equal(attentionFilterCounts(a04.events, 0).waiting, 1);
+assert.equal(attentionJumpTarget(a04Event, ["run-1"]).runId, "run-1");
+assert.equal(attentionJumpTarget(a04Event, ["run-1"]).paneId, null);
+
+// A05: extra key on attention-center localStorage JSON → reject, previous state kept
+const a05Previous = emptyAttentionCenterState("/tmp/proj");
+a05Previous.lastSeenCursor = 7;
+const a05Loaded = loadAttentionCenterState(
+  '{"schema_version":1,"projectDir":"/tmp/proj","lastSeenCursor":0,"extra":true}',
+  a05Previous,
+);
+assert.match(a05Loaded.error, /rejected/i);
+assert.deepEqual(a05Loaded.state, a05Previous);
+assert.throws(() => parseAttentionCenterState('{"schema_version":2,"projectDir":"","lastSeenCursor":0}'));
+assert.throws(() => parseAttentionCenterState("[]"));
+assert.equal(ATTENTION_CENTER_STORAGE_KEY, "winsmux.attention-center.v1");
+
+// A06: malformed events stdout / missing events array → fail closed, no rows
+assert.throws(() => parseEventsCommandJson("{"));
+assert.throws(() => parseEventsCommandJson("[]"));
+assert.throws(() => parseEventsCommandJson('{"cursor":0}'));
+assert.throws(() => parseEventsCommandJson('{"events":[]}'));
+assert.throws(() => parseEventsCommandJson('{"type":"thread_created","cursor":1}'));
+const a06Malformed = readEventsCommandSnapshot({ exitCode: 0, stdout: "not-json", stderr: "" });
+assert.equal(a06Malformed.ok, false);
+assert.equal(a06Malformed.reason, "malformed");
+assert.deepEqual(a06Malformed.snapshot.events, []);
+const a06Usage = readEventsCommandSnapshot({
+  exitCode: 1,
+  stdout: "",
+  stderr: "usage: winsmux events [cursor] [--follow] [--json] [--project-dir <path>]",
+});
+assert.equal(a06Usage.ok, false);
+assert.equal(a06Usage.reason, "usage");
+assert.deepEqual(a06Usage.snapshot.events, []);
+
+// A07: unknown condensed type → ignored; wrapper cursor still consumed
+const a07 = parseEventsCommandJson(JSON.stringify({
+  cursor: 9,
+  events: [{ type: "pipeline_verify_pass", cursor: 8, extra: "allowed" }],
+}));
+assert.equal(a07.cursor, 9);
+assert.equal(classifyAttention(a07.events[0]), "ignored");
+assert.deepEqual(unreadEvents(a07.events, 0), []);
+const a07Marked = markAllRead(emptyAttentionCenterState("/tmp/proj"), a07.cursor);
+assert.equal(a07Marked.lastSeenCursor, 9);
+
+// A08: mark-all-read → lastSeenCursor = snapshot cursor
+const a08State = emptyAttentionCenterState("/repo");
+a08State.lastSeenCursor = 1;
+const a08 = markAllRead(a08State, 12);
+assert.equal(a08.lastSeenCursor, 12);
+assert.equal(a08.projectDir, "/repo");
+assert.deepEqual(Object.keys(JSON.parse(serializeAttentionCenterState(a08))), [
+  "schema_version",
+  "projectDir",
+  "lastSeenCursor",
+]);
+
+// A09: jump target prefers pane_id; missing pane does not invent an id
+const a09Pane = attentionJumpTarget({ type: "thread_created", cursor: 0, pane_id: "%1", run_id: "run-1" }, ["run-1"]);
+assert.equal(a09Pane.paneId, "%1");
+assert.equal(a09Pane.statusOnly, false);
+const a09Missing = attentionJumpTarget({ type: "status_idle", cursor: 1, stop_reason: "completed" }, ["run-1"]);
+assert.equal(a09Missing.paneId, null);
+assert.equal(a09Missing.runId, null);
+assert.equal(a09Missing.statusOnly, true);
+const a09UnknownRun = attentionJumpTarget({ type: "message_received", cursor: 2, run_id: "run-missing" }, ["run-1"]);
+assert.equal(a09UnknownRun.paneId, null);
+assert.equal(a09UnknownRun.statusOnly, true);
+
+// A10: resume/capture/pty strings are not an event source
+assert.equal(isPaneBufferAuthority("pty"), false);
+assert.equal(isPaneBufferAuthority("capture-pane"), false);
+assert.equal(isPaneBufferAuthority("resume"), false);
+assert.equal(isPaneBufferEventSource("pty"), true);
+assert.equal(isPaneBufferEventSource("capture-pane"), true);
+assert.equal(isPaneBufferEventSource("resume"), true);
+assert.doesNotMatch(attentionSource, /appendPaneOutputBuffer|capture-pane|outputBuffer/);
+
+assert.deepEqual(buildEventsCommandArgv("/tmp/proj", 0), ["events", "--json", "--project-dir", "/tmp/proj"]);
+assert.deepEqual(buildEventsCommandArgv("/tmp/proj", 3), ["events", "3", "--json", "--project-dir", "/tmp/proj"]);
+assert.equal(nextLastSeenCursor(3, 2), 3);
+assert.equal(nextLastSeenCursor(3, 3), 3);
+assert.equal(nextLastSeenCursor(3, 5), 5);
+assert.equal(markEventRead(emptyAttentionCenterState(), { type: "thread_created", cursor: 4 }).lastSeenCursor, 4);
+assert.equal(classifyAttention({ type: "thread_created", cursor: 0 }), "unread");
+assert.equal(classifyAttention({ type: "status_running", cursor: 1, pane_id: "%1" }), "running");
+assert.equal(classifyAttention({ type: "status_idle", cursor: 2, stop_reason: "completed" }), "idle");
+assert.equal(isCompanionWinsmuxMissingError(COMPANION_WINSMUX_MISSING_STATUS), true);
+assert.deepEqual(
+  alignAttentionCenterProject({ schema_version: 1, projectDir: "/old", lastSeenCursor: 8 }, "/new").lastSeenCursor,
+  0,
+);
+
+const mainSource = await readFile(path.resolve("src/main.ts"), "utf8");
+const htmlSource = await readFile(path.resolve("index.html"), "utf8");
+const stylesSource = await readFile(path.resolve("src/styles.css"), "utf8");
+const desktopClientSource = await readFile(path.resolve("src/desktopClient.ts"), "utf8");
+const libSource = await readFile(path.resolve("src-tauri/src/lib.rs"), "utf8");
+const backendSource = await readFile(path.resolve("src-tauri/src/desktop_backend.rs"), "utf8");
+const splitGateSource = await readFile(path.resolve("../scripts/test-v03626-desktop-split-gate.ps1"), "utf8");
+
+assert.match(mainSource, /from "\.\/attentionCenter"/);
+assert.match(mainSource, /ATTENTION_CENTER_STORAGE_KEY|winsmux\.attention-center\.v1/);
+assert.match(mainSource, /parseEventsCommandJson|readEventsCommandSnapshot/);
+assert.match(mainSource, /buildEventsCommandArgv/);
+assert.match(mainSource, /getDesktopEventsJson/);
+assert.match(mainSource, /getLanguageText\("Attention center", "要確認センター"\)/);
+assert.match(mainSource, /getLanguageText\("Mark all read", "すべて既読"\)/);
+assert.match(mainSource, /getLanguageText\("Unread", "未読"\)/);
+assert.match(mainSource, /getLanguageText\("Waiting", "待機"\)/);
+assert.match(mainSource, /getLanguageText\("Approval", "承認"\)/);
+assert.match(mainSource, /getLanguageText\("Failure", "失敗"\)/);
+assert.match(mainSource, /companion winsmux CLI was not found|COMPANION_WINSMUX_MISSING_STATUS/);
+assert.match(mainSource, /buildAgentVaultFeedEntries/);
+assert.match(mainSource, /focusWorkerPaneFromStatus/);
+assert.match(mainSource, /refreshAttentionCenter/);
+assert.doesNotMatch(mainSource, /poll-events --json/);
+assert.doesNotMatch(mainSource, /appendPaneOutputBuffer\([^)]*attention/i);
+
+assert.match(htmlSource, /id="attention-center"/);
+assert.match(htmlSource, /id="agent-vault-feed"/);
+assert.match(htmlSource, /id="agent-vault-ring"/);
+
+assert.match(stylesSource, /\.attention-center\b/);
+assert.doesNotMatch(stylesSource, /#pane-worker-[2-6][^{]*\{[^}]*(?:display\s*:\s*none|visibility\s*:\s*hidden)/);
+
+assert.match(desktopClientSource, /desktop_events_json/);
+assert.match(libSource, /fn desktop_events_json/);
+assert.match(backendSource, /fn load_desktop_events_json/);
+assert.match(backendSource, /events/);
+assert.match(backendSource, /--json/);
+assert.doesNotMatch(splitGateSource, /attention-center-check/);
+
+console.log("attention-center-check: ok");

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -87,6 +87,47 @@ fn apply_desktop_winsmux_child_env(
     }
 }
 
+fn build_companion_events_argv(project_dir: &str, cursor: u64) -> Vec<String> {
+    let mut args = vec!["events".to_string()];
+    if cursor > 0 {
+        args.push(cursor.to_string());
+    }
+    args.push("--json".to_string());
+    args.push("--project-dir".to_string());
+    args.push(project_dir.to_string());
+    args
+}
+
+pub fn load_desktop_events_json(project_dir: String, cursor: u64) -> Result<String, String> {
+    let companion = resolve_companion_winsmux_cli()
+        .ok_or_else(|| "companion winsmux CLI was not found".to_string())?;
+    let project_path = PathBuf::from(&project_dir);
+    if !project_path.is_dir() {
+        return Err(format!("project directory not found: {project_dir}"));
+    }
+
+    let args = build_companion_events_argv(&project_dir, cursor);
+    let mut command = Command::new(&companion);
+    command.args(&args).current_dir(&project_path);
+    apply_desktop_winsmux_child_env(&mut command, Some(companion.as_path()), std::process::id());
+    hide_subprocess_window(&mut command);
+
+    let output = command
+        .output()
+        .map_err(|err| format!("Failed to start companion winsmux: {err}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    if !output.status.success() {
+        let detail = if !stderr.trim().is_empty() {
+            stderr
+        } else {
+            stdout
+        };
+        return Err(format!("winsmux events failed: {}", detail.trim()));
+    }
+    Ok(stdout)
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct DesktopBoardSummary {
     pub pane_count: usize,
@@ -2716,6 +2757,18 @@ mod tests {
             .get_envs()
             .find(|(name, _)| name.to_string_lossy() == key)
             .and_then(|(_, value)| value.map(|value| value.to_string_lossy().to_string()))
+    }
+
+    #[test]
+    fn companion_events_argv_matches_public_cli() {
+        assert_eq!(
+            build_companion_events_argv(r"C:\proj", 0),
+            vec!["events", "--json", "--project-dir", r"C:\proj"]
+        );
+        assert_eq!(
+            build_companion_events_argv("/tmp/proj", 3),
+            vec!["events", "3", "--json", "--project-dir", "/tmp/proj"]
+        );
     }
 
     #[test]

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -7,8 +7,9 @@ mod remote_debug_gate;
 
 use control_pipe::{start_control_pipe_server, WINSMUX_CONTROL_PIPE_TOKEN_ENV};
 use desktop_backend::{
-    handle_desktop_json_rpc, load_desktop_run_explain, load_desktop_summary_snapshot,
-    resolve_repo_root, spawn_desktop_summary_refresh_stream, DesktopExplainPayload,
+    handle_desktop_json_rpc, load_desktop_events_json, load_desktop_run_explain,
+    load_desktop_summary_snapshot, resolve_repo_root, spawn_desktop_summary_refresh_stream,
+    DesktopExplainPayload,
     DesktopJsonRpcRequest, DesktopJsonRpcResponse, DesktopStreamCommand,
     DesktopSummaryRefreshSignal, DesktopSummarySnapshot, DesktopVoiceCaptureStatus,
     PwshScriptTransport,
@@ -1167,6 +1168,11 @@ async fn desktop_run_explain(
 }
 
 #[tauri::command]
+fn desktop_events_json(project_dir: String, cursor: Option<u64>) -> Result<String, String> {
+    load_desktop_events_json(project_dir, cursor.unwrap_or(0))
+}
+
+#[tauri::command]
 async fn desktop_json_rpc(
     request: DesktopJsonRpcRequest,
     project_dir: Option<String>,
@@ -2006,6 +2012,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             desktop_summary_snapshot,
             desktop_run_explain,
+            desktop_events_json,
             desktop_json_rpc,
             desktop_voice_capture_status,
             desktop_voice_capture_start,

--- a/winsmux-app/src/attentionCenter.ts
+++ b/winsmux-app/src/attentionCenter.ts
@@ -1,0 +1,370 @@
+export const ATTENTION_CENTER_STORAGE_KEY = "winsmux.attention-center.v1";
+export const COMPANION_WINSMUX_MISSING_STATUS = "companion winsmux CLI was not found";
+
+export const ATTENTION_EVENT_TYPES = [
+  "thread_created",
+  "status_running",
+  "status_idle",
+  "message_received",
+  "requires_action",
+] as const;
+
+export type AttentionEventType = (typeof ATTENTION_EVENT_TYPES)[number];
+export type AttentionKind = "unread" | "waiting" | "approval" | "failure" | "running" | "idle" | "ignored";
+export type AttentionFilter = "unread" | "waiting" | "approval" | "failure";
+
+export interface AttentionCenterState {
+  schema_version: 1;
+  projectDir: string;
+  lastSeenCursor: number;
+}
+
+export interface CondensedEvent {
+  type: string;
+  cursor?: number;
+  pane_id?: string;
+  run_id?: string;
+  task_id?: string;
+  role?: string;
+  stop_reason?: string;
+  kind?: string;
+  [key: string]: unknown;
+}
+
+export interface EventsCommandSnapshot {
+  cursor: number;
+  events: CondensedEvent[];
+}
+
+export interface AttentionJumpTarget {
+  paneId: string | null;
+  runId: string | null;
+  statusOnly: boolean;
+}
+
+export type EventsCommandFailureReason = "usage" | "exit" | "malformed";
+
+export type EventsCommandReadResult =
+  | { ok: true; snapshot: EventsCommandSnapshot }
+  | { ok: false; reason: EventsCommandFailureReason; snapshot: EventsCommandSnapshot };
+
+const STATE_KEYS = ["schema_version", "projectDir", "lastSeenCursor"] as const;
+const PANE_BUFFER_SOURCE = new RegExp(
+  [
+    "pty",
+    ["capture", "pane"].join("-"),
+    ["capture", "pane"].join("_"),
+    ["append", "pane", "output", "buffer"].join(""),
+    ["output", "buffer"].join(""),
+    "resum" + "e",
+  ].join("|"),
+  "i",
+);
+
+export function emptyAttentionCenterState(projectDir = ""): AttentionCenterState {
+  return {
+    schema_version: 1,
+    projectDir: normalizeAttentionProjectDir(projectDir),
+    lastSeenCursor: 0,
+  };
+}
+
+export function normalizeAttentionProjectDir(value: string | null | undefined): string {
+  return (value ?? "").trim().replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+export function serializeAttentionCenterState(state: AttentionCenterState): string {
+  if (state.schema_version !== 1) {
+    throw new Error("attention-center schema_version must be 1");
+  }
+  if (typeof state.projectDir !== "string") {
+    throw new Error("attention-center projectDir must be a string");
+  }
+  if (!Number.isInteger(state.lastSeenCursor) || state.lastSeenCursor < 0) {
+    throw new Error("attention-center lastSeenCursor must be an integer >= 0");
+  }
+  return JSON.stringify({
+    schema_version: 1,
+    projectDir: normalizeAttentionProjectDir(state.projectDir),
+    lastSeenCursor: state.lastSeenCursor,
+  });
+}
+
+export function parseAttentionCenterState(text: string): AttentionCenterState {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("attention-center state is not valid JSON");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("attention-center state must be an object");
+  }
+  const record = parsed as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (keys.length !== STATE_KEYS.length || STATE_KEYS.some((key) => !keys.includes(key))) {
+    throw new Error("attention-center state must contain only schema_version, projectDir, and lastSeenCursor");
+  }
+  if (record.schema_version !== 1) {
+    throw new Error("attention-center schema_version must be 1");
+  }
+  if (typeof record.projectDir !== "string") {
+    throw new Error("attention-center projectDir must be a string");
+  }
+  if (!Number.isInteger(record.lastSeenCursor) || (record.lastSeenCursor as number) < 0) {
+    throw new Error("attention-center lastSeenCursor must be an integer >= 0");
+  }
+  return {
+    schema_version: 1,
+    projectDir: normalizeAttentionProjectDir(record.projectDir),
+    lastSeenCursor: record.lastSeenCursor as number,
+  };
+}
+
+export function loadAttentionCenterState(
+  rawValue: string | null | undefined,
+  previous: AttentionCenterState = emptyAttentionCenterState(),
+): { state: AttentionCenterState; error: string | null } {
+  if (rawValue === null || rawValue === undefined || rawValue.trim() === "") {
+    return { state: previous, error: null };
+  }
+  try {
+    return { state: parseAttentionCenterState(rawValue), error: null };
+  } catch {
+    return {
+      state: previous,
+      error: "Attention center state was rejected. Previous state was kept.",
+    };
+  }
+}
+
+export function persistAttentionCenterStateToStorage(
+  storage: Pick<Storage, "setItem"> | null | undefined,
+  state: AttentionCenterState,
+): { ok: true } | { ok: false; error: string } {
+  if (!storage) {
+    return { ok: false, error: "Attention center state could not be saved." };
+  }
+  try {
+    storage.setItem(ATTENTION_CENTER_STORAGE_KEY, serializeAttentionCenterState(state));
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "Attention center state could not be saved." };
+  }
+}
+
+export function alignAttentionCenterProject(state: AttentionCenterState, projectDir: string): AttentionCenterState {
+  const normalized = normalizeAttentionProjectDir(projectDir);
+  if (state.projectDir === normalized) {
+    return state;
+  }
+  return emptyAttentionCenterState(normalized);
+}
+
+export function parseEventsCommandJson(text: string): EventsCommandSnapshot {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error("events --json stdout is not valid JSON");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("events --json stdout must be an object with cursor and events");
+  }
+  const record = parsed as Record<string, unknown>;
+  if (!Object.prototype.hasOwnProperty.call(record, "cursor") || !Object.prototype.hasOwnProperty.call(record, "events")) {
+    throw new Error("events --json stdout must include cursor and events");
+  }
+  if (!Number.isInteger(record.cursor) || (record.cursor as number) < 0) {
+    throw new Error("events --json cursor must be an integer >= 0");
+  }
+  if (!Array.isArray(record.events)) {
+    throw new Error("events --json events must be an array");
+  }
+  const events: CondensedEvent[] = [];
+  for (const item of record.events) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw new Error("events --json events must contain objects");
+    }
+    const event = item as Record<string, unknown>;
+    const type = typeof event.type === "string" ? event.type : "";
+    events.push({
+      ...(event as CondensedEvent),
+      type,
+    });
+  }
+  return {
+    cursor: record.cursor as number,
+    events,
+  };
+}
+
+export function emptyEventsSnapshot(): EventsCommandSnapshot {
+  return { cursor: 0, events: [] };
+}
+
+export function isEventsCommandUsageText(text: string): boolean {
+  return /usage:\s*winsmux events/i.test(text);
+}
+
+export function isCompanionWinsmuxMissingError(message: string): boolean {
+  return /companion winsmux/i.test(message) && /not found|missing/i.test(message);
+}
+
+export function readEventsCommandSnapshot(result: {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}): EventsCommandReadResult {
+  const combined = `${result.stdout}\n${result.stderr}`;
+  if (result.exitCode !== 0) {
+    return {
+      ok: false,
+      reason: isEventsCommandUsageText(combined) ? "usage" : "exit",
+      snapshot: emptyEventsSnapshot(),
+    };
+  }
+  try {
+    return { ok: true, snapshot: parseEventsCommandJson(result.stdout) };
+  } catch {
+    return { ok: false, reason: "malformed", snapshot: emptyEventsSnapshot() };
+  }
+}
+
+export function eventCursor(event: CondensedEvent): number | null {
+  if (!Number.isInteger(event.cursor) || (event.cursor as number) < 0) {
+    return null;
+  }
+  return event.cursor as number;
+}
+
+export function classifyAttention(event: CondensedEvent): AttentionKind {
+  switch (event.type) {
+    case "thread_created":
+      return "unread";
+    case "status_running":
+      return "running";
+    case "status_idle":
+      return "idle";
+    case "message_received":
+      return "waiting";
+    case "requires_action":
+      return classifyRequiresActionKind(typeof event.kind === "string" ? event.kind : "");
+    default:
+      return "ignored";
+  }
+}
+
+function classifyRequiresActionKind(kind: string): "waiting" | "approval" | "failure" {
+  const value = kind.toLowerCase();
+  if (/(crash|hung|stall|fail)/.test(value)) {
+    return "failure";
+  }
+  if (/(approval|review_requested)/.test(value)) {
+    return "approval";
+  }
+  return "waiting";
+}
+
+export function unreadEvents(events: CondensedEvent[], lastSeenCursor: number): CondensedEvent[] {
+  const seen = Number.isInteger(lastSeenCursor) && lastSeenCursor >= 0 ? lastSeenCursor : 0;
+  return events.filter((event) => {
+    if (classifyAttention(event) === "ignored") {
+      return false;
+    }
+    const cursor = eventCursor(event);
+    return cursor !== null && cursor > seen;
+  });
+}
+
+export function attentionEventsForFilter(
+  events: CondensedEvent[],
+  lastSeenCursor: number,
+  filter: AttentionFilter,
+): CondensedEvent[] {
+  const unread = unreadEvents(events, lastSeenCursor);
+  if (filter === "unread") {
+    return unread;
+  }
+  return unread.filter((event) => classifyAttention(event) === filter);
+}
+
+export function attentionFilterCounts(events: CondensedEvent[], lastSeenCursor: number): Record<AttentionFilter, number> {
+  const unread = unreadEvents(events, lastSeenCursor);
+  return {
+    unread: unread.length,
+    waiting: unread.filter((event) => classifyAttention(event) === "waiting").length,
+    approval: unread.filter((event) => classifyAttention(event) === "approval").length,
+    failure: unread.filter((event) => classifyAttention(event) === "failure").length,
+  };
+}
+
+export function nextLastSeenCursor(current: number, observedCursor: number): number {
+  const currentCursor = Number.isInteger(current) && current >= 0 ? current : 0;
+  if (!Number.isInteger(observedCursor) || observedCursor < 0) {
+    return currentCursor;
+  }
+  return observedCursor >= currentCursor ? observedCursor : currentCursor;
+}
+
+export function markAllRead(state: AttentionCenterState, snapshotCursor: number): AttentionCenterState {
+  if (!Number.isInteger(snapshotCursor) || snapshotCursor < 0) {
+    return state;
+  }
+  return {
+    ...state,
+    lastSeenCursor: snapshotCursor,
+  };
+}
+
+export function markEventRead(state: AttentionCenterState, event: CondensedEvent): AttentionCenterState {
+  const cursor = eventCursor(event);
+  if (cursor === null) {
+    return state;
+  }
+  return {
+    ...state,
+    lastSeenCursor: nextLastSeenCursor(state.lastSeenCursor, cursor),
+  };
+}
+
+export function optionalEventString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function attentionJumpTarget(
+  event: CondensedEvent,
+  availableRunIds: readonly string[] = [],
+): AttentionJumpTarget {
+  const paneId = optionalEventString(event.pane_id);
+  if (paneId) {
+    return { paneId, runId: optionalEventString(event.run_id), statusOnly: false };
+  }
+  const runId = optionalEventString(event.run_id);
+  if (runId && availableRunIds.includes(runId)) {
+    return { paneId: null, runId, statusOnly: false };
+  }
+  return { paneId: null, runId: runId && availableRunIds.includes(runId) ? runId : null, statusOnly: true };
+}
+
+export function buildEventsCommandArgv(projectDir: string, lastSeenCursor: number): string[] {
+  const args = ["events"];
+  if (Number.isInteger(lastSeenCursor) && lastSeenCursor > 0) {
+    args.push(String(lastSeenCursor));
+  }
+  args.push("--json", "--project-dir", projectDir);
+  return args;
+}
+
+export function isPaneBufferAuthority(source: string): boolean {
+  void source;
+  return false;
+}
+
+export function isPaneBufferEventSource(source: string): boolean {
+  return PANE_BUFFER_SOURCE.test(source);
+}

--- a/winsmux-app/src/desktopClient.ts
+++ b/winsmux-app/src/desktopClient.ts
@@ -957,6 +957,20 @@ export async function getDesktopInitialProjectDir() {
   return await invoke<string | null>("desktop_initial_project_dir");
 }
 
+export async function getDesktopEventsJson(projectDir: string, cursor = 0) {
+  if (!isTauri()) {
+    throw new Error("companion winsmux CLI was not found");
+  }
+  try {
+    return await invoke<string>("desktop_events_json", {
+      projectDir,
+      cursor,
+    });
+  } catch (error) {
+    throw normalizeDesktopError("desktop_events_json", error);
+  }
+}
+
 export async function writeDesktopOrchestraMode(
   projectDir: string,
   relativePath: string,

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -16,6 +16,7 @@ import {
   getDesktopRunExplain,
   getDesktopExplorerEntries,
   getDesktopSummarySnapshot,
+  getDesktopEventsJson,
   getDesktopWorkersStatus,
   getDesktopTeamProfileSettingsView,
   getDesktopVoiceCaptureStatus,
@@ -120,6 +121,7 @@ import {
   renderFirstRunWizard,
 } from "./firstRunWizard";
 import * as vaultOrganize from "./agentVaultOrganize";
+import * as attentionCenter from "./attentionCenter";
 
 interface PaneEntry {
   terminal: Terminal;
@@ -683,6 +685,11 @@ let agentVaultStatusMessage = "";
 let selectedAgentVaultSessionId = "";
 let agentVaultOrganizeState = vaultOrganize.emptyAgentVaultOrganize();
 let agentVaultShowArchived = false;
+let attentionCenterState = attentionCenter.emptyAttentionCenterState();
+let attentionCenterEvents: attentionCenter.CondensedEvent[] = [];
+let attentionCenterSnapshotCursor = 0;
+let attentionCenterStatusMessage = "";
+let attentionCenterFilter: attentionCenter.AttentionFilter = "unread";
 const agentVaultCollapsedProviderIds = new Set<AgentVaultProviderId>();
 const agentVaultCollapsedGroupIds = new Set<string>();
 let workbenchLayout: WorkbenchLayoutMode = "3x2";
@@ -3163,6 +3170,234 @@ function getVisibleAgentVaultEntries() {
   });
 }
 
+function persistAttentionCenterState() {
+  const saved = attentionCenter.persistAttentionCenterStateToStorage(window.localStorage, attentionCenterState);
+  if (!saved.ok) {
+    attentionCenterStatusMessage = getLanguageText(saved.error, "要確認センターの状態を保存できませんでした。");
+    return false;
+  }
+  return true;
+}
+
+function loadAttentionCenterStateFromStorage() {
+  const loaded = attentionCenter.loadAttentionCenterState(
+    window.localStorage.getItem(attentionCenter.ATTENTION_CENTER_STORAGE_KEY),
+  );
+  attentionCenterState = loaded.state;
+  if (loaded.error) {
+    attentionCenterStatusMessage = getLanguageText(loaded.error, "要確認センターの状態を読み込めませんでした。以前の状態を保持します。");
+  }
+}
+
+async function refreshAttentionCenter() {
+  const projectDir = normalizeProjectDirInput(getActiveProjectDirPayload()) || "";
+  const previousProjectDir = attentionCenterState.projectDir;
+  attentionCenterState = attentionCenter.alignAttentionCenterProject(attentionCenterState, projectDir);
+  if (attentionCenterState.projectDir !== previousProjectDir) {
+    persistAttentionCenterState();
+  }
+  if (!projectDir) {
+    attentionCenterEvents = [];
+    attentionCenterSnapshotCursor = 0;
+    return;
+  }
+
+  try {
+    const argv = attentionCenter.buildEventsCommandArgv(projectDir, attentionCenterState.lastSeenCursor);
+    if (!argv.includes("--json")) {
+      attentionCenterEvents = [];
+      attentionCenterSnapshotCursor = 0;
+      attentionCenterStatusMessage = getLanguageText("events --json is required.", "events --json が必要です。");
+      return;
+    }
+    const stdout = await getDesktopEventsJson(projectDir, attentionCenterState.lastSeenCursor);
+    const snapshot = attentionCenter.parseEventsCommandJson(stdout);
+    attentionCenterEvents = snapshot.events;
+    attentionCenterSnapshotCursor = snapshot.cursor;
+    attentionCenterStatusMessage = "";
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (attentionCenter.isCompanionWinsmuxMissingError(message) || /companion winsmux CLI was not found/i.test(message)) {
+      attentionCenterStatusMessage = getLanguageText(
+        attentionCenter.COMPANION_WINSMUX_MISSING_STATUS,
+        "companion winsmux 実行ファイルが見つかりません。",
+      );
+      return;
+    }
+    attentionCenterEvents = [];
+    attentionCenterSnapshotCursor = 0;
+    if (attentionCenter.isEventsCommandUsageText(message)) {
+      attentionCenterStatusMessage = getLanguageText("events --json is required.", "events --json が必要です。");
+      return;
+    }
+    attentionCenterStatusMessage = getLanguageText(
+      "Condensed events could not be read.",
+      "要約イベントを読み取れませんでした。",
+    );
+  }
+}
+
+function describeAttentionEvent(event: attentionCenter.CondensedEvent): { title: string; body: string; tone: SurfaceTone } {
+  const kind = attentionCenter.classifyAttention(event);
+  switch (event.type) {
+    case "thread_created":
+      return {
+        title: getLanguageText("Unread thread", "未読スレッド"),
+        body: String(event.role || event.pane_id || event.run_id || ""),
+        tone: "info",
+      };
+    case "status_running":
+      return {
+        title: getLanguageText("Running", "実行中"),
+        body: String(event.pane_id || event.run_id || ""),
+        tone: "info",
+      };
+    case "status_idle":
+      return {
+        title: getLanguageText("Idle", "アイドル"),
+        body: String(event.stop_reason || event.pane_id || ""),
+        tone: "info",
+      };
+    case "message_received":
+      return {
+        title: getLanguageText("Waiting to collect", "回収待ち"),
+        body: String(event.task_id || event.run_id || ""),
+        tone: "warning",
+      };
+    case "requires_action":
+      if (kind === "failure") {
+        return { title: getLanguageText("Failure", "失敗"), body: String(event.kind || ""), tone: "danger" };
+      }
+      if (kind === "approval") {
+        return { title: getLanguageText("Approval", "承認"), body: String(event.kind || ""), tone: "warning" };
+      }
+      return { title: getLanguageText("Waiting", "待機"), body: String(event.kind || ""), tone: "warning" };
+    default:
+      return { title: event.type, body: "", tone: "info" };
+  }
+}
+
+function getAttentionAndFeedTone(feedEntries: AgentVaultFeedEntry[]): SurfaceTone {
+  const unread = attentionCenter.unreadEvents(attentionCenterEvents, attentionCenterState.lastSeenCursor);
+  if (unread.some((event) => attentionCenter.classifyAttention(event) === "failure") || feedEntries.some((entry) => entry.tone === "danger")) {
+    return "danger";
+  }
+  if (
+    unread.some((event) => {
+      const kind = attentionCenter.classifyAttention(event);
+      return kind === "approval" || kind === "waiting";
+    })
+    || feedEntries.some((entry) => entry.tone === "warning")
+  ) {
+    return "warning";
+  }
+  return getAgentVaultNotificationTone(feedEntries);
+}
+
+function markAllAttentionRead() {
+  attentionCenterState = attentionCenter.markAllRead(attentionCenterState, attentionCenterSnapshotCursor);
+  persistAttentionCenterState();
+  renderAgentVaultPanel();
+}
+
+function focusAttentionEvent(event: attentionCenter.CondensedEvent) {
+  const jump = attentionCenter.attentionJumpTarget(event, getAvailableRunIds());
+  attentionCenterState = attentionCenter.markEventRead(attentionCenterState, event);
+  persistAttentionCenterState();
+  if (jump.paneId) {
+    focusWorkerPaneFromStatus(jump.paneId);
+    attentionCenterStatusMessage = getLanguageText(
+      `Focused ${getPaneDisplayLabel(jump.paneId)} from Attention center.`,
+      `要確認センターから ${getPaneDisplayLabel(jump.paneId)} へ移動しました。`,
+    );
+  } else if (jump.runId) {
+    setSelectedRun(jump.runId);
+    attentionCenterStatusMessage = getLanguageText(
+      `Selected run ${jump.runId} from Attention center.`,
+      `要確認センターから run ${jump.runId} を選択しました。`,
+    );
+    renderDesktopSurfaces();
+    return;
+  } else {
+    attentionCenterStatusMessage = getLanguageText(
+      "No pane is attached to this event.",
+      "このイベントに紐づくペインはありません。",
+    );
+  }
+  renderAgentVaultPanel();
+}
+
+function renderAttentionCenter(root: HTMLElement) {
+  const counts = attentionCenter.attentionFilterCounts(attentionCenterEvents, attentionCenterState.lastSeenCursor);
+  const rows = attentionCenter.attentionEventsForFilter(
+    attentionCenterEvents,
+    attentionCenterState.lastSeenCursor,
+    attentionCenterFilter,
+  );
+  root.replaceChildren();
+
+  const header = document.createElement("div");
+  header.className = "attention-center-header";
+  const title = document.createElement("div");
+  title.className = "attention-center-title";
+  title.textContent = getLanguageText("Attention center", "要確認センター");
+  const markAll = document.createElement("button");
+  markAll.type = "button";
+  markAll.className = "agent-vault-filter-btn";
+  markAll.textContent = getLanguageText("Mark all read", "すべて既読");
+  markAll.addEventListener("click", () => markAllAttentionRead());
+  header.append(title, markAll);
+  root.appendChild(header);
+
+  const filters = document.createElement("div");
+  filters.className = "attention-center-filters";
+  const filterItems: Array<{ id: attentionCenter.AttentionFilter; label: string; count: number }> = [
+    { id: "unread", label: getLanguageText("Unread", "未読"), count: counts.unread },
+    { id: "waiting", label: getLanguageText("Waiting", "待機"), count: counts.waiting },
+    { id: "approval", label: getLanguageText("Approval", "承認"), count: counts.approval },
+    { id: "failure", label: getLanguageText("Failure", "失敗"), count: counts.failure },
+  ];
+  for (const filter of filterItems) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "agent-vault-filter-btn";
+    button.textContent = `${filter.label} ${filter.count}`;
+    button.setAttribute("aria-pressed", attentionCenterFilter === filter.id ? "true" : "false");
+    button.addEventListener("click", () => {
+      attentionCenterFilter = filter.id;
+      renderAgentVaultPanel();
+    });
+    filters.appendChild(button);
+  }
+  root.appendChild(filters);
+
+  if (attentionCenterStatusMessage) {
+    const status = document.createElement("div");
+    status.className = "attention-center-status";
+    status.textContent = attentionCenterStatusMessage;
+    root.appendChild(status);
+  }
+
+  if (rows.length === 0) {
+    const empty = document.createElement("div");
+    empty.className = "attention-center-empty";
+    empty.textContent = getLanguageText("No unread condensed events.", "未読の要約イベントはありません。");
+    root.appendChild(empty);
+    return;
+  }
+
+  for (const event of rows) {
+    const described = describeAttentionEvent(event);
+    const row = document.createElement("button");
+    row.type = "button";
+    row.className = "attention-center-row";
+    row.dataset.tone = described.tone;
+    row.textContent = described.body ? `${described.title}: ${described.body}` : described.title;
+    row.addEventListener("click", () => focusAttentionEvent(event));
+    root.appendChild(row);
+  }
+}
+
 function buildAgentVaultFeedEntries(): AgentVaultFeedEntry[] {
   const entries: AgentVaultFeedEntry[] = [];
   for (const item of desktopSummarySnapshot?.inbox.items ?? []) {
@@ -3331,6 +3566,7 @@ function renderAgentVaultPanel() {
   const providerFilters = document.getElementById("agent-vault-provider-filters");
   const status = document.getElementById("agent-vault-drop-status");
   const list = document.getElementById("agent-vault-session-list");
+  const attentionRoot = document.getElementById("attention-center");
   const feed = document.getElementById("agent-vault-feed");
 
   if (search && search.value !== agentVaultQuery) {
@@ -3344,10 +3580,18 @@ function renderAgentVaultPanel() {
   if (title) {
     title.textContent = getLanguageText(`${visibleEntries.length} indexed sessions`, `${visibleEntries.length} 件の索引済みセッション`);
   }
+  const attentionCounts = attentionCenter.attentionFilterCounts(
+    attentionCenterEvents,
+    attentionCenterState.lastSeenCursor,
+  );
   if (ring) {
-    ring.textContent = feedEntries.length > 0 ? `${feedEntries.length}` : "OK";
-    ring.dataset.tone = getAgentVaultNotificationTone(feedEntries);
-    ring.title = getLanguageText("Feed and worker notification ring", "フィードとワーカー通知リング");
+    const ringCount = attentionCounts.unread + feedEntries.length;
+    ring.textContent = ringCount > 0 ? `${ringCount}` : "OK";
+    ring.dataset.tone = getAttentionAndFeedTone(feedEntries);
+    ring.title = getLanguageText(
+      `${attentionCounts.unread} unread attention · ${feedEntries.length} inbox`,
+      `未読 ${attentionCounts.unread} · 受信箱 ${feedEntries.length}`,
+    );
   }
   if (projectFilter) {
     projectFilter.textContent = getLanguageText("This project", "このプロジェクト");
@@ -3404,6 +3648,9 @@ function renderAgentVaultPanel() {
         });
       }
     }
+  }
+  if (attentionRoot) {
+    renderAttentionCenter(attentionRoot);
   }
   if (feed) {
     feed.replaceChildren();
@@ -18355,7 +18602,9 @@ async function refreshDesktopSummaryFromScheduler(context: DesktopSummaryRefresh
       }
     }
 
+    await refreshAttentionCenter();
     if (previousSnapshot && !diff.hasMeaningfulChange && !forceExplainRunId && !shouldPrefetchExplain) {
+      renderAgentVaultPanel();
       return;
     }
 
@@ -18582,6 +18831,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   } catch {
     agentVaultStatusMessage = getLanguageText("Agent Vault organize data was rejected. Previous state was kept.", "Agent Vault の整理データを読み込めませんでした。以前の状態を保持します。");
   }
+  loadAttentionCenterStateFromStorage();
 
   applyShellPreferences();
   applyLanguageChrome();
@@ -18634,6 +18884,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   renderSourceEntries();
   renderEvidenceView();
   renderAgentVaultPanel();
+  void refreshAttentionCenter().then(() => renderAgentVaultPanel());
   renderContextPanel();
   renderSettingsControls();
   renderFooterLane();

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -3469,6 +3469,72 @@ body[data-popout-surface="1"] #editor-surface {
   opacity: 0.72;
 }
 
+.attention-center {
+  display: grid;
+  gap: 6px;
+  padding-top: 4px;
+}
+
+.attention-center-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.attention-center-title {
+  color: var(--ws-fg);
+  font-size: var(--text-xs);
+  font-weight: 700;
+}
+
+.attention-center-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.attention-center-status {
+  color: var(--ws-fg-muted);
+  font-size: var(--text-xs);
+}
+
+.attention-center-empty {
+  color: var(--ws-fg-muted);
+  font-size: var(--text-xs);
+}
+
+.attention-center-row {
+  width: 100%;
+  border: 0;
+  border-left: 2px solid var(--ws-border-focus);
+  background: transparent;
+  padding-left: 7px;
+  color: var(--ws-fg-secondary);
+  font-size: var(--text-xs);
+  line-height: 1.35;
+  text-align: left;
+  cursor: pointer;
+}
+
+.attention-center-row:hover,
+.attention-center-row:focus-visible {
+  color: var(--ws-fg);
+  outline: none;
+}
+
+.attention-center-row:disabled {
+  cursor: default;
+}
+
+.attention-center-row[data-tone="warning"] {
+  border-left-color: #f5c15d;
+}
+
+.attention-center-row[data-tone="danger"] {
+  border-left-color: #ff8a8a;
+}
+
 .agent-vault-feed {
   display: grid;
   gap: 6px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

TASK-666 only. Draft. Do not merge.

Stacked on #1274 / `acd67c3`. Base branch `cursor/task-665-vault-archive-group-fork` so this diff does not re-list TASK-664/665 files.

Adds an unread **Attention center** that consumes the public `winsmux events --json` command (TASK-786 condensed events). The operator can see unread / waiting / approval / failure and jump to the pane when `pane_id` is present, or select an existing `run_id` when the pane is unknown.

Reuse, do not rebuild:

- Desktop inbox remains `desktopSummarySnapshot.inbox` via `buildAgentVaultFeedEntries`. Inbox rows stay visible.
- Public CLI remains `winsmux events [cursor] [--follow] [--json] [--project-dir <path>]`. One JSON wrapper `{"cursor": <int>, "events": [...]}`. Never a bare array. Never NDJSON of bare events.
- Jump reuses `focusWorkerPaneFromStatus` / existing run selection.

Unread state is desktop localStorage only (`winsmux.attention-center.v1`: `schema_version`, `projectDir`, `lastSeenCursor`). Extra keys / `schema_version` ≠ 1 reject and keep the previous valid state. Mark-all-read sets `lastSeenCursor` to the snapshot wrapper cursor. Per-row read is monotonic.

Companion `winsmux` is spawned with argv `events [--cursor] --json --project-dir <dir>`. Missing companion shows a status string and keeps the inbox feed. Pane PTY / capture-pane / `appendPaneOutputBuffer` are not an event authority. No second event store. `poll-events` is unchanged. No TASK-667 HUD. No TASK-789 spawn/archive.

## Surface Classification

- [x] Public product surface
- [x] Contributor/test surface
- [ ] Runtime contract surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Responsibility And Cutover

- Replaced behavior, workflow, config path, or responsibility: none. Attention center is additive on Agent Vault next to the existing inbox feed.
- Expected outcome: condensed events with cursor greater than `lastSeenCursor` appear under Unread / Waiting / Approval / Failure; click jumps to pane or known run; mark-all-read advances the localStorage cursor.
- Source of truth: `winsmux events --json` wrapper from the companion CLI. Inbox remains `desktopSummarySnapshot.inbox`. Cursor overlay is desktop localStorage only.
- Old paths preserved, redirected, deprecated, or removed: `.winsmux/events.jsonl` and `poll-events` are unchanged. Pane buffers are not an attention source.

## Verification

Ubuntu (this agent). Not orchestra-smoke / Pester / Tauri desktop-pane-e2e proof. `test:attention-center` is not added to `scripts/test-v03626-desktop-split-gate.ps1`.

```
cd winsmux-app
npm ci
node ./scripts/attention-center-check.mjs
npm run build
```

Exit codes:

- `npm ci`: **0**
- `node ./scripts/attention-center-check.mjs`: **0**
- `npm run build` (`tsc && vite build`): **0**

RED then GREEN: `21b4721` test commit failed product source assertions on unmodified `main.ts`; `035955c` feat commit wires the attention center and the same node check passes.

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.

Attention cursor JSON is not written to the project `.winsmux` directory. Invalid JSON / extra keys fail closed without writing. Status strings do not dump event payloads, secrets, or pane buffers.

Do not merge. Do not mark ready. Do not tag. Do not npm publish. Do not bump VERSION.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d6b028d-79d4-4b1b-be37-e5a13237279e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d6b028d-79d4-4b1b-be37-e5a13237279e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

