### PR TITLE
feat(orchestra): spawn worker panes on dispatch and archive on collect (TASK-789)

### DIFF
--- a/core/src/prompt_bundle.rs
+++ b/core/src/prompt_bundle.rs
@@ -5,12 +5,10 @@ use std::{
 };
 
 use serde_json::{json, Value as JsonValue};
-use serde_yaml::{Mapping, Value};
 use sha2::{Digest, Sha256};
 
 use crate::instruction_pack::{self, compose_pack};
 use crate::team_profile::{self, ResolvedSlot, ResolvedTeam};
-use crate::workspace_recipe::parse_workspace_yaml;
 
 pub(crate) fn project_launch(
     project_dir: &Path,
@@ -52,12 +50,6 @@ pub(crate) fn project_launch(
     let digest = format!("{:x}", Sha256::digest(body.as_bytes()));
     let rel_path = format!(".winsmux/runtime/prompt-bundles/{session_id}/{slot_id}.md");
     let bundle_path = project_dir.join(&rel_path);
-    let manifest_path = project_dir.join(".winsmux").join("manifest.yaml");
-    let original_manifest = if manifest_path.is_file() {
-        Some(fs::read_to_string(&manifest_path)?)
-    } else {
-        None
-    };
     let original_bundle = if bundle_path.is_file() {
         Some(fs::read(&bundle_path)?)
     } else {
@@ -72,44 +64,16 @@ pub(crate) fn project_launch(
         &digest,
         &pack.template_ids,
     )?;
-    let merged_manifest = original_manifest
-        .as_deref()
-        .map(|original| merge_manifest(original, &projection, &slot.slot_id))
-        .transpose()?;
 
     fs::create_dir_all(bundle_path.parent().ok_or_else(|| {
         invalid_input("prompt-bundle path has no parent directory.")
     })?)?;
     let tmp_bundle = bundle_path.with_extension("md.tmp-prompt-bundle");
     fs::write(&tmp_bundle, &body)?;
-    let tmp_manifest = merged_manifest.as_ref().map(|merged| {
-        (
-            manifest_path.with_extension("yaml.tmp-prompt-bundle"),
-            merged,
-        )
-    });
-    if let Some((tmp_path, merged)) = tmp_manifest.as_ref() {
-        fs::create_dir_all(manifest_path.parent().ok_or_else(|| {
-            invalid_input("manifest path has no parent directory.")
-        })?)?;
-        fs::write(tmp_path, merged)?;
-    }
     if let Err(error) = replace_existing_file(&tmp_bundle, &bundle_path) {
         let _ = fs::remove_file(&tmp_bundle);
-        if let Some((tmp_path, _)) = tmp_manifest.as_ref() {
-            let _ = fs::remove_file(tmp_path);
-        }
+        restore_previous_bundle(&bundle_path, original_bundle.as_deref());
         return Err(error);
-    }
-    if let Some((tmp_path, _)) = tmp_manifest.as_ref() {
-        if let Err(error) = replace_existing_file(tmp_path, &manifest_path) {
-            let _ = fs::remove_file(tmp_path);
-            restore_previous_bundle(&bundle_path, original_bundle.as_deref());
-            if let Some(original) = original_manifest {
-                let _ = fs::write(&manifest_path, original);
-            }
-            return Err(error);
-        }
     }
     Ok(json!({
         "schema_version": 1,
@@ -182,75 +146,6 @@ fn projection_value(
     }))
 }
 
-fn merge_manifest(original: &str, projection: &JsonValue, slot_id: &str) -> io::Result<String> {
-    let mut root = parse_workspace_yaml(original)?;
-    let mapping = root
-        .as_mapping_mut()
-        .ok_or_else(|| invalid_data("manifest.yaml must be a mapping."))?;
-    let session = mapping
-        .entry(Value::String("session".into()))
-        .or_insert(Value::Mapping(Mapping::new()));
-    let session_map = session
-        .as_mapping_mut()
-        .ok_or_else(|| invalid_data("manifest session must be a mapping."))?;
-    session_map.insert(
-        Value::String("team_profile".into()),
-        json_to_yaml(&projection["session"]["team_profile"]),
-    );
-    let panes = mapping
-        .entry(Value::String("panes".into()))
-        .or_insert(Value::Mapping(Mapping::new()));
-    match panes {
-        Value::Mapping(map) => {
-            let entry = map
-                .entry(Value::String(slot_id.into()))
-                .or_insert(Value::Mapping(Mapping::new()));
-            merge_pane(entry, &projection["pane"])?;
-        }
-        Value::Sequence(items) => {
-            let mut found = false;
-            for item in items.iter_mut() {
-                let Some(map) = item.as_mapping_mut() else {
-                    continue;
-                };
-                let id = map
-                    .get(&Value::String("slot_id".into()))
-                    .or_else(|| map.get(&Value::String("label".into())))
-                    .and_then(Value::as_str);
-                if id == Some(slot_id) {
-                    merge_pane(item, &projection["pane"])?;
-                    found = true;
-                    break;
-                }
-            }
-            if !found {
-                items.push(json_to_yaml(&projection["pane"]));
-            }
-        }
-        _ => {
-            return Err(invalid_data("manifest panes must be a mapping or sequence."));
-        }
-    }
-    serde_yaml::to_string(&root).map_err(|error| invalid_data(error.to_string()))
-}
-
-fn merge_pane(pane: &mut Value, projection: &JsonValue) -> io::Result<()> {
-    let map = pane
-        .as_mapping_mut()
-        .ok_or_else(|| invalid_data("manifest pane must be a mapping."))?;
-    for key in ["slot_id", "assignment", "prompt_bundle", "status"] {
-        map.insert(
-            Value::String(key.into()),
-            json_to_yaml(&projection[key]),
-        );
-    }
-    Ok(())
-}
-
-fn json_to_yaml(value: &JsonValue) -> Value {
-    serde_yaml::to_value(value).unwrap_or(Value::Null)
-}
-
 fn require_token(value: &str, name: &str) -> io::Result<String> {
     let trimmed = value.trim();
     if trimmed.is_empty()
@@ -286,24 +181,7 @@ fn restore_previous_bundle(bundle_path: &Path, original_bundle: Option<&[u8]>) {
     }
 }
 
-#[cfg(test)]
-thread_local! {
-    static FAIL_NEXT_MANIFEST_REPLACE: std::cell::Cell<bool> =
-        const { std::cell::Cell::new(false) };
-}
-
 fn replace_existing_file(tmp_path: &Path, path: &Path) -> io::Result<()> {
-    #[cfg(test)]
-    if path.file_name().is_some_and(|name| name == "manifest.yaml")
-        && FAIL_NEXT_MANIFEST_REPLACE.with(std::cell::Cell::get)
-    {
-        FAIL_NEXT_MANIFEST_REPLACE.with(|flag| flag.set(false));
-        let _ = fs::remove_file(tmp_path);
-        return Err(io::Error::new(
-            ErrorKind::PermissionDenied,
-            "injected manifest replace failure",
-        ));
-    }
     replace_existing_file_os(tmp_path, path)
 }
 
@@ -394,48 +272,24 @@ mod tests {
     }
 
     #[test]
-    fn project_launch_merges_existing_manifest_and_preserves_other_panes() {
+    fn project_launch_does_not_mutate_existing_live_manifest() {
         let dir = seed_project();
         let winsmux = dir.path().join(".winsmux");
         fs::create_dir_all(&winsmux).unwrap();
-        fs::write(
-            winsmux.join("manifest.yaml"),
-            "version: 1\nsession:\n  name: existing\npanes:\n  worker-1:\n    pane_id: '%1'\n    role: Worker\n    label: worker-1\n  operator:\n    pane_id: '%0'\n    role: Operator\n",
-        )
-        .unwrap();
-        project_launch(dir.path(), "sess-1", "worker-1", None, None).unwrap();
-        let saved = fs::read_to_string(winsmux.join("manifest.yaml")).unwrap();
-        assert!(saved.contains("name: existing"));
-        assert!(saved.contains("team_profile:"));
-        assert!(saved.contains("prompt_bundle:"));
-        assert!(saved.contains("role: Operator"));
-        assert!(!saved.contains("A1 delegation"));
-    }
-
-    #[test]
-    fn manifest_replace_failure_restores_previous_bundle() {
-        let dir = seed_project();
-        let winsmux = dir.path().join(".winsmux");
-        fs::create_dir_all(winsmux.join("runtime/prompt-bundles/sess-1")).unwrap();
-        let original_manifest = "version: 1\nsession:\n  name: keep\npanes: {}\n";
-        fs::write(winsmux.join("manifest.yaml"), original_manifest).unwrap();
-        let bundle = dir
-            .path()
-            .join(".winsmux/runtime/prompt-bundles/sess-1/worker-1.md");
-        fs::write(&bundle, "OLD BUNDLE\n").unwrap();
-        FAIL_NEXT_MANIFEST_REPLACE.with(|flag| flag.set(true));
-        let result = project_launch(dir.path(), "sess-1", "worker-1", None, None);
-        FAIL_NEXT_MANIFEST_REPLACE.with(|flag| flag.set(false));
-        let err = result.expect_err("manifest replace must fail");
-        assert!(
-            err.to_string().contains("injected manifest replace failure"),
-            "err={err}"
+        let original = "version: 1\nsession:\n  name: existing\npanes:\n  worker-1:\n    pane_id: '%1'\n    role: Worker\n    label: worker-1\n  operator:\n    pane_id: '%0'\n    role: Operator\n";
+        let manifest_path = winsmux.join("manifest.yaml");
+        fs::write(&manifest_path, original).unwrap();
+        let payload = project_launch(dir.path(), "sess-1", "worker-1", None, None).unwrap();
+        assert_eq!(fs::read_to_string(&manifest_path).unwrap(), original);
+        assert!(payload["projection"]["pane"]["prompt_bundle"].is_object());
+        assert!(payload["projection"]["session"]["team_profile"].is_object());
+        let bundle = dir.path().join(
+            payload["bundle_path"]
+                .as_str()
+                .expect("bundle_path"),
         );
-        assert_eq!(fs::read_to_string(&bundle).unwrap(), "OLD BUNDLE\n");
-        assert_eq!(
-            fs::read_to_string(winsmux.join("manifest.yaml")).unwrap(),
-            original_manifest
-        );
+        assert!(fs::read_to_string(bundle).unwrap().contains("slot-id: worker-1"));
+        assert!(!original.contains("team_profile:"));
     }
 
     #[test]

--- a/install.ps1
+++ b/install.ps1
@@ -342,6 +342,7 @@ function Install-OrchestraSupportScripts {
     Download-File "winsmux-core/scripts/orchestra-ui-attach.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "orchestra-ui-attach.ps1")
     Download-File "winsmux-core/scripts/pane-control.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-control.ps1")
     Download-File "winsmux-core/scripts/pane-env.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-env.ps1")
+    Download-File "winsmux-core/scripts/pane-scaler.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-scaler.ps1")
     Download-File "winsmux-core/scripts/pane-border.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-border.ps1")
     Download-File "winsmux-core/scripts/pane-status.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "pane-status.ps1")
     Download-File "winsmux-core/scripts/planning-paths.ps1" (Join-Path $BRIDGE_SCRIPTS_DIR "planning-paths.ps1")
@@ -403,6 +404,7 @@ function Remove-ProfileExcludedSupportScripts {
                 "orchestra-ui-attach.ps1",
                 "pane-control.ps1",
                 "pane-env.ps1",
+                "pane-scaler.ps1",
                 "pane-border.ps1",
                 "pane-status.ps1",
                 "planning-paths.ps1",

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -18603,6 +18603,7 @@ Commands:
   Bound review forms ignore process CWD; branch and HEAD come from the submission-resolved target worktree.
   dispatch-review           Dispatch review-request to a review-capable pane (Reviewer/Worker)
   dispatch-task <text>      Route and send task text to a managed pane using manifest-aware role selection
+  archive-pane <slot>       Interrupt a live worker if needed, then remove the pane without respawning [--json] [--project-dir <path>]
   consult-request <mode> [--message <text>] [--target-slot <slot>]  Record a consultation request packet/event
   consult-result <mode> [--message <text>] [--target-slot <slot>] [--confidence <0..1>] [--next-test <text>] [--risk <text>] [--run-id <run_id>] [--json]  Record a consultation result packet/event
   consult-error <mode> [--message <text>] [--target-slot <slot>]  Record a consultation error packet/event
@@ -19163,6 +19164,7 @@ switch ($Command) {
     'github-preflight' { Invoke-WinsmuxGithubPreflightCommand -BridgeScriptRoot $PSScriptRoot -CommandTarget $Target -CommandRest $Rest }
     'verify'          { Invoke-Verify }
     'dispatch-task'   { Invoke-WinsmuxDispatchTaskCommand -BridgeScriptRoot $PSScriptRoot -CommandTarget $Target -CommandRest $Rest }
+    'archive-pane'    { Invoke-WinsmuxArchivePaneCommand -BridgeScriptRoot $PSScriptRoot -CommandTarget $Target -CommandRest $Rest }
     'dispatch-route'  { Invoke-WinsmuxDispatchRouteCommand -BridgeScriptRoot $PSScriptRoot -CommandTarget $Target -CommandRest $Rest }
     'task-split'      { Invoke-WinsmuxTaskSplitCommand -BridgeScriptRoot $PSScriptRoot -CommandTarget $Target -CommandRest $Rest }
     'pipeline'        { Invoke-WinsmuxTeamPipelineCommand -BridgeScriptRoot $PSScriptRoot -CommandTarget $Target -CommandRest $Rest -AllowDeclarativeWorkflow }

--- a/tests/bridge/AgentOrchestra.Tests.ps1
+++ b/tests/bridge/AgentOrchestra.Tests.ps1
@@ -4959,3 +4959,175 @@ Describe 'orchestra layout script' {
         $global:layoutMutationCalls | Should -Be 1
     }
 }
+
+Describe 'TASK-789 dynamic worker pane lifecycle' {
+    BeforeAll {
+        $repoRoot = Split-Path -Parent $script:BridgeTestsRoot
+        $script:task789OrchestraStartPath = Join-Path $repoRoot 'winsmux-core\scripts\orchestra-start.ps1'
+        $script:task789OrchestraSmokePath = Join-Path $repoRoot 'winsmux-core\scripts\orchestra-smoke.ps1'
+        $script:task789PaneScalerPath = Join-Path $repoRoot 'winsmux-core\scripts\pane-scaler.ps1'
+        $script:task789ManifestPath = Join-Path $repoRoot 'winsmux-core\scripts\manifest.ps1'
+        $script:task789DispatchPath = Join-Path $repoRoot 'winsmux-core\scripts\control-plane-dispatch.ps1'
+        $script:task789WinsmuxCorePath = Join-Path $repoRoot 'scripts\winsmux-core.ps1'
+        . $script:task789OrchestraStartPath
+        . $script:task789ManifestPath
+        $script:task789OrchestraStartContent = Get-Content -LiteralPath $script:task789OrchestraStartPath -Raw -Encoding UTF8
+        $script:task789OrchestraSmokeContent = Get-Content -LiteralPath $script:task789OrchestraSmokePath -Raw -Encoding UTF8
+        $script:task789PaneScalerContent = Get-Content -LiteralPath $script:task789PaneScalerPath -Raw -Encoding UTF8
+        $script:task789DispatchContent = Get-Content -LiteralPath $script:task789DispatchPath -Raw -Encoding UTF8
+        $script:task789WinsmuxCoreContent = Get-Content -LiteralPath $script:task789WinsmuxCorePath -Raw -Encoding UTF8
+        $script:task789ManifestContent = Get-Content -LiteralPath $script:task789ManifestPath -Raw -Encoding UTF8
+        $script:task789AgentSlots = @(1..6 | ForEach-Object {
+            [ordered]@{
+                slot_id       = "worker-$_"
+                runtime_role  = 'worker'
+                agent         = 'codex'
+                model         = 'gpt-5.4'
+                worktree_mode = 'managed'
+            }
+        })
+    }
+
+    BeforeEach {
+        $script:task789TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-task789-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path (Join-Path $script:task789TempRoot '.winsmux') -Force | Out-Null
+    }
+
+    AfterEach {
+        if ($script:task789TempRoot -and (Test-Path -LiteralPath $script:task789TempRoot)) {
+            Remove-Item -LiteralPath $script:task789TempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'starts a live worker pool of 1 even when the Team Profile catalog has 6 agent_slots' {
+        $layout = Get-OrchestraLayoutSettings -Settings ([ordered]@{
+            external_operator  = $true
+            worker_count       = 6
+            agent_slots        = @($script:task789AgentSlots)
+            legacy_role_layout = $false
+            operators          = 0
+            builders           = 0
+            researchers        = 0
+            reviewers          = 0
+        })
+
+        $layout.ExternalOperator | Should -Be $true
+        $layout.Operators | Should -Be 0
+        $layout.Workers | Should -Be 1
+        $layout.Builders | Should -Be 0
+        (Get-OrchestraExpectedPaneCount -LayoutSettings $layout) | Should -Be 1
+    }
+
+    It 'does not persist a constant Operators+Workers pane count of 7 for managed operator + six catalog slots' {
+        $layout = Get-OrchestraLayoutSettings -Settings ([ordered]@{
+            external_operator  = $false
+            worker_count       = 6
+            agent_slots        = @($script:task789AgentSlots)
+            legacy_role_layout = $false
+            operators          = 0
+            builders           = 0
+            researchers        = 0
+            reviewers          = 0
+        })
+
+        $layout.Operators | Should -Be 1
+        $layout.Workers | Should -Be 1
+        (Get-OrchestraExpectedPaneCount -LayoutSettings $layout) | Should -Be 2
+        (Get-OrchestraExpectedPaneCount -LayoutSettings $layout) | Should -Not -Be 7
+    }
+
+    It 'does not copy catalog size onto live layout workers' {
+        $script:task789OrchestraStartContent | Should -Not -Match '\$workers\s*=\s*\$agentSlots\.Count'
+        $script:task789OrchestraSmokeContent | Should -Not -Match '\$workers\s*=\s*\$agentSlots\.Count'
+        $script:task789OrchestraStartContent | Should -Match 'Get-OrchestraMinLiveWorkerPaneCount'
+    }
+
+    It 'persists expected_pane_count from the live layout pane count after panes are created' {
+        $layoutIndex = $script:task789OrchestraStartContent.IndexOf('$layout = . $layoutScript -SessionName $sessionName')
+        $layoutIndex | Should -BeGreaterThan -1
+        $afterLayout = $script:task789OrchestraStartContent.Substring($layoutIndex)
+        $afterLayout | Should -Match '\$expectedPaneCount\s*=\s*(?:\[int\])?\$layout\.Panes\.Count'
+        $script:task789OrchestraStartContent | Should -Match 'Save-OrchestraSessionState[^\r\n]+-ExpectedPaneCount \$expectedPaneCount'
+        $script:task789OrchestraStartContent | Should -Not -Match 'partial_start\s*=\s*\$true'
+    }
+
+    It 'still invokes Team Profile start-gate before layout and does not weaken it to YAML row presence' {
+        $startGateIndex = $script:task789OrchestraStartContent.IndexOf('Assert-TeamProfileStartGate -ProjectDir $projectDir')
+        $layoutIndex = $script:task789OrchestraStartContent.IndexOf('$layout = . $layoutScript -SessionName $sessionName')
+        $startGateIndex | Should -BeGreaterThan -1
+        $layoutIndex | Should -BeGreaterThan $startGateIndex
+        $script:task789OrchestraStartContent | Should -Match "'--action', 'start-gate'"
+        $script:task789OrchestraStartContent | Should -Not -Match 'six_slot_incomplete'
+        $script:task789OrchestraStartContent | Should -Not -Match 'partial_start\s*=\s*\$true'
+    }
+
+    It 'treats a missing orchestra-mode.json as team for returning users' {
+        $doc = Get-OrchestraModeDocument -ProjectDir $script:task789TempRoot
+        $doc.mode | Should -Be 'team'
+        $doc.schema_version | Should -Be 1
+        $doc.valid | Should -Be $true
+        $doc.source | Should -Be 'default'
+    }
+
+    It 'fail-closes invalid orchestra-mode.json instead of guessing simple or team' {
+        $modePath = Join-Path $script:task789TempRoot '.winsmux\orchestra-mode.json'
+        '{not-json' | Set-Content -LiteralPath $modePath -Encoding UTF8
+        { Get-OrchestraModeDocument -ProjectDir $script:task789TempRoot } | Should -Throw '*orchestra-mode.json*'
+
+        '{"schema_version":1,"mode":"team","extra":true}' | Set-Content -LiteralPath $modePath -Encoding UTF8
+        { Get-OrchestraModeDocument -ProjectDir $script:task789TempRoot } | Should -Throw '*orchestra-mode.json*'
+
+        '{"schema_version":2,"mode":"team"}' | Set-Content -LiteralPath $modePath -Encoding UTF8
+        { Get-OrchestraModeDocument -ProjectDir $script:task789TempRoot } | Should -Throw '*orchestra-mode.json*'
+
+        '{"schema_version":1,"mode":"solo"}' | Set-Content -LiteralPath $modePath -Encoding UTF8
+        { Get-OrchestraModeDocument -ProjectDir $script:task789TempRoot } | Should -Throw '*orchestra-mode.json*'
+    }
+
+    It 'accepts a strict schema_version 1 simple or team orchestra-mode.json object' {
+        $modePath = Join-Path $script:task789TempRoot '.winsmux\orchestra-mode.json'
+        '{"schema_version":1,"mode":"simple"}' | Set-Content -LiteralPath $modePath -Encoding UTF8
+        $simple = Get-OrchestraModeDocument -ProjectDir $script:task789TempRoot
+        $simple.mode | Should -Be 'simple'
+        $simple.valid | Should -Be $true
+        $simple.source | Should -Be 'file'
+
+        '{"schema_version":1,"mode":"team"}' | Set-Content -LiteralPath $modePath -Encoding UTF8
+        $team = Get-OrchestraModeDocument -ProjectDir $script:task789TempRoot
+        $team.mode | Should -Be 'team'
+    }
+
+    It 'counts only live worker-role panes and fail-closes simple mode above one live worker' {
+        Test-OrchestraSimpleModeLiveWorkerLimit -Mode 'simple' -LiveWorkerPaneCount 1 | Should -BeTrue
+        Test-OrchestraSimpleModeLiveWorkerLimit -Mode 'simple' -LiveWorkerPaneCount 2 | Should -BeFalse
+        Test-OrchestraSimpleModeLiveWorkerLimit -Mode 'team' -LiveWorkerPaneCount 6 | Should -BeTrue
+        Test-OrchestraSimpleModeLiveWorkerLimit -Mode 'team' -LiveWorkerPaneCount 7 | Should -BeFalse
+
+        $manifest = [pscustomobject]@{
+            panes = [ordered]@{
+                'operator' = [pscustomobject]@{ role = 'Operator'; pane_id = '%1' }
+                'worker-1' = [pscustomobject]@{ role = 'Worker'; pane_id = '%2' }
+                'worker-2' = [pscustomobject]@{ role = 'Worker'; pane_id = '%3' }
+            }
+        }
+        (Get-OrchestraLiveWorkerRolePaneCount -Manifest $manifest) | Should -Be 2
+    }
+
+    It 'makes orchestra-smoke not ready when simple mode has more than one live worker-role pane' {
+        $script:task789OrchestraSmokeContent | Should -Match 'Test-OrchestraSimpleModeLiveWorkerLimit'
+        $script:task789OrchestraSmokeContent | Should -Match 'simple_mode_live_worker_limit'
+        $script:task789OrchestraSmokeContent | Should -Match 'Get-OrchestraModeDocument'
+        $script:task789OrchestraSmokeContent | Should -Match 'Get-OrchestraLiveWorkerRolePaneCount'
+        $script:task789OrchestraSmokeContent | Should -Not -Match 'display:\s*none'
+        $script:task789ManifestContent | Should -Match 'function Get-OrchestraModeDocument'
+        $script:task789ManifestContent | Should -Match 'function Test-OrchestraSimpleModeLiveWorkerLimit'
+    }
+
+    It 'reuses Add-OrchestraPane and Remove-OrchestraPane for worker spawn and archive' {
+        $script:task789PaneScalerContent | Should -Match "ValidateSet\('Builder',\s*'Worker'\)"
+        $script:task789PaneScalerContent | Should -Match 'New-TeamProfileSlotAgentConfig'
+        $script:task789PaneScalerContent | Should -Not -Match 'requiredBackend'
+        $script:task789PaneScalerContent | Should -Match 'kill-pane'
+        $script:task789PaneScalerContent | Should -Match 'split-window'
+    }
+}

--- a/tests/bridge/ArtifactsRuntime.Tests.ps1
+++ b/tests/bridge/ArtifactsRuntime.Tests.ps1
@@ -209,6 +209,18 @@ Describe 'orchestra pane bootstrap plan' {
         $script:orchestraStartContent | Should -Match 'Get-SlotAgentConfig -Role \$canonicalRole -SlotId \$label -Settings \$settings -RootPath \$projectDir'
     }
 
+    It 'TASK-789 applies Team Profile assignment at worker spawn and does not map catalog requiredBackend' {
+        $script:orchestraStartContent | Should -Not -Match '\$workers\s*=\s*\$agentSlots\.Count'
+        $script:orchestraStartContent | Should -Not -Match 'requiredBackend'
+        $script:orchestraStartContent | Should -Match 'function New-TeamProfileSlotAgentConfig'
+        $script:orchestraStartContent | Should -Match '\$slot\[''worker_backend''\] = \$backend'
+        $dispatchPath = Join-Path (Split-Path -Parent $script:BridgeTestsRoot) 'winsmux-core\scripts\control-plane-dispatch.ps1'
+        $dispatchContent = Get-Content -LiteralPath $dispatchPath -Raw -Encoding UTF8
+        $dispatchContent | Should -Match 'New-TeamProfileSlotAgentConfig'
+        $dispatchContent | Should -Not -Match 'requiredBackend'
+        $dispatchContent | Should -Match 'Add-OrchestraPane'
+    }
+
     It 'builds pane launch commands through provider capability metadata' {
         $script:orchestraStartContent | Should -Match 'Get-BridgeProviderLaunchCommand'
         $script:orchestraStartContent | Should -Match 'Get-AgentLaunchCommand -Agent \$slotAgentConfig\.Agent -Model \$slotAgentConfig\.Model -ModelSource \$slotAgentConfig\.ModelSource -ReasoningEffort \$slotAgentConfig\.ReasoningEffort -McpMode \$slotAgentConfig\.McpMode -SlotId \$label -ProjectDir \$launchDir -GitWorktreeDir \$launchGitWorktreeDir -RootPath \$projectDir'

--- a/tests/bridge/CommandReviewDispatch.Tests.ps1
+++ b/tests/bridge/CommandReviewDispatch.Tests.ps1
@@ -3157,6 +3157,107 @@ Write-Output 'reached-after-exit'
         $saved.Panes.Contains('worker-2') | Should -BeFalse
     }
 
+    It 'TASK-789 spawn readiness uses CapabilityAdapter instead of provider Agent' {
+        $scalerIndex = $script:task789PaneScalerContent.IndexOf('function Add-OrchestraWorkerPane')
+        $scalerIndex | Should -BeGreaterThan -1
+        $next = $script:task789PaneScalerContent.IndexOf("`nfunction ", $scalerIndex + 1)
+        if ($next -lt 0) {
+            $next = $script:task789PaneScalerContent.Length
+        }
+        $spawnBody = $script:task789PaneScalerContent.Substring($scalerIndex, $next - $scalerIndex)
+        $spawnBody | Should -Match 'Get-PaneScalerReadinessAgent'
+        $spawnBody | Should -Match 'Wait-OrchestraSpawnAgentReady -PaneId \$newPaneId -Agent \$readinessAgent'
+        $spawnBody | Should -Not -Match 'Wait-OrchestraSpawnAgentReady -PaneId \$newPaneId -Agent \$agent'
+        $script:task789PaneScalerContent | Should -Match 'function Get-PaneScalerReadinessAgent'
+
+        Get-PaneScalerReadinessAgent -SlotAgentConfig ([pscustomobject]@{
+            Agent = 'openrouter'; CapabilityAdapter = 'openai-compatible'
+        }) -FallbackAgent 'codex' | Should -Be 'openai-compatible'
+        Get-PaneScalerReadinessAgent -SlotAgentConfig ([pscustomobject]@{
+            Agent = 'openrouter'; CapabilityAdapter = ''
+        }) -FallbackAgent 'codex' | Should -Be 'openrouter'
+
+        $promptText = (@(
+            'status: ready'
+            'api_llm[worker-1]>'
+        ) -join [Environment]::NewLine)
+        Test-AgentPromptText -Text $promptText -Agent 'openrouter' | Should -BeFalse
+        Test-AgentPromptText -Text $promptText -Agent 'openai-compatible' | Should -BeTrue
+
+        $markerDir = Join-Path $script:task789FixRoot '.winsmux\orchestra-bootstrap'
+        New-Item -ItemType Directory -Path $markerDir -Force | Out-Null
+        $markerPath = Join-Path $markerDir '5-generation-789.ready.json'
+        @{
+            state = 'bootstrap_pending'
+            generation_id = 'generation-789'
+            server_session_id = '$9'
+            slot_id = 'worker-2'
+            pane_id = '%5'
+            backend = 'openrouter'
+            role = 'worker'
+            title = 'worker-2'
+            bootstrap_pid = 4300
+            bootstrap_process_started_at = '2026-08-17T00:00:02.0000000Z'
+        } | ConvertTo-Json | Set-Content -LiteralPath $markerPath -Encoding utf8
+
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        @"
+version: 1
+saved_at: 2026-08-17T00:00:00Z
+session:
+  name: winsmux-orchestra
+  project_dir: $script:task789FixRoot
+  generation_id: generation-789
+  server_session_id: '`$9'
+  bootstrap_pane_id: '%1'
+  expected_pane_count: 1
+panes:
+  worker-1:
+    slot_id: worker-1
+    pane_id: '%3'
+    role: Worker
+    worker_role: worker
+    worker_backend: openrouter
+    title: worker-1
+    status: ready
+"@ | Set-Content -LiteralPath $manifestPath -Encoding utf8
+        $worktreePath = Join-Path $script:task789FixRoot '.worktrees\worker-2'
+        New-Item -ItemType Directory -Path $worktreePath -Force | Out-Null
+        Mock New-PaneScalerWorkerWorktree {
+            [pscustomobject]@{ WorktreePath = $worktreePath; BranchName = 'worktree-worker-2'; GitWorktreeDir = $worktreePath }
+        }
+        Mock Invoke-MonitorWinsmux {
+            param($Arguments)
+            if (@($Arguments) -contains 'split-window') { return '%5' }
+        }
+        Mock Wait-MonitorPaneShellReady { }
+        Mock Get-PaneScalerLaunchCommand { 'echo spawn-worker-2' }
+        Mock New-OrchestraPaneBootstrapPlan { Join-Path $markerDir '5.json' }
+        Mock Get-OrchestraPaneBootstrapMarkerPath { $markerPath }
+        Mock Start-OrchestraPaneBootstrap { }
+        Mock Get-BridgeSettings { [ordered]@{ agent = 'openrouter'; model = 'z-ai/glm-5.2' } }
+        Mock Get-PaneAgentStatus {
+            [PSCustomObject]@{
+                Status       = 'ready'
+                PaneId       = '%5'
+                SnapshotTail = ''
+                ExitReason   = ''
+            }
+        }
+
+        $null = Add-OrchestraWorkerPane -ManifestPath $manifestPath -SlotId 'worker-2' -SlotAgentConfig ([pscustomobject]@{
+            Agent = 'openrouter'; CapabilityAdapter = 'openai-compatible'; Model = 'z-ai/glm-5.2'; WorkerBackend = 'openrouter'; PaneTitle = 'worker-2'
+        })
+        $saved = Read-PaneScalerManifest -ManifestPath $manifestPath
+        $saved.Panes['worker-2'].status | Should -Be 'ready'
+        Should -Invoke Get-PaneAgentStatus -Times 1 -Exactly -ParameterFilter {
+            $PaneId -eq '%5' -and $Agent -eq 'openai-compatible' -and $Role -eq 'Worker'
+        }
+        Should -Invoke Get-PaneAgentStatus -Times 0 -ParameterFilter {
+            $Agent -eq 'openrouter'
+        }
+    }
+
     It 'restores v2 archive files when kill-pane fails and the pane is still listed' {
         $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
         $registryPath = Get-WinsmuxRuntimeRegistryPath -ProjectDir $script:task789FixRoot

--- a/tests/bridge/CommandReviewDispatch.Tests.ps1
+++ b/tests/bridge/CommandReviewDispatch.Tests.ps1
@@ -1631,3 +1631,80 @@ Describe 'winsmux control-plane dispatch module' {
         $script:controlPlaneDispatchContent | Should -Match 'function Invoke-WinsmuxShadowCutoverGateCommand'
     }
 }
+
+Describe 'TASK-789 dispatch spawn and archive-pane' {
+    BeforeAll {
+        $repoRoot = Split-Path -Parent $script:BridgeTestsRoot
+        $script:task789DispatchPath = Join-Path $repoRoot 'winsmux-core\scripts\control-plane-dispatch.ps1'
+        $script:task789DispatchContent = Get-Content -LiteralPath $script:task789DispatchPath -Raw -Encoding UTF8
+        $script:task789WinsmuxCorePath = Join-Path $repoRoot 'scripts\winsmux-core.ps1'
+        $script:task789WinsmuxCoreContent = Get-Content -LiteralPath $script:task789WinsmuxCorePath -Raw -Encoding UTF8
+        $script:task789PaneScalerPath = Join-Path $repoRoot 'winsmux-core\scripts\pane-scaler.ps1'
+        $script:task789PaneScalerContent = Get-Content -LiteralPath $script:task789PaneScalerPath -Raw -Encoding UTF8
+        . $script:task789DispatchPath
+    }
+
+    It 'documents public archive-pane in usage and the command table' {
+        $script:task789WinsmuxCoreContent | Should -Match 'archive-pane <slot>\s+'
+        $script:task789WinsmuxCoreContent | Should -Match "'archive-pane'\s*\{\s*Invoke-WinsmuxArchivePaneCommand"
+        $script:task789DispatchContent | Should -Match 'function Invoke-WinsmuxArchivePaneCommand'
+    }
+
+    It 'archives by interrupt-then-Remove-OrchestraPane and never calls workers-stop respawn' {
+        $script:task789DispatchContent | Should -Match 'function Invoke-WinsmuxArchivePaneCommand'
+        $archiveIndex = $script:task789DispatchContent.IndexOf('function Invoke-WinsmuxArchivePaneCommand')
+        $archiveIndex | Should -BeGreaterThan -1
+        $next = $script:task789DispatchContent.IndexOf("`nfunction ", $archiveIndex + 1)
+        if ($next -lt 0) {
+            $next = $script:task789DispatchContent.Length
+        }
+        $body = $script:task789DispatchContent.Substring($archiveIndex, $next - $archiveIndex)
+        $body | Should -Match 'Remove-OrchestraPane'
+        $body | Should -Match 'C-c'
+        $body | Should -Match 'pane\.idle'
+        $body | Should -Not -Match 'Invoke-WorkersStop'
+        $body | Should -Not -Match 'respawn-pane'
+        $body | Should -Not -Match 'workers stop'
+        $script:task789PaneScalerContent | Should -Match 'kill-pane'
+    }
+
+    It 'spawns a missing live worker through Add-OrchestraPane and Team Profile assignment overlay' {
+        $script:task789DispatchContent | Should -Match 'function Ensure-DispatchTaskLiveWorkerPane'
+        $ensureIndex = $script:task789DispatchContent.IndexOf('function Ensure-DispatchTaskLiveWorkerPane')
+        $ensureIndex | Should -BeGreaterThan -1
+        $next = $script:task789DispatchContent.IndexOf("`nfunction ", $ensureIndex + 1)
+        if ($next -lt 0) {
+            $next = $script:task789DispatchContent.Length
+        }
+        $body = $script:task789DispatchContent.Substring($ensureIndex, $next - $ensureIndex)
+        $body | Should -Match 'Add-OrchestraPane'
+        $body | Should -Match 'New-TeamProfileSlotAgentConfig'
+        $body | Should -Match 'Invoke-TeamProfileLaunchProjection'
+        $body | Should -Match 'worker_backend'
+        $body | Should -Not -Match 'requiredBackend'
+        $body | Should -Match 'simple_mode_live_worker_limit'
+        $script:task789DispatchContent | Should -Match 'Ensure-DispatchTaskLiveWorkerPane'
+    }
+
+    It 'fail-closes simple mode instead of spawning a second live worker pane' {
+        Get-Command Ensure-DispatchTaskLiveWorkerPane -ErrorAction Stop | Should -Not -BeNullOrEmpty
+        function Get-OrchestraModeDocument {
+            param([string]$ProjectDir)
+            [pscustomobject]@{ schema_version = 1; mode = 'simple'; valid = $true; source = 'file' }
+        }
+        function Get-OrchestraLiveWorkerRolePaneCount {
+            param($Manifest)
+            1
+        }
+        function Add-OrchestraPane {
+            throw 'simple mode must not spawn a second live worker pane'
+        }
+        function New-TeamProfileSlotAgentConfig {
+            throw 'simple mode must not spawn a second live worker pane'
+        }
+
+        $result = Ensure-DispatchTaskLiveWorkerPane -ProjectDir (Join-Path ([System.IO.Path]::GetTempPath()) 'winsmux-task789-missing') -Label 'worker-2' -ManifestEntry $null
+        $result.Spawned | Should -BeFalse
+        $result.ReasonCode | Should -Be 'simple_mode_live_worker_limit'
+    }
+}

--- a/tests/bridge/CommandReviewDispatch.Tests.ps1
+++ b/tests/bridge/CommandReviewDispatch.Tests.ps1
@@ -1644,6 +1644,23 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
         $script:task789ManifestPath = Join-Path $repoRoot 'winsmux-core\scripts\manifest.ps1'
         . $script:task789ManifestPath
         . $script:task789DispatchPath
+        $script:task789SubmissionContractPath = Join-Path $repoRoot 'winsmux-core\scripts\submission-contract.ps1'
+        if (Test-Path -LiteralPath $script:task789SubmissionContractPath -PathType Leaf) {
+            . $script:task789SubmissionContractPath
+        }
+        $script:task789ScriptsRoot = Join-Path $repoRoot 'scripts'
+        if (-not (Get-Command Stop-WithError -ErrorAction SilentlyContinue)) {
+            function script:Stop-WithError {
+                param([string]$Message)
+                throw $Message
+            }
+        }
+        if (-not (Get-Command Start-DeferredPaneFromManifestEntry -ErrorAction SilentlyContinue)) {
+            function script:Start-DeferredPaneFromManifestEntry {
+                param($ProjectDir, $ManifestEntry, $ExpectedGenerationId)
+                return $false
+            }
+        }
         if (-not (Get-Command New-TeamProfileSlotAgentConfig -ErrorAction SilentlyContinue)) {
             function script:New-TeamProfileSlotAgentConfig {
                 param($Role, $SlotId, $Assignment, $Settings, $RootPath)
@@ -1652,6 +1669,12 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
         if (-not (Get-Command Invoke-TeamProfileLaunchProjection -ErrorAction SilentlyContinue)) {
             function script:Invoke-TeamProfileLaunchProjection {
                 param($ProjectDir, $SessionId, $SlotId, $Worktree, $ReadWriteScope, [switch]$Force)
+            }
+        }
+        if (-not (Get-Command Add-TeamProfileBundleToLaunchCommand -ErrorAction SilentlyContinue)) {
+            function script:Add-TeamProfileBundleToLaunchCommand {
+                param($LaunchCommand, $Projection, $ProjectDir)
+                return $LaunchCommand
             }
         }
         if (-not (Get-Command New-OrchestraPaneBootstrapPlan -ErrorAction SilentlyContinue)) {
@@ -1793,6 +1816,37 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
                 throw ("unexpected pane-control winsmux: {0}" -f (@($Arguments) -join ' '))
             }
         }
+
+        function script:New-Task789LiveEntry {
+            param(
+                [Parameter(Mandatory = $true)][string]$Label,
+                [Parameter(Mandatory = $true)][string]$PaneId,
+                [string]$Status = 'ready'
+            )
+            return [pscustomobject]@{
+                Label         = $Label
+                SlotId        = $Label
+                PaneId        = $PaneId
+                Role          = 'Worker'
+                WorkerRole    = 'worker'
+                WorkerBackend = 'codex'
+                Title         = $Label
+                Status        = $Status
+            }
+        }
+
+        function script:Invoke-Task789PublicDispatchTask {
+            param([Parameter(Mandatory = $true)][string[]]$Argv)
+            $target = [string]$Argv[0]
+            $rest = @()
+            if ($Argv.Count -gt 1) {
+                $rest = @($Argv[1..($Argv.Count - 1)])
+            }
+            return @(
+                Invoke-WinsmuxDispatchTaskCommand -BridgeScriptRoot $script:task789ScriptsRoot `
+                    -CommandTarget $target -CommandRest $rest
+            )
+        }
     }
 
     BeforeEach {
@@ -1849,11 +1903,25 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
         $body | Should -Match 'Add-OrchestraPane'
         $body | Should -Match 'New-TeamProfileSlotAgentConfig'
         $body | Should -Match 'Invoke-TeamProfileLaunchProjection'
+        $body | Should -Match '-Projection \$projection'
         $body | Should -Match 'worker_backend'
         $body | Should -Not -Match 'requiredBackend'
         $body | Should -Match 'simple_mode_live_worker_limit'
         $body | Should -Match 'team_profile_projection_unavailable'
         $script:task789DispatchContent | Should -Match 'Ensure-DispatchTaskLiveWorkerPane'
+        $script:task789DispatchContent | Should -Match 'function Get-DispatchTaskCatalogSlotIds'
+        $script:task789DispatchContent | Should -Match 'function Get-DispatchTaskMissingCatalogSlotIds'
+        $script:task789DispatchContent | Should -Match 'Get-DispatchTaskAvailableTargets'
+        $invokeIndex = $script:task789DispatchContent.IndexOf('function Invoke-WinsmuxDispatchTaskCommand')
+        $invokeIndex | Should -BeGreaterThan -1
+        $invokeNext = $script:task789DispatchContent.IndexOf("`nfunction ", $invokeIndex + 1)
+        if ($invokeNext -lt 0) {
+            $invokeNext = $script:task789DispatchContent.Length
+        }
+        $invokeBody = $script:task789DispatchContent.Substring($invokeIndex, $invokeNext - $invokeIndex)
+        $invokeBody | Should -Match 'Get-DispatchRoute -Text \$taskText -AvailableTargets @\(\$classifiedSlotId\)'
+        $invokeBody | Should -Match 'Get-DispatchTaskMissingCatalogSlotIds'
+        $script:task789PaneScalerContent | Should -Match 'Add-TeamProfileBundleToLaunchCommand'
     }
 
     It 'fail-closes simple mode instead of spawning a second live worker pane' {
@@ -3202,5 +3270,639 @@ Write-Output 'reached-after-exit'
         ($output | Out-String) | Should -Not -Match 'reached-after-exit'
         Test-Path -LiteralPath $sentPath | Should -BeTrue
         Test-Path -LiteralPath $killedPath | Should -BeFalse
+    }
+
+    It 'E03 public argv parse keeps --slot-id and --project-dir as separate tokens' {
+        $parts = @(
+            Get-WinsmuxControlPlaneArguments -CommandTarget '--slot-id' -CommandRest @(
+                'worker-2', '--project-dir', $script:task789FixRoot, 'implement the focused change'
+            )
+        )
+        $parsed = Split-WinsmuxDispatchTaskArguments -Parts $parts
+        $parsed.SlotId | Should -Be 'worker-2'
+        $parsed.ProjectDir | Should -Be $script:task789FixRoot
+        $parsed.TaskText | Should -Be 'implement the focused change'
+        @($parts).Count | Should -Be 5
+        $parts[0] | Should -Be '--slot-id'
+        $parts[1] | Should -Be 'worker-2'
+    }
+
+    It 'E01 public dispatch-task without --slot-id spawns a missing catalog slot instead of only the live worker' {
+        $null = New-Item -ItemType File -Path (Join-Path $script:task789FixRoot '.winsmux.yaml') -Force
+        $script:task789SpawnedSlots = @()
+        $script:task789SubmittedLabel = ''
+        $script:task789Receipt = $null
+        $script:task789Worker2Live = $false
+        Mock Get-OrchestraModeDocument {
+            [pscustomobject]@{ schema_version = 1; mode = 'team'; valid = $true; source = 'file' }
+        }
+        Mock Get-OrchestraLiveWorkerRolePaneCount { 1 }
+        Mock Get-OrchestraMaxLiveWorkerPaneCount { 6 }
+        Mock Get-WinsmuxManifest {
+            [pscustomobject]@{
+                Panes = [ordered]@{
+                    'worker-1' = [pscustomobject]@{ pane_id = '%3'; role = 'Worker' }
+                }
+            }
+        }
+        Mock Get-BridgeSettings {
+            [ordered]@{
+                agent_slots = @(
+                    [pscustomobject]@{ slot_id = 'worker-1'; runtime_role = 'worker'; worker_role = 'impl' }
+                    [pscustomobject]@{ slot_id = 'worker-2'; runtime_role = 'worker'; worker_role = 'impl' }
+                )
+            }
+        }
+        Mock Get-PaneControlManifestEntries {
+            $entries = @(script:New-Task789LiveEntry -Label 'worker-1' -PaneId '%3')
+            if ($script:task789Worker2Live) {
+                $entries += script:New-Task789LiveEntry -Label 'worker-2' -PaneId '%5'
+            }
+            return $entries
+        }
+        Mock Get-DispatchTaskCatalogSlotIds { @('worker-1', 'worker-2') }
+        Mock Invoke-TeamProfileLaunchProjection {
+            [pscustomobject]@{
+                bundle_path = '.winsmux/team-profile/worker-2.md'
+                projection  = [pscustomobject]@{
+                    pane = [pscustomobject]@{
+                        assignment    = [pscustomobject]@{ provider = 'codex'; launch_model = 'gpt-5.4'; worker_backend = 'codex' }
+                        prompt_bundle = [pscustomobject]@{ path = '.winsmux/team-profile/worker-2.md' }
+                    }
+                }
+            }
+        }
+        Mock New-TeamProfileSlotAgentConfig {
+            [pscustomobject]@{ Agent = 'codex'; Model = 'gpt-5.4'; WorkerBackend = 'codex'; PaneTitle = $SlotId }
+        }
+        Mock Add-OrchestraPane {
+            $script:task789SpawnedSlots += [string]$SlotId
+            $script:task789Worker2Live = $true
+            return [pscustomobject]@{ Changed = $true; Label = $SlotId; PaneId = '%5' }
+        }
+        Mock Test-PaneControlRuntimeContext {
+            [pscustomobject]@{
+                valid       = $true
+                reason_code = 'dispatch_verified'
+                diagnostic  = 'ok'
+                context     = [ordered]@{ generation_id = 'generation-789' }
+            }
+        }
+        Mock Start-DeferredPaneFromManifestEntry { $false }
+        Mock Invoke-WinsmuxSubmissionAdapter {
+            param($ProjectDir, $ManifestEntry, $Kind, $Content, $SubmissionId)
+            $script:task789SubmittedLabel = [string]$ManifestEntry.Label
+            return [pscustomobject]@{
+                protocol_version = 1
+                submission_id    = $SubmissionId
+                kind             = 'task'
+                status           = 'accepted'
+                backend          = 'codex'
+                reason_code      = ''
+                diagnostic       = ''
+                target           = [ordered]@{ label = [string]$ManifestEntry.Label; pane_id = [string]$ManifestEntry.PaneId; role = 'Worker' }
+                routing          = $null
+                acknowledgement  = $null
+            }
+        }
+        Mock ConvertTo-WinsmuxSubmissionReceiptJson {
+            param($Receipt)
+            $script:task789Receipt = $Receipt
+            return ($Receipt | ConvertTo-Json -Compress -Depth 8)
+        }
+
+        $null = script:Invoke-Task789PublicDispatchTask -Argv @(
+            '--project-dir', $script:task789FixRoot, 'implement the focused change'
+        )
+
+        $script:task789SpawnedSlots | Should -Be @('worker-2')
+        $script:task789SubmittedLabel | Should -Be 'worker-2'
+        $script:task789Receipt.routing.matched_rule | Should -Not -BeNullOrEmpty
+        Should -Invoke Add-OrchestraPane -Times 1
+    }
+
+    It 'E03 public --slot-id spawn initializes route and emits routing.matched_rule' {
+        $null = New-Item -ItemType File -Path (Join-Path $script:task789FixRoot '.winsmux.yaml') -Force
+        $script:task789SpawnedSlots = @()
+        $script:task789SubmittedLabel = ''
+        $script:task789Receipt = $null
+        $script:task789Worker2Live = $false
+        Mock Get-OrchestraModeDocument {
+            [pscustomobject]@{ schema_version = 1; mode = 'team'; valid = $true; source = 'file' }
+        }
+        Mock Get-OrchestraLiveWorkerRolePaneCount { 1 }
+        Mock Get-OrchestraMaxLiveWorkerPaneCount { 6 }
+        Mock Get-WinsmuxManifest {
+            [pscustomobject]@{
+                Panes = [ordered]@{
+                    'worker-1' = [pscustomobject]@{ pane_id = '%3'; role = 'Worker' }
+                }
+            }
+        }
+        Mock Get-PaneControlManifestEntries {
+            $entries = @(script:New-Task789LiveEntry -Label 'worker-1' -PaneId '%3')
+            if ($script:task789Worker2Live) {
+                $entries += script:New-Task789LiveEntry -Label 'worker-2' -PaneId '%5'
+            }
+            return $entries
+        }
+        Mock Get-DispatchTaskCatalogSlotIds { @('worker-1', 'worker-2') }
+        Mock Get-BridgeSettings {
+            [ordered]@{
+                agent_slots = @(
+                    [pscustomobject]@{ slot_id = 'worker-1'; runtime_role = 'worker'; worker_role = 'impl' }
+                    [pscustomobject]@{ slot_id = 'worker-2'; runtime_role = 'worker'; worker_role = 'impl' }
+                )
+            }
+        }
+        Mock Invoke-TeamProfileLaunchProjection {
+            [pscustomobject]@{
+                bundle_path = '.winsmux/team-profile/worker-2.md'
+                projection  = [pscustomobject]@{
+                    pane = [pscustomobject]@{
+                        assignment = [pscustomobject]@{ provider = 'codex'; launch_model = 'gpt-5.4'; worker_backend = 'codex' }
+                    }
+                }
+            }
+        }
+        Mock New-TeamProfileSlotAgentConfig {
+            [pscustomobject]@{ Agent = 'codex'; Model = 'gpt-5.4'; WorkerBackend = 'codex'; PaneTitle = $SlotId }
+        }
+        Mock Add-OrchestraPane {
+            $script:task789SpawnedSlots += [string]$SlotId
+            $script:task789Worker2Live = $true
+            return [pscustomobject]@{ Changed = $true; Label = $SlotId; PaneId = '%5' }
+        }
+        Mock Test-PaneControlRuntimeContext {
+            [pscustomobject]@{
+                valid       = $true
+                reason_code = 'dispatch_verified'
+                diagnostic  = 'ok'
+                context     = [ordered]@{ generation_id = 'generation-789' }
+            }
+        }
+        Mock Start-DeferredPaneFromManifestEntry { $false }
+        Mock Invoke-WinsmuxSubmissionAdapter {
+            param($ProjectDir, $ManifestEntry, $Kind, $Content, $SubmissionId)
+            $script:task789SubmittedLabel = [string]$ManifestEntry.Label
+            return [pscustomobject]@{
+                protocol_version = 1
+                submission_id    = $SubmissionId
+                kind             = 'task'
+                status           = 'accepted'
+                backend          = 'codex'
+                reason_code      = ''
+                diagnostic       = ''
+                target           = [ordered]@{ label = [string]$ManifestEntry.Label; pane_id = [string]$ManifestEntry.PaneId; role = 'Worker' }
+                routing          = $null
+                acknowledgement  = $null
+            }
+        }
+        Mock ConvertTo-WinsmuxSubmissionReceiptJson {
+            param($Receipt)
+            $script:task789Receipt = $Receipt
+            return ($Receipt | ConvertTo-Json -Compress -Depth 8)
+        }
+
+        { script:Invoke-Task789PublicDispatchTask -Argv @(
+            '--slot-id', 'worker-2', '--project-dir', $script:task789FixRoot, 'implement the focused change'
+        ) } | Should -Not -Throw
+
+        $script:task789SpawnedSlots | Should -Be @('worker-2')
+        $script:task789SubmittedLabel | Should -Be 'worker-2'
+        $script:task789Receipt.routing.matched_rule | Should -Not -BeNullOrEmpty
+        $script:task789Receipt.routing.expected_owner | Should -Be 'Worker'
+    }
+
+    It 'E04 public --slot-id on a live worker does not spawn and still initializes route' {
+        $null = New-Item -ItemType File -Path (Join-Path $script:task789FixRoot '.winsmux.yaml') -Force
+        $script:task789SpawnedSlots = @()
+        $script:task789SubmittedLabel = ''
+        $script:task789Receipt = $null
+        Mock Get-OrchestraModeDocument {
+            [pscustomobject]@{ schema_version = 1; mode = 'team'; valid = $true; source = 'file' }
+        }
+        Mock Get-OrchestraLiveWorkerRolePaneCount { 1 }
+        Mock Get-OrchestraMaxLiveWorkerPaneCount { 6 }
+        Mock Get-WinsmuxManifest {
+            [pscustomobject]@{
+                Panes = [ordered]@{
+                    'worker-1' = [pscustomobject]@{ pane_id = '%3'; role = 'Worker' }
+                }
+            }
+        }
+        Mock Get-BridgeSettings {
+            [ordered]@{
+                agent_slots = @(
+                    [pscustomobject]@{ slot_id = 'worker-1'; runtime_role = 'worker'; worker_role = 'impl' }
+                    [pscustomobject]@{ slot_id = 'worker-2'; runtime_role = 'worker'; worker_role = 'impl' }
+                )
+            }
+        }
+        Mock Get-PaneControlManifestEntries {
+            @(script:New-Task789LiveEntry -Label 'worker-1' -PaneId '%3')
+        }
+        Mock Get-DispatchTaskManifestEntry {
+            param($ProjectDir, $Label)
+            if ([string]$Label -eq 'worker-1') {
+                return (script:New-Task789LiveEntry -Label 'worker-1' -PaneId '%3')
+            }
+            return $null
+        }
+        Mock Get-DispatchTaskCatalogSlotIds { @('worker-1', 'worker-2') }
+        Mock Invoke-TeamProfileLaunchProjection { throw 'E04 must not project a live slot' }
+        Mock Add-OrchestraPane {
+            $script:task789SpawnedSlots += [string]$SlotId
+            throw 'E04 must not spawn a second pane for a live slot'
+        }
+        Mock Test-PaneControlRuntimeContext {
+            [pscustomobject]@{
+                valid       = $true
+                reason_code = 'dispatch_verified'
+                diagnostic  = 'ok'
+                context     = [ordered]@{ generation_id = 'generation-789' }
+            }
+        }
+        Mock Start-DeferredPaneFromManifestEntry { $false }
+        Mock Invoke-WinsmuxSubmissionAdapter {
+            param($ProjectDir, $ManifestEntry, $Kind, $Content, $SubmissionId)
+            $script:task789SubmittedLabel = [string]$ManifestEntry.Label
+            return [pscustomobject]@{
+                protocol_version = 1
+                submission_id    = $SubmissionId
+                kind             = 'task'
+                status           = 'accepted'
+                backend          = 'codex'
+                reason_code      = ''
+                diagnostic       = ''
+                target           = [ordered]@{ label = [string]$ManifestEntry.Label; pane_id = [string]$ManifestEntry.PaneId; role = 'Worker' }
+                routing          = $null
+                acknowledgement  = $null
+            }
+        }
+        Mock ConvertTo-WinsmuxSubmissionReceiptJson {
+            param($Receipt)
+            $script:task789Receipt = $Receipt
+            return ($Receipt | ConvertTo-Json -Compress -Depth 8)
+        }
+
+        $null = script:Invoke-Task789PublicDispatchTask -Argv @(
+            '--slot-id', 'worker-1', '--project-dir', $script:task789FixRoot, 'implement the focused change'
+        )
+
+        $script:task789SpawnedSlots | Should -Be @()
+        $script:task789SubmittedLabel | Should -Be 'worker-1'
+        $script:task789Receipt | Should -Not -BeNullOrEmpty
+        $script:task789Receipt.routing.matched_rule | Should -Not -BeNullOrEmpty
+        Should -Invoke Add-OrchestraPane -Times 0
+    }
+
+    It 'E02 public dispatch-task at the live worker cap does not spawn' {
+        $script:task789SpawnedSlots = @()
+        $script:task789SubmittedLabel = ''
+        Mock Get-OrchestraModeDocument {
+            [pscustomobject]@{ schema_version = 1; mode = 'team'; valid = $true; source = 'file' }
+        }
+        Mock Get-OrchestraLiveWorkerRolePaneCount { 6 }
+        Mock Get-OrchestraMaxLiveWorkerPaneCount { 6 }
+        Mock Get-WinsmuxManifest {
+            [pscustomobject]@{
+                Panes = [ordered]@{
+                    'worker-1' = [pscustomobject]@{ pane_id = '%3'; role = 'Worker' }
+                    'worker-2' = [pscustomobject]@{ pane_id = '%4'; role = 'Worker' }
+                    'worker-3' = [pscustomobject]@{ pane_id = '%5'; role = 'Worker' }
+                    'worker-4' = [pscustomobject]@{ pane_id = '%6'; role = 'Worker' }
+                    'worker-5' = [pscustomobject]@{ pane_id = '%7'; role = 'Worker' }
+                    'worker-6' = [pscustomobject]@{ pane_id = '%8'; role = 'Worker' }
+                }
+            }
+        }
+        Mock Get-PaneControlManifestEntries {
+            @(
+                script:New-Task789LiveEntry -Label 'worker-1' -PaneId '%3'
+                script:New-Task789LiveEntry -Label 'worker-2' -PaneId '%4'
+                script:New-Task789LiveEntry -Label 'worker-3' -PaneId '%5'
+                script:New-Task789LiveEntry -Label 'worker-4' -PaneId '%6'
+                script:New-Task789LiveEntry -Label 'worker-5' -PaneId '%7'
+                script:New-Task789LiveEntry -Label 'worker-6' -PaneId '%8'
+            )
+        }
+        Mock Get-DispatchTaskCatalogSlotIds { @('worker-1', 'worker-2', 'worker-3', 'worker-4', 'worker-5', 'worker-6') }
+        Mock Add-OrchestraPane { throw 'E02 must not spawn when live workers are at max' }
+        Mock Test-PaneControlRuntimeContext {
+            [pscustomobject]@{
+                valid       = $true
+                reason_code = 'dispatch_verified'
+                diagnostic  = 'ok'
+                context     = [ordered]@{ generation_id = 'generation-789' }
+            }
+        }
+        Mock Start-DeferredPaneFromManifestEntry { $false }
+        Mock Invoke-WinsmuxSubmissionAdapter {
+            param($ProjectDir, $ManifestEntry, $Kind, $Content, $SubmissionId)
+            $script:task789SubmittedLabel = [string]$ManifestEntry.Label
+            return [pscustomobject]@{
+                protocol_version = 1
+                submission_id    = $SubmissionId
+                kind             = 'task'
+                status           = 'accepted'
+                backend          = 'codex'
+                reason_code      = ''
+                diagnostic       = ''
+                target           = [ordered]@{ label = [string]$ManifestEntry.Label; pane_id = [string]$ManifestEntry.PaneId; role = 'Worker' }
+                routing          = $null
+                acknowledgement  = $null
+            }
+        }
+        Mock ConvertTo-WinsmuxSubmissionReceiptJson {
+            param($Receipt)
+            return ($Receipt | ConvertTo-Json -Compress -Depth 8)
+        }
+
+        $null = script:Invoke-Task789PublicDispatchTask -Argv @(
+            '--project-dir', $script:task789FixRoot, 'implement the focused change'
+        )
+
+        $script:task789SpawnedSlots | Should -Be @()
+        $script:task789SubmittedLabel | Should -Match '^worker-\d+$'
+        Should -Invoke Add-OrchestraPane -Times 0
+    }
+
+    It 'E05 public simple mode does not spawn a second live worker-role pane' {
+        $null = New-Item -ItemType File -Path (Join-Path $script:task789FixRoot '.winsmux.yaml') -Force
+        $script:task789SpawnedSlots = @()
+        $script:task789SubmittedLabel = ''
+        Mock Get-OrchestraModeDocument {
+            [pscustomobject]@{ schema_version = 1; mode = 'simple'; valid = $true; source = 'file' }
+        }
+        Mock Get-OrchestraLiveWorkerRolePaneCount { 1 }
+        Mock Get-OrchestraMaxLiveWorkerPaneCount { 1 }
+        Mock Get-WinsmuxManifest {
+            [pscustomobject]@{
+                Panes = [ordered]@{
+                    'worker-1' = [pscustomobject]@{ pane_id = '%3'; role = 'Worker' }
+                }
+            }
+        }
+        Mock Get-PaneControlManifestEntries {
+            @(script:New-Task789LiveEntry -Label 'worker-1' -PaneId '%3')
+        }
+        Mock Get-DispatchTaskCatalogSlotIds { @('worker-1', 'worker-2') }
+        Mock Get-BridgeSettings {
+            [ordered]@{
+                agent_slots = @(
+                    [pscustomobject]@{ slot_id = 'worker-1'; runtime_role = 'worker'; worker_role = 'impl' }
+                    [pscustomobject]@{ slot_id = 'worker-2'; runtime_role = 'worker'; worker_role = 'impl' }
+                )
+            }
+        }
+        Mock Add-OrchestraPane {
+            $script:task789SpawnedSlots += [string]$SlotId
+            throw 'E05 must not spawn a second simple-mode worker'
+        }
+        Mock Test-PaneControlRuntimeContext {
+            [pscustomobject]@{
+                valid       = $true
+                reason_code = 'dispatch_verified'
+                diagnostic  = 'ok'
+                context     = [ordered]@{ generation_id = 'generation-789' }
+            }
+        }
+        Mock Start-DeferredPaneFromManifestEntry { $false }
+        Mock Invoke-WinsmuxSubmissionAdapter {
+            param($ProjectDir, $ManifestEntry, $Kind, $Content, $SubmissionId)
+            $script:task789SubmittedLabel = [string]$ManifestEntry.Label
+            return [pscustomobject]@{
+                protocol_version = 1
+                submission_id    = $SubmissionId
+                kind             = 'task'
+                status           = 'accepted'
+                backend          = 'codex'
+                reason_code      = ''
+                diagnostic       = ''
+                target           = [ordered]@{ label = [string]$ManifestEntry.Label; pane_id = [string]$ManifestEntry.PaneId; role = 'Worker' }
+                routing          = $null
+                acknowledgement  = $null
+            }
+        }
+        Mock ConvertTo-WinsmuxSubmissionReceiptJson {
+            param($Receipt)
+            return ($Receipt | ConvertTo-Json -Compress -Depth 8)
+        }
+
+        $null = script:Invoke-Task789PublicDispatchTask -Argv @(
+            '--project-dir', $script:task789FixRoot, 'implement the focused change'
+        )
+
+        $script:task789SpawnedSlots | Should -Be @()
+        $script:task789SubmittedLabel | Should -Be 'worker-1'
+        Should -Invoke Add-OrchestraPane -Times 0
+    }
+
+    It 'E08 public spawn launch command attaches the Team Profile bundle from the same projection' {
+        $null = New-Item -ItemType File -Path (Join-Path $script:task789FixRoot '.winsmux.yaml') -Force
+        $script:task789BundleCalls = @()
+        $script:task789LaunchCommands = @()
+        $script:task789SubmittedLabel = ''
+        $script:task789Worker2Live = $false
+        $projection = [pscustomobject]@{
+            bundle_path = '.winsmux/team-profile/worker-2.md'
+            projection  = [pscustomobject]@{
+                pane = [pscustomobject]@{
+                    assignment    = [pscustomobject]@{ provider = 'codex'; launch_model = 'gpt-5.4'; worker_backend = 'codex' }
+                    prompt_bundle = [pscustomobject]@{ path = '.winsmux/team-profile/worker-2.md' }
+                }
+            }
+        }
+        Mock Get-OrchestraModeDocument {
+            [pscustomobject]@{ schema_version = 1; mode = 'team'; valid = $true; source = 'file' }
+        }
+        Mock Get-OrchestraLiveWorkerRolePaneCount { 1 }
+        Mock Get-OrchestraMaxLiveWorkerPaneCount { 6 }
+        Mock Get-WinsmuxManifest {
+            [pscustomobject]@{
+                Panes = [ordered]@{
+                    'worker-1' = [pscustomobject]@{ pane_id = '%3'; role = 'Worker' }
+                }
+            }
+        }
+        Mock Get-PaneControlManifestEntries {
+            $entries = @(script:New-Task789LiveEntry -Label 'worker-1' -PaneId '%3')
+            if ($script:task789Worker2Live) {
+                $entries += script:New-Task789LiveEntry -Label 'worker-2' -PaneId '%5'
+            }
+            return $entries
+        }
+        Mock Get-DispatchTaskCatalogSlotIds { @('worker-1', 'worker-2') }
+        Mock Invoke-TeamProfileLaunchProjection { $projection }
+        Mock New-TeamProfileSlotAgentConfig {
+            [pscustomobject]@{ Agent = 'codex'; Model = 'gpt-5.4'; WorkerBackend = 'codex'; PaneTitle = $SlotId }
+        }
+        Mock Add-TeamProfileBundleToLaunchCommand {
+            param($LaunchCommand, $Projection, $ProjectDir)
+            $script:task789BundleCalls += [pscustomobject]@{
+                LaunchCommand = [string]$LaunchCommand
+                BundlePath    = [string]$Projection.bundle_path
+                ProjectDir    = [string]$ProjectDir
+            }
+            $script:task789LaunchCommands += ([string]$LaunchCommand + ' TEAM-PROFILE-BUNDLE')
+            return ($LaunchCommand + ' TEAM-PROFILE-BUNDLE')
+        }
+        Mock Add-OrchestraWorkerPane {
+            param($ManifestPath, $SlotId, $Settings, $SlotAgentConfig, $Assignment, $Projection)
+            if ($null -eq $Projection -or [string]::IsNullOrWhiteSpace([string]$Projection.bundle_path)) {
+                throw 'E08 spawn must receive the Team Profile projection'
+            }
+            $null = Add-TeamProfileBundleToLaunchCommand -LaunchCommand 'echo spawn-worker-2' -Projection $Projection -ProjectDir $script:task789FixRoot
+            $script:task789Worker2Live = $true
+            return [pscustomobject]@{ Changed = $true; Label = $SlotId; PaneId = '%5' }
+        }
+        Mock Test-PaneControlRuntimeContext {
+            [pscustomobject]@{
+                valid       = $true
+                reason_code = 'dispatch_verified'
+                diagnostic  = 'ok'
+                context     = [ordered]@{ generation_id = 'generation-789' }
+            }
+        }
+        Mock Start-DeferredPaneFromManifestEntry { $false }
+        Mock Invoke-WinsmuxSubmissionAdapter {
+            param($ProjectDir, $ManifestEntry, $Kind, $Content, $SubmissionId)
+            $script:task789SubmittedLabel = [string]$ManifestEntry.Label
+            return [pscustomobject]@{
+                protocol_version = 1
+                submission_id    = $SubmissionId
+                kind             = 'task'
+                status           = 'accepted'
+                backend          = 'codex'
+                reason_code      = ''
+                diagnostic       = ''
+                target           = [ordered]@{ label = [string]$ManifestEntry.Label; pane_id = [string]$ManifestEntry.PaneId; role = 'Worker' }
+                routing          = $null
+                acknowledgement  = $null
+            }
+        }
+        Mock ConvertTo-WinsmuxSubmissionReceiptJson {
+            param($Receipt)
+            return ($Receipt | ConvertTo-Json -Compress -Depth 8)
+        }
+
+        $null = script:Invoke-Task789PublicDispatchTask -Argv @(
+            '--slot-id', 'worker-2', '--project-dir', $script:task789FixRoot, 'implement the focused change'
+        )
+
+        $script:task789SubmittedLabel | Should -Be 'worker-2'
+        $script:task789BundleCalls.Count | Should -BeGreaterThan 0
+        $script:task789BundleCalls[0].BundlePath | Should -Be '.winsmux/team-profile/worker-2.md'
+        $script:task789LaunchCommands[0] | Should -Match 'TEAM-PROFILE-BUNDLE'
+    }
+
+    It 'E08 Add-OrchestraWorkerPane launch command calls Add-TeamProfileBundleToLaunchCommand' {
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        $supervisor = script:Get-Task789SupervisorIdentity
+        script:Write-Task789V2Manifest -Path $manifestPath -ProjectDir $script:task789FixRoot -Panes @(
+            script:New-Task789V2Pane -Label 'worker-1' -PaneId '%3'
+        )
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid $supervisor.Pid `
+            -SupervisorProcessStartedAt $supervisor.StartedAt -ExpectedPaneCount 1 -LeaseSeconds 300 `
+            -Panes @(script:New-Task789V2RegistryPane -Label 'worker-1' -PaneId '%3' -BootstrapPid 4200)
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
+        $script:task789Observed = @(
+            script:New-Task789ObservedPane -PaneId '%1' -Title 'bootstrap'
+            script:New-Task789ObservedPane -PaneId '%3' -Title 'worker-1'
+        )
+        $script:task789BundleCalls = @()
+        script:Mock-Task789LiveServer
+        $worktreePath = Join-Path $script:task789FixRoot '.worktrees\worker-2'
+        New-Item -ItemType Directory -Path $worktreePath -Force | Out-Null
+        $projection = [pscustomobject]@{
+            bundle_path = '.winsmux/team-profile/worker-2.md'
+            projection  = [pscustomobject]@{
+                pane = [pscustomobject]@{
+                    prompt_bundle = [pscustomobject]@{ path = '.winsmux/team-profile/worker-2.md' }
+                }
+            }
+        }
+        Mock New-PaneScalerWorkerWorktree {
+            [pscustomobject]@{ WorktreePath = $worktreePath; BranchName = 'worktree-worker-2'; GitWorktreeDir = $worktreePath }
+        }
+        Mock Invoke-MonitorWinsmux {
+            param($Arguments)
+            $argsList = @($Arguments)
+            if ($argsList -contains 'split-window') {
+                $script:task789Observed = @($script:task789Observed) + @(
+                    script:New-Task789ObservedPane -PaneId '%5' -Title 'worker-2'
+                )
+                return '%5'
+            }
+            if ($argsList -contains 'select-pane') { return }
+        }
+        Mock Wait-MonitorPaneShellReady { }
+        Mock Get-PaneScalerLaunchCommand { 'echo spawn-worker-2' }
+        Mock Add-TeamProfileBundleToLaunchCommand {
+            param($LaunchCommand, $Projection, $ProjectDir)
+            $script:task789BundleCalls += [pscustomobject]@{
+                LaunchCommand = [string]$LaunchCommand
+                BundlePath    = [string]$Projection.bundle_path
+                ProjectDir    = [string]$ProjectDir
+            }
+            return ($LaunchCommand + ' TEAM-PROFILE-BUNDLE')
+        }
+        Mock New-OrchestraPaneBootstrapPlan {
+            param($LaunchCommand)
+            $script:task789CapturedLaunch = [string]$LaunchCommand
+            $planDir = Join-Path $script:task789FixRoot '.winsmux\orchestra-bootstrap'
+            New-Item -ItemType Directory -Path $planDir -Force | Out-Null
+            $planPath = Join-Path $planDir '5.json'
+            Set-Content -LiteralPath $planPath -Value '{}' -Encoding utf8
+            return $planPath
+        }
+        Mock Get-OrchestraPaneBootstrapMarkerPath {
+            Join-Path $script:task789FixRoot '.winsmux\orchestra-bootstrap\5-generation-789.ready.json'
+        }
+        Mock Start-OrchestraPaneBootstrap { }
+        Mock Get-BridgeSettings { [ordered]@{ agent = 'codex'; model = 'gpt-5.4' } }
+
+        $result = Add-OrchestraWorkerPane -ManifestPath $manifestPath -SlotId 'worker-2' -SlotAgentConfig ([pscustomobject]@{
+            Agent = 'codex'; Model = 'gpt-5.4'; WorkerBackend = 'codex'; PaneTitle = 'worker-2'
+        }) -Projection $projection
+        $result.Changed | Should -BeTrue
+        $script:task789BundleCalls.Count | Should -Be 1
+        $script:task789BundleCalls[0].BundlePath | Should -Be '.winsmux/team-profile/worker-2.md'
+        $script:task789CapturedLaunch | Should -Match 'TEAM-PROFILE-BUNDLE'
+        $saved = Read-PaneScalerManifest -ManifestPath $manifestPath
+        $saved.version | Should -Be 2
+        $saved.Session.expected_pane_count | Should -Be 2
+    }
+
+    It 'E09 Get-DispatchTaskAvailableTargets still excludes reviewer-only live slots after catalog union' {
+        Mock Get-OrchestraModeDocument {
+            [pscustomobject]@{ schema_version = 1; mode = 'team'; valid = $true; source = 'file' }
+        }
+        Mock Get-OrchestraLiveWorkerRolePaneCount { 1 }
+        Mock Get-OrchestraMaxLiveWorkerPaneCount { 6 }
+        Mock Get-PaneControlManifestEntries {
+            @(
+                [PSCustomObject]@{ Label = 'worker-1'; PaneId = '%1'; Role = 'Worker'; WorkerRole = 'reviewer'; AgentRole = '' },
+                [PSCustomObject]@{ Label = 'worker-2'; PaneId = '%2'; Role = 'Worker'; WorkerRole = 'impl'; AgentRole = '' }
+            )
+        }
+        Mock Get-DispatchTaskCatalogSlotIds { @('worker-2', 'worker-3') }
+        Mock Get-BridgeSettings {
+            [ordered]@{
+                agent_slots = @(
+                    [pscustomobject]@{ slot_id = 'worker-1'; runtime_role = 'worker'; worker_role = 'reviewer' }
+                    [pscustomobject]@{ slot_id = 'worker-2'; runtime_role = 'worker'; worker_role = 'impl' }
+                    [pscustomobject]@{ slot_id = 'worker-3'; runtime_role = 'worker'; worker_role = 'impl' }
+                )
+            }
+        }
+        $null = New-Item -ItemType File -Path (Join-Path $script:task789FixRoot '.winsmux.yaml') -Force
+
+        $targets = @(Get-DispatchTaskAvailableTargets -ProjectDir $script:task789FixRoot)
+        $targets | Should -Contain 'worker-2'
+        $targets | Should -Contain 'worker-3'
+        $targets | Should -Not -Contain 'worker-1'
     }
 }

--- a/tests/bridge/CommandReviewDispatch.Tests.ps1
+++ b/tests/bridge/CommandReviewDispatch.Tests.ps1
@@ -1654,6 +1654,24 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
                 param($ProjectDir, $SessionId, $SlotId, $Worktree, $ReadWriteScope, [switch]$Force)
             }
         }
+        if (-not (Get-Command New-OrchestraPaneBootstrapPlan -ErrorAction SilentlyContinue)) {
+            function script:New-OrchestraPaneBootstrapPlan {
+                param($ProjectDir, $PaneId, $Label, $SlotId, $Role, $WorkerBackend, $WorkerRole, $PaneTitle, $GenerationId, $ServerSessionId, $Agent, $Model, $StartupToken, $LaunchDir, $CleanPtyEnv, $LaunchCommand, $SupportsInterrupt, $ApprovedLaunch)
+                throw 'New-OrchestraPaneBootstrapPlan not mocked'
+            }
+        }
+        if (-not (Get-Command Get-OrchestraPaneBootstrapMarkerPath -ErrorAction SilentlyContinue)) {
+            function script:Get-OrchestraPaneBootstrapMarkerPath {
+                param($PlanPath, $GenerationId)
+                throw 'Get-OrchestraPaneBootstrapMarkerPath not mocked'
+            }
+        }
+        if (-not (Get-Command Start-OrchestraPaneBootstrap -ErrorAction SilentlyContinue)) {
+            function script:Start-OrchestraPaneBootstrap {
+                param($PaneId, $PlanPath, $SessionName)
+                throw 'Start-OrchestraPaneBootstrap not mocked'
+            }
+        }
     }
 
     BeforeEach {
@@ -1683,8 +1701,11 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
         }
         $body = $script:task789DispatchContent.Substring($archiveIndex, $next - $archiveIndex)
         $body | Should -Match 'Remove-OrchestraPane'
+        $body | Should -Match 'Get-WinsmuxArchivePaneRuntimeRefusal'
         $body | Should -Match 'C-c'
         $body | Should -Match 'pane\.idle'
+        $body.IndexOf('Get-WinsmuxArchivePaneRuntimeRefusal') | Should -BeLessThan $body.IndexOf('C-c')
+        $script:task789DispatchContent | Should -Match "Operation stop_transition"
         $body | Should -Not -Match 'Invoke-WorkersStop'
         $body | Should -Not -Match 'respawn-pane'
         $body | Should -Not -Match 'workers stop'
@@ -1793,7 +1814,26 @@ Write-Output 'ok'
             }
         }
 
-        $count = Set-OrchestraLiveExpectedPaneCount -Manifest $manifest -ExpectedPaneCount 3 -ProjectDir $script:task789FixRoot
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        @"
+version: 1
+saved_at: 2026-08-17T00:00:00Z
+session:
+  name: winsmux-orchestra
+  project_dir: $script:task789FixRoot
+  expected_pane_count: 2
+panes:
+  operator:
+    slot_id: operator
+    pane_id: '%2'
+    role: Operator
+  worker-1:
+    slot_id: worker-1
+    pane_id: '%3'
+    role: Worker
+"@ | Set-Content -LiteralPath $manifestPath -Encoding utf8
+        $manifest | Add-Member -NotePropertyName 'version' -NotePropertyValue 1 -Force
+        $count = Save-OrchestraLivePaneSetTransition -ManifestPath $manifestPath -Manifest $manifest -ProjectDir $script:task789FixRoot
         $count | Should -Be 3
         $manifest.Session.expected_pane_count | Should -Be 3
 
@@ -1802,6 +1842,8 @@ Write-Output 'ok'
         @($read.panes).Count | Should -Be 3
         @($read.panes | ForEach-Object { [string]$_.label }) | Should -Be @('operator', 'worker-1', 'worker-2')
         ($read.panes | Where-Object { $_.label -eq 'worker-2' }).pane_id | Should -Be '%4'
+        $saved = Read-PaneScalerManifest -ManifestPath $manifestPath
+        @($saved.Panes.Keys) | Should -Be @('operator', 'worker-1', 'worker-2')
     }
 
     It 'does not clamp an empty pane set to expected_pane_count 1' {
@@ -1971,5 +2013,382 @@ panes:
         $result.ReasonCode | Should -Be 'team_profile_projection_unavailable'
         $result.Diagnostic | Should -Be $ProjectionError
         Should -Invoke Add-OrchestraPane -Times 0
+    }
+
+    It 'does not publish a new registry when the guarded manifest save fails' {
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        $registryPath = Get-WinsmuxRuntimeRegistryPath -ProjectDir $script:task789FixRoot
+        @"
+version: 2
+saved_at: 2026-08-17T00:00:00Z
+session:
+  name: winsmux-orchestra
+  generation_id: generation-789
+  server_session_id: '`$9'
+  bootstrap_pane_id: '%1'
+  expected_pane_count: 1
+panes:
+  worker-1:
+    slot_id: worker-1
+    pane_id: '%3'
+    role: Worker
+    worker_role: worker
+    worker_backend: codex
+    title: worker-1
+    status: ready
+"@ | Set-Content -LiteralPath $manifestPath -Encoding utf8
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid 4100 `
+            -SupervisorProcessStartedAt '2026-08-17T00:00:00.0000000Z' -ExpectedPaneCount 1 `
+            -Panes @(
+                [PSCustomObject]@{ label = 'worker-1'; slot_id = 'worker-1'; pane_id = '%3'; backend = 'codex'; role = 'worker'; title = 'worker-1'; state = 'live'; bootstrap_pid = 4200; bootstrap_process_started_at = '2026-08-17T00:00:01.0000000Z'; marker_path = '' }
+            )
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
+        $beforeRegistry = [System.IO.File]::ReadAllBytes($registryPath)
+        $beforeManifest = [System.IO.File]::ReadAllBytes($manifestPath)
+
+        $manifest = Read-PaneScalerManifest -ManifestPath $manifestPath
+        $manifest.Panes['worker-2'] = [pscustomobject]@{
+            slot_id = 'worker-2'; pane_id = '%4'; role = 'Worker'; worker_role = 'worker'
+            worker_backend = 'codex'; title = 'worker-2'; status = 'ready'
+        }
+        Mock Save-PaneScalerManifest { throw 'injected manifest save failure' }
+        Mock Save-WinsmuxRuntimeRegistry { throw 'registry must not publish after a failed manifest save' }
+
+        { Save-OrchestraLivePaneSetTransition -ManifestPath $manifestPath -Manifest $manifest -ProjectDir $script:task789FixRoot -ExpectedGenerationId 'generation-789' } |
+            Should -Throw '*injected manifest save failure*'
+
+        [System.IO.File]::ReadAllBytes($registryPath) | Should -Be $beforeRegistry
+        [System.IO.File]::ReadAllBytes($manifestPath) | Should -Be $beforeManifest
+        Should -Invoke Save-WinsmuxRuntimeRegistry -Times 0
+    }
+
+    It 'rolls both halves back when registry save fails after the new manifest is written' {
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        $registryPath = Get-WinsmuxRuntimeRegistryPath -ProjectDir $script:task789FixRoot
+        $oldYaml = "version: 1`nsession:`n  name: old`npanes:`n  worker-1:`n    pane_id: '%3'`n"
+        Set-Content -LiteralPath $manifestPath -Value $oldYaml -Encoding utf8
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid 4100 `
+            -SupervisorProcessStartedAt '2026-08-17T00:00:00.0000000Z' -ExpectedPaneCount 1 `
+            -Panes @(
+                [PSCustomObject]@{ label = 'worker-1'; slot_id = 'worker-1'; pane_id = '%3'; backend = 'codex'; role = 'worker'; title = 'worker-1'; state = 'live'; bootstrap_pid = 4200; bootstrap_process_started_at = '2026-08-17T00:00:01.0000000Z'; marker_path = '' }
+            )
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
+        $beforeRegistry = [System.IO.File]::ReadAllBytes($registryPath)
+        $beforeManifest = [System.IO.File]::ReadAllBytes($manifestPath)
+
+        $manifest = [pscustomobject]@{
+            version = 1
+            Session = [pscustomobject]@{ expected_pane_count = 1 }
+            Panes   = [ordered]@{
+                'worker-1' = [pscustomobject]@{ slot_id = 'worker-1'; pane_id = '%3'; role = 'Worker'; worker_role = 'worker'; worker_backend = 'codex'; title = 'worker-1' }
+                'worker-2' = [pscustomobject]@{ slot_id = 'worker-2'; pane_id = '%4'; role = 'Worker'; worker_role = 'worker'; worker_backend = 'codex'; title = 'worker-2' }
+            }
+        }
+        Mock Save-PaneScalerManifest {
+            [System.IO.File]::WriteAllText($ManifestPath, 'NEW-HALF-PUBLISHED-MANIFEST')
+        }
+        Mock Save-WinsmuxRuntimeRegistry { throw 'injected registry save failure' }
+
+        { Save-OrchestraLivePaneSetTransition -ManifestPath $manifestPath -Manifest $manifest -ProjectDir $script:task789FixRoot } |
+            Should -Throw '*injected registry save failure*'
+
+        [System.IO.File]::ReadAllBytes($manifestPath) | Should -Be $beforeManifest
+        [System.IO.File]::ReadAllBytes($registryPath) | Should -Be $beforeRegistry
+    }
+
+    It 'does not expose a spawned worker as ready without a bootstrap marker identity' {
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        @"
+version: 1
+saved_at: 2026-08-17T00:00:00Z
+session:
+  name: winsmux-orchestra
+  project_dir: $script:task789FixRoot
+  generation_id: generation-789
+  server_session_id: '`$9'
+  bootstrap_pane_id: '%1'
+  expected_pane_count: 1
+panes:
+  worker-1:
+    slot_id: worker-1
+    pane_id: '%3'
+    role: Worker
+    worker_role: worker
+    worker_backend: codex
+    title: worker-1
+    status: ready
+"@ | Set-Content -LiteralPath $manifestPath -Encoding utf8
+        $worktreePath = Join-Path $script:task789FixRoot '.worktrees\worker-2'
+        New-Item -ItemType Directory -Path $worktreePath -Force | Out-Null
+        Mock New-PaneScalerWorkerWorktree {
+            [pscustomobject]@{ WorktreePath = $worktreePath; BranchName = 'worktree-worker-2'; GitWorktreeDir = $worktreePath }
+        }
+        Mock Invoke-MonitorWinsmux {
+            param($Arguments)
+            if (@($Arguments) -contains 'split-window') { return '%5' }
+        }
+        Mock Wait-MonitorPaneShellReady { }
+        Mock Send-MonitorBridgeCommand { throw 'direct launch must not replace orchestra bootstrap' }
+        Mock Get-PaneScalerLaunchCommand { 'echo spawn-worker-2' }
+        Mock New-OrchestraPaneBootstrapPlan {
+            $planDir = Join-Path $script:task789FixRoot '.winsmux\orchestra-bootstrap'
+            New-Item -ItemType Directory -Path $planDir -Force | Out-Null
+            $planPath = Join-Path $planDir '5.json'
+            Set-Content -LiteralPath $planPath -Value '{}' -Encoding utf8
+            return $planPath
+        }
+        Mock Get-OrchestraPaneBootstrapMarkerPath {
+            Join-Path $script:task789FixRoot '.winsmux\orchestra-bootstrap\5-generation-789.ready.json'
+        }
+        Mock Start-OrchestraPaneBootstrap { }
+        Mock Get-BridgeSettings { [ordered]@{ agent = 'codex'; model = 'gpt-5.4' } }
+
+        $result = Add-OrchestraWorkerPane -ManifestPath $manifestPath -SlotId 'worker-2' -SlotAgentConfig ([pscustomobject]@{
+            Agent = 'codex'; Model = 'gpt-5.4'; WorkerBackend = 'codex'; PaneTitle = 'worker-2'
+        })
+        $result.Changed | Should -BeTrue
+        $saved = Read-PaneScalerManifest -ManifestPath $manifestPath
+        $saved.Panes['worker-2'].status | Should -Be 'deferred_starting'
+        $readyRaw = $saved.Panes['worker-2'].runtime_ready
+        ($readyRaw -eq $true -or [string]$readyRaw -ceq 'true') | Should -BeFalse
+        [string]$saved.Panes['worker-2'].bootstrap_marker_path | Should -Match '5-generation-789\.ready\.json'
+        Should -Invoke Send-MonitorBridgeCommand -Times 0
+        Should -Invoke Start-OrchestraPaneBootstrap -Times 1
+
+        $dispatchCheck = Test-WinsmuxRuntimeContext -Manifest ([pscustomobject]@{
+            version = 2
+            session = [pscustomobject]@{
+                name = 'winsmux-orchestra'; generation_id = 'generation-789'
+                server_session_id = '$9'; bootstrap_pane_id = '%1'; expected_pane_count = 2
+            }
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{ slot_id = 'worker-1'; pane_id = '%3'; worker_backend = 'codex'; worker_role = 'worker'; role = 'Worker'; title = 'worker-1'; status = 'ready' }
+                'worker-2' = [ordered]@{ slot_id = 'worker-2'; pane_id = '%5'; worker_backend = 'codex'; worker_role = 'worker'; role = 'Worker'; title = 'worker-2'; status = 'ready' }
+            }
+        }) -Registry ([pscustomobject]@{
+            schema_version = 1; status = 'active'; session_name = 'winsmux-orchestra'
+            generation_id = 'generation-789'; server_session_id = '$9'; bootstrap_pane_id = '%1'
+            expected_pane_count = 2
+            supervisor = [pscustomobject]@{ pid = 4100; process_started_at = '2026-08-17T00:00:00.0000000Z' }
+            lease = [pscustomobject]@{ state = 'active'; expires_at = '2099-01-01T00:00:00.0000000Z' }
+            panes = @(
+                [pscustomobject]@{ label = 'worker-1'; slot_id = 'worker-1'; pane_id = '%3'; backend = 'codex'; role = 'worker'; title = 'worker-1'; state = 'live'; bootstrap_pid = 4200; bootstrap_process_started_at = '2026-08-17T00:00:01.0000000Z' }
+                [pscustomobject]@{ label = 'worker-2'; slot_id = 'worker-2'; pane_id = '%5'; backend = 'codex'; role = 'worker'; title = 'worker-2'; state = 'live'; bootstrap_pid = 0; bootstrap_process_started_at = '' }
+            )
+        }) -ObservedServerSessionId '$9' -ObservedPanes @(
+            [pscustomobject]@{ pane_id = '%1'; title = 'bootstrap' }
+            [pscustomobject]@{ pane_id = '%3'; title = 'worker-1' }
+            [pscustomobject]@{ pane_id = '%5'; title = 'worker-2' }
+        ) -ManifestEntry ([pscustomobject]@{
+            Label = 'worker-2'; SlotId = 'worker-2'; PaneId = '%5'; WorkerBackend = 'codex'
+            WorkerRole = 'worker'; Role = 'Worker'; Title = 'worker-2'; Status = 'ready'
+        }) -PaneMarker $null -ProcessResolver {
+            param([int]$Id)
+            if ($Id -eq 4100) {
+                return [PSCustomObject]@{ Id = 4100; StartTime = [datetime]'2026-08-17T00:00:00Z'; ParentProcessId = 1; Name = 'pwsh.exe' }
+            }
+            return $null
+        } -Operation dispatch -Now ([datetime]'2026-08-17T00:05:00Z')
+        $dispatchCheck.valid | Should -BeFalse
+        $dispatchCheck.reason_code | Should -Be 'runtime_target_mismatch'
+    }
+
+    It 'lets dispatch runtime succeed after a spawned worker persists bootstrap marker identity' {
+        $markerDir = Join-Path $script:task789FixRoot '.winsmux\orchestra-bootstrap'
+        New-Item -ItemType Directory -Path $markerDir -Force | Out-Null
+        $markerPath = Join-Path $markerDir '5-generation-789.ready.json'
+        $startedAt = '2026-08-17T00:00:02.0000000Z'
+        @{
+            state = 'bootstrap_pending'
+            generation_id = 'generation-789'
+            server_session_id = '$9'
+            slot_id = 'worker-2'
+            pane_id = '%5'
+            backend = 'codex'
+            role = 'worker'
+            title = 'worker-2'
+            bootstrap_pid = 4300
+            bootstrap_process_started_at = $startedAt
+        } | ConvertTo-Json | Set-Content -LiteralPath $markerPath -Encoding utf8
+
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        @"
+version: 1
+saved_at: 2026-08-17T00:00:00Z
+session:
+  name: winsmux-orchestra
+  project_dir: $script:task789FixRoot
+  generation_id: generation-789
+  server_session_id: '`$9'
+  bootstrap_pane_id: '%1'
+  expected_pane_count: 1
+panes:
+  worker-1:
+    slot_id: worker-1
+    pane_id: '%3'
+    role: Worker
+    worker_role: worker
+    worker_backend: codex
+    title: worker-1
+    status: ready
+"@ | Set-Content -LiteralPath $manifestPath -Encoding utf8
+        $worktreePath = Join-Path $script:task789FixRoot '.worktrees\worker-2'
+        New-Item -ItemType Directory -Path $worktreePath -Force | Out-Null
+        Mock New-PaneScalerWorkerWorktree {
+            [pscustomobject]@{ WorktreePath = $worktreePath; BranchName = 'worktree-worker-2'; GitWorktreeDir = $worktreePath }
+        }
+        Mock Invoke-MonitorWinsmux {
+            param($Arguments)
+            if (@($Arguments) -contains 'split-window') { return '%5' }
+        }
+        Mock Wait-MonitorPaneShellReady { }
+        Mock Get-PaneScalerLaunchCommand { 'echo spawn-worker-2' }
+        Mock New-OrchestraPaneBootstrapPlan {
+            Join-Path $markerDir '5.json'
+        }
+        Mock Get-OrchestraPaneBootstrapMarkerPath { $markerPath }
+        Mock Start-OrchestraPaneBootstrap { }
+        Mock Get-BridgeSettings { [ordered]@{ agent = 'codex'; model = 'gpt-5.4' } }
+
+        $null = Add-OrchestraWorkerPane -ManifestPath $manifestPath -SlotId 'worker-2' -SlotAgentConfig ([pscustomobject]@{
+            Agent = 'codex'; Model = 'gpt-5.4'; WorkerBackend = 'codex'; PaneTitle = 'worker-2'
+        })
+        $saved = Read-PaneScalerManifest -ManifestPath $manifestPath
+        $saved.Panes['worker-2'].status | Should -Be 'ready'
+        [bool]$saved.Panes['worker-2'].runtime_ready | Should -BeTrue
+        [string]$saved.Panes['worker-2'].bootstrap_marker_path | Should -Be $markerPath
+
+        $marker = Get-Content -LiteralPath $markerPath -Raw -Encoding UTF8 | ConvertFrom-Json
+        $processResolver = {
+            param([int]$Id)
+            switch ($Id) {
+                4100 { return [PSCustomObject]@{ Id = 4100; StartTime = [datetime]'2026-08-17T00:00:00Z'; ParentProcessId = 1; Name = 'pwsh.exe' } }
+                4300 { return [PSCustomObject]@{ Id = 4300; StartTime = [datetime]'2026-08-17T00:00:02Z'; ParentProcessId = 1; Name = 'pwsh.exe' } }
+                default { return $null }
+            }
+        }
+        $dispatchCheck = Test-WinsmuxRuntimeContext -Manifest ([pscustomobject]@{
+            version = 2
+            session = [pscustomobject]@{
+                name = 'winsmux-orchestra'; generation_id = 'generation-789'
+                server_session_id = '$9'; bootstrap_pane_id = '%1'; expected_pane_count = 2
+            }
+            panes = [ordered]@{
+                'worker-1' = [ordered]@{ slot_id = 'worker-1'; pane_id = '%3'; worker_backend = 'codex'; worker_role = 'worker'; role = 'Worker'; title = 'worker-1'; status = 'ready' }
+                'worker-2' = [ordered]@{ slot_id = 'worker-2'; pane_id = '%5'; worker_backend = 'codex'; worker_role = 'worker'; role = 'Worker'; title = 'worker-2'; status = 'ready' }
+            }
+        }) -Registry ([pscustomobject]@{
+            schema_version = 1; status = 'active'; session_name = 'winsmux-orchestra'
+            generation_id = 'generation-789'; server_session_id = '$9'; bootstrap_pane_id = '%1'
+            expected_pane_count = 2
+            supervisor = [pscustomobject]@{ pid = 4100; process_started_at = '2026-08-17T00:00:00.0000000Z' }
+            lease = [pscustomobject]@{ state = 'active'; expires_at = '2099-01-01T00:00:00.0000000Z' }
+            panes = @(
+                [pscustomobject]@{ label = 'worker-1'; slot_id = 'worker-1'; pane_id = '%3'; backend = 'codex'; role = 'worker'; title = 'worker-1'; state = 'live'; bootstrap_pid = 4200; bootstrap_process_started_at = '2026-08-17T00:00:01.0000000Z' }
+                [pscustomobject]@{ label = 'worker-2'; slot_id = 'worker-2'; pane_id = '%5'; backend = 'codex'; role = 'worker'; title = 'worker-2'; state = 'live'; bootstrap_pid = 4300; bootstrap_process_started_at = $startedAt }
+            )
+        }) -ObservedServerSessionId '$9' -ObservedPanes @(
+            [pscustomobject]@{ pane_id = '%1'; title = 'bootstrap' }
+            [pscustomobject]@{ pane_id = '%3'; title = 'worker-1' }
+            [pscustomobject]@{ pane_id = '%5'; title = 'worker-2' }
+        ) -ManifestEntry ([pscustomobject]@{
+            Label = 'worker-2'; SlotId = 'worker-2'; PaneId = '%5'; WorkerBackend = 'codex'
+            WorkerRole = 'worker'; Role = 'Worker'; Title = 'worker-2'; Status = 'ready'
+            BootstrapMarkerPath = $markerPath
+        }) -PaneMarker $marker -ProcessResolver $processResolver -Operation dispatch -Now ([datetime]'2026-08-17T00:05:00Z')
+        $dispatchCheck.valid | Should -BeTrue
+        $dispatchCheck.reason_code | Should -Be 'live_runtime_verified'
+    }
+
+    It 'does not send C-c when archive runtime ownership is unverified' {
+        $entry = [pscustomobject]@{
+            Label = 'worker-2'; SlotId = 'worker-2'; PaneId = '%9'; Role = 'Worker'
+            WorkerRole = 'worker'; WorkerBackend = 'codex'; Title = 'worker-2'; Status = 'busy'
+        }
+        if (-not (Get-Command Invoke-WinsmuxRaw -ErrorAction SilentlyContinue)) {
+            function script:Invoke-WinsmuxRaw { param($Arguments) }
+        }
+        if (-not (Get-Command Invoke-MonitorWinsmux -ErrorAction SilentlyContinue)) {
+            function script:Invoke-MonitorWinsmux { param($Arguments) }
+        }
+        Mock Test-PaneControlRuntimeContext {
+            [pscustomobject]@{
+                valid = $false
+                reason_code = 'runtime_target_mismatch'
+                diagnostic = 'stale project-dir or unverified pane id'
+            }
+        }
+        Mock Invoke-WinsmuxRaw { throw 'C-c must not run after a failed runtime check' }
+        Mock Invoke-MonitorWinsmux { throw 'C-c must not run after a failed runtime check' }
+
+        $refusal = Get-WinsmuxArchivePaneRuntimeRefusal -ProjectDir $script:task789FixRoot -Entry $entry
+        $refusal.ReasonCode | Should -Be 'runtime_target_mismatch'
+        $refusal.Diagnostic | Should -Match 'stale project-dir'
+        Should -Invoke Invoke-WinsmuxRaw -Times 0
+        Should -Invoke Invoke-MonitorWinsmux -Times 0
+    }
+
+    It 'skips C-c in archive-pane when a mismatched project-dir fails runtime ownership' {
+        $probePath = Join-Path $script:task789FixRoot 'archive-runtime-probe.ps1'
+        $dispatchPath = $script:task789DispatchPath
+        $sentPath = Join-Path $script:task789FixRoot 'cc-sent.txt'
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        @"
+version: 1
+session:
+  name: winsmux-orchestra
+  project_dir: $script:task789FixRoot
+  expected_pane_count: 2
+panes:
+  worker-1:
+    slot_id: worker-1
+    pane_id: '%3'
+    role: Worker
+    worker_role: worker
+    status: ready
+  worker-2:
+    slot_id: worker-2
+    pane_id: '%9'
+    role: Worker
+    worker_role: worker
+    status: busy
+"@ | Set-Content -LiteralPath $manifestPath -Encoding utf8
+        $probe = @"
+`$ErrorActionPreference = 'Stop'
+function Stop-WithError { param([string]`$Message) throw `$Message }
+function Get-Labels { return @{ 'worker-2' = '%9' } }
+. '$($dispatchPath.Replace("'", "''"))'
+function Test-PaneControlRuntimeContext {
+    param(`$ProjectDir, `$ManifestEntry, `$Operation)
+    return [pscustomobject]@{ valid = `$false; reason_code = 'runtime_target_mismatch'; diagnostic = 'unverified pane' }
+}
+function Get-PaneControlManifestEntries {
+    param(`$ProjectDir)
+    return @([pscustomobject]@{
+        Label = 'worker-2'; SlotId = 'worker-2'; PaneId = '%9'; Role = 'Worker'
+        WorkerRole = 'worker'; WorkerBackend = 'codex'; Title = 'worker-2'
+        Status = 'busy'; LastEvent = 'pane.progress'
+    })
+}
+function Invoke-WinsmuxRaw {
+    param(`$Arguments)
+    if (@(`$Arguments) -contains 'C-c') { Set-Content -LiteralPath '$($sentPath.Replace("'", "''"))' -Value 'sent' -Encoding utf8 }
+}
+function Invoke-MonitorWinsmux {
+    param(`$Arguments)
+    if (@(`$Arguments) -contains 'C-c') { Set-Content -LiteralPath '$($sentPath.Replace("'", "''"))' -Value 'sent' -Encoding utf8 }
+}
+Set-Location -LiteralPath '$($script:task789FixRoot.Replace("'", "''"))'
+Invoke-WinsmuxArchivePaneCommand -BridgeScriptRoot '$($script:task789FixRoot.Replace("'", "''"))' -CommandTarget 'worker-2' -CommandRest @()
+Write-Output 'reached-after-exit'
+"@
+        Set-Content -LiteralPath $probePath -Value $probe -Encoding utf8
+        $output = & pwsh -NoProfile -File $probePath 2>&1
+        $LASTEXITCODE | Should -Be 1
+        ($output | Out-String) | Should -Match 'unverified pane'
+        ($output | Out-String) | Should -Not -Match 'reached-after-exit'
+        Test-Path -LiteralPath $sentPath | Should -BeFalse
     }
 }

--- a/tests/bridge/CommandReviewDispatch.Tests.ps1
+++ b/tests/bridge/CommandReviewDispatch.Tests.ps1
@@ -1644,6 +1644,27 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
         $script:task789ManifestPath = Join-Path $repoRoot 'winsmux-core\scripts\manifest.ps1'
         . $script:task789ManifestPath
         . $script:task789DispatchPath
+        if (-not (Get-Command New-TeamProfileSlotAgentConfig -ErrorAction SilentlyContinue)) {
+            function script:New-TeamProfileSlotAgentConfig {
+                param($Role, $SlotId, $Assignment, $Settings, $RootPath)
+            }
+        }
+        if (-not (Get-Command Invoke-TeamProfileLaunchProjection -ErrorAction SilentlyContinue)) {
+            function script:Invoke-TeamProfileLaunchProjection {
+                param($ProjectDir, $SessionId, $SlotId, $Worktree, $ReadWriteScope, [switch]$Force)
+            }
+        }
+    }
+
+    BeforeEach {
+        $script:task789FixRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-task789-fix-' + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path (Join-Path $script:task789FixRoot '.winsmux') -Force | Out-Null
+    }
+
+    AfterEach {
+        if ($script:task789FixRoot -and (Test-Path -LiteralPath $script:task789FixRoot)) {
+            Remove-Item -LiteralPath $script:task789FixRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
     }
 
     It 'documents public archive-pane in usage and the command table' {
@@ -1685,6 +1706,7 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
         $body | Should -Match 'worker_backend'
         $body | Should -Not -Match 'requiredBackend'
         $body | Should -Match 'simple_mode_live_worker_limit'
+        $body | Should -Match 'team_profile_projection_unavailable'
         $script:task789DispatchContent | Should -Match 'Ensure-DispatchTaskLiveWorkerPane'
     }
 
@@ -1696,5 +1718,258 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
         $result = Ensure-DispatchTaskLiveWorkerPane -ProjectDir (Join-Path ([System.IO.Path]::GetTempPath()) 'winsmux-task789-missing') -Label 'worker-2' -ManifestEntry $null
         $result.Spawned | Should -BeFalse
         $result.ReasonCode | Should -Be 'simple_mode_live_worker_limit'
+    }
+
+    It 'exposes Add-OrchestraPane after loading only control-plane-dispatch.ps1' {
+        $probePath = Join-Path $script:task789FixRoot 'scope-probe.ps1'
+        $dispatchPath = $script:task789DispatchPath
+        $probe = @"
+`$ErrorActionPreference = 'Stop'
+if (Get-Command Add-OrchestraPane -ErrorAction SilentlyContinue) {
+    throw 'Add-OrchestraPane already existed before dispatch load'
+}
+if (Get-Command New-TeamProfileSlotAgentConfig -ErrorAction SilentlyContinue) {
+    throw 'orchestra-start.ps1 was pre-loaded'
+}
+. '$($dispatchPath.Replace("'", "''"))'
+if (-not (Get-Command Add-OrchestraPane -ErrorAction SilentlyContinue)) {
+    throw 'Add-OrchestraPane missing after dispatch load'
+}
+if (-not (Get-Command Remove-OrchestraPane -ErrorAction SilentlyContinue)) {
+    throw 'Remove-OrchestraPane missing after dispatch load'
+}
+if (Get-Command New-TeamProfileSlotAgentConfig -ErrorAction SilentlyContinue) {
+    throw 'Add-OrchestraPane must not depend on pre-loading orchestra-start.ps1'
+}
+`$null = Get-Command Ensure-DispatchTaskLiveWorkerPane -ErrorAction Stop
+`$null = Get-Command Invoke-WinsmuxArchivePaneCommand -ErrorAction Stop
+try {
+    `$null = Ensure-DispatchTaskLiveWorkerPane -ProjectDir '$($script:task789FixRoot.Replace("'", "''"))' -Label 'worker-2' -ManifestEntry `$null
+} catch {
+    if (`$_.FullyQualifiedErrorId -eq 'CommandNotFoundException' -and [string]`$_.Exception.Message -match 'Add-OrchestraPane|Remove-OrchestraPane') {
+        throw
+    }
+}
+Write-Output 'ok'
+"@
+        Set-Content -LiteralPath $probePath -Value $probe -Encoding utf8
+        $output = & pwsh -NoProfile -File $probePath 2>&1
+        $LASTEXITCODE | Should -Be 0
+        ($output | Out-String) | Should -Match 'ok'
+    }
+
+    It 'transitions registry pane identities together with expected_pane_count' {
+        $operatorPane = [PSCustomObject]@{
+            label = 'operator'; slot_id = 'operator'; pane_id = '%2'; backend = 'local'
+            role = 'operator'; title = 'Operator'; state = 'live'; bootstrap_pid = 4100
+            bootstrap_process_started_at = '2026-08-17T00:00:00.0000000Z'; marker_path = ''
+        }
+        $worker1Pane = [PSCustomObject]@{
+            label = 'worker-1'; slot_id = 'worker-1'; pane_id = '%3'; backend = 'codex'
+            role = 'worker'; title = 'worker-1'; state = 'live'; bootstrap_pid = 4200
+            bootstrap_process_started_at = '2026-08-17T00:00:01.0000000Z'; marker_path = ''
+        }
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid 4100 `
+            -SupervisorProcessStartedAt '2026-08-17T00:00:00.0000000Z' -ExpectedPaneCount 2 `
+            -Panes @($operatorPane, $worker1Pane)
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
+
+        $manifest = [pscustomobject]@{
+            Session = [pscustomobject]@{ expected_pane_count = 2 }
+            Panes   = [ordered]@{
+                'operator' = [pscustomobject]@{
+                    slot_id = 'operator'; pane_id = '%2'; role = 'Operator'
+                    worker_role = 'operator'; worker_backend = 'local'; title = 'Operator'
+                }
+                'worker-1' = [pscustomobject]@{
+                    slot_id = 'worker-1'; pane_id = '%3'; role = 'Worker'
+                    worker_role = 'worker'; worker_backend = 'codex'; title = 'worker-1'
+                }
+                'worker-2' = [pscustomobject]@{
+                    slot_id = 'worker-2'; pane_id = '%4'; role = 'Worker'
+                    worker_role = 'worker'; worker_backend = 'codex'; title = 'worker-2'
+                }
+            }
+        }
+
+        $count = Set-OrchestraLiveExpectedPaneCount -Manifest $manifest -ExpectedPaneCount 3 -ProjectDir $script:task789FixRoot
+        $count | Should -Be 3
+        $manifest.Session.expected_pane_count | Should -Be 3
+
+        $read = Read-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot
+        $read.expected_pane_count | Should -Be 3
+        @($read.panes).Count | Should -Be 3
+        @($read.panes | ForEach-Object { [string]$_.label }) | Should -Be @('operator', 'worker-1', 'worker-2')
+        ($read.panes | Where-Object { $_.label -eq 'worker-2' }).pane_id | Should -Be '%4'
+    }
+
+    It 'does not clamp an empty pane set to expected_pane_count 1' {
+        $workerPane = [PSCustomObject]@{
+            label = 'worker-1'; slot_id = 'worker-1'; pane_id = '%3'; backend = 'codex'
+            role = 'worker'; title = 'worker-1'; state = 'live'; bootstrap_pid = 4200
+            bootstrap_process_started_at = '2026-08-17T00:00:01.0000000Z'; marker_path = ''
+        }
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid 4100 `
+            -SupervisorProcessStartedAt '2026-08-17T00:00:00.0000000Z' -ExpectedPaneCount 1 `
+            -Panes @($workerPane)
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
+
+        $manifest = [pscustomobject]@{
+            Session = [pscustomobject]@{ expected_pane_count = 1 }
+            Panes   = [ordered]@{}
+        }
+        { Update-PaneScalerLiveExpectedPaneCount -Manifest $manifest -ProjectDir $script:task789FixRoot } |
+            Should -Throw '*1 or greater*'
+
+        $read = Read-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot
+        $read.expected_pane_count | Should -Be 1
+        @($read.panes).Count | Should -Be 1
+        $read.panes[0].label | Should -Be 'worker-1'
+    }
+
+    It 'rejects operator and a non-worker label without mutating the session' {
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        $yaml = @"
+version: 1
+saved_at: 2026-08-17T00:00:00Z
+session:
+  name: winsmux-orchestra
+  project_dir: $script:task789FixRoot
+  generation_id: generation-789
+  server_session_id: '`$9'
+  bootstrap_pane_id: '%1'
+  expected_pane_count: 3
+panes:
+  operator:
+    label: operator
+    slot_id: operator
+    pane_id: '%2'
+    role: Operator
+    worker_role: operator
+    worker_backend: local
+    title: Operator
+    status: ready
+  reviewer:
+    label: reviewer
+    slot_id: reviewer
+    pane_id: '%4'
+    role: Reviewer
+    worker_role: reviewer
+    worker_backend: local
+    title: Reviewer
+    status: ready
+  worker-1:
+    label: worker-1
+    slot_id: worker-1
+    pane_id: '%3'
+    role: Worker
+    worker_role: worker
+    worker_backend: codex
+    title: worker-1
+    status: ready
+"@
+        Set-Content -LiteralPath $manifestPath -Value $yaml -Encoding utf8
+        $registryPath = Get-WinsmuxRuntimeRegistryPath -ProjectDir $script:task789FixRoot
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid 4100 `
+            -SupervisorProcessStartedAt '2026-08-17T00:00:00.0000000Z' -ExpectedPaneCount 3 `
+            -Panes @(
+                [PSCustomObject]@{ label = 'operator'; slot_id = 'operator'; pane_id = '%2'; backend = 'local'; role = 'operator'; title = 'Operator'; state = 'live'; bootstrap_pid = 0; bootstrap_process_started_at = ''; marker_path = '' },
+                [PSCustomObject]@{ label = 'reviewer'; slot_id = 'reviewer'; pane_id = '%4'; backend = 'local'; role = 'reviewer'; title = 'Reviewer'; state = 'live'; bootstrap_pid = 0; bootstrap_process_started_at = ''; marker_path = '' },
+                [PSCustomObject]@{ label = 'worker-1'; slot_id = 'worker-1'; pane_id = '%3'; backend = 'codex'; role = 'worker'; title = 'worker-1'; state = 'live'; bootstrap_pid = 0; bootstrap_process_started_at = ''; marker_path = '' }
+            )
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
+        $beforeManifest = [System.IO.File]::ReadAllBytes($manifestPath)
+        $beforeRegistry = [System.IO.File]::ReadAllBytes($registryPath)
+
+        Mock Invoke-MonitorWinsmux { throw 'kill-pane must not run for a non-worker archive' }
+
+        foreach ($label in @('operator', 'reviewer')) {
+            $result = Remove-OrchestraWorkerPane -ManifestPath $manifestPath -Label $label
+            $result.Changed | Should -BeFalse
+            $result.Reason | Should -Be 'archive_role_not_worker'
+
+            $entry = [pscustomobject]@{ Label = $label; Role = $label; PaneId = '%2' }
+            $refusal = Get-WinsmuxArchivePaneRefusal -Entry $entry -Label $label -Manifest (Read-PaneScalerManifest -ManifestPath $manifestPath)
+            $refusal.ReasonCode | Should -Be 'archive_role_not_worker'
+        }
+
+        [System.IO.File]::ReadAllBytes($manifestPath) | Should -Be $beforeManifest
+        [System.IO.File]::ReadAllBytes($registryPath) | Should -Be $beforeRegistry
+        Should -Invoke Invoke-MonitorWinsmux -Times 0
+    }
+
+    It 'refuses to archive the last required worker without mutating the session' {
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        $yaml = @"
+version: 1
+saved_at: 2026-08-17T00:00:00Z
+session:
+  name: winsmux-orchestra
+  project_dir: $script:task789FixRoot
+  generation_id: generation-789
+  server_session_id: '`$9'
+  bootstrap_pane_id: '%1'
+  expected_pane_count: 1
+panes:
+  worker-1:
+    label: worker-1
+    slot_id: worker-1
+    pane_id: '%3'
+    role: Worker
+    worker_role: worker
+    worker_backend: codex
+    title: worker-1
+    status: ready
+"@
+        Set-Content -LiteralPath $manifestPath -Value $yaml -Encoding utf8
+        $registryPath = Get-WinsmuxRuntimeRegistryPath -ProjectDir $script:task789FixRoot
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid 4100 `
+            -SupervisorProcessStartedAt '2026-08-17T00:00:00.0000000Z' -ExpectedPaneCount 1 `
+            -Panes @(
+                [PSCustomObject]@{ label = 'worker-1'; slot_id = 'worker-1'; pane_id = '%3'; backend = 'codex'; role = 'worker'; title = 'worker-1'; state = 'live'; bootstrap_pid = 0; bootstrap_process_started_at = ''; marker_path = '' }
+            )
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
+        $beforeManifest = [System.IO.File]::ReadAllBytes($manifestPath)
+        $beforeRegistry = [System.IO.File]::ReadAllBytes($registryPath)
+
+        Mock Invoke-MonitorWinsmux { throw 'kill-pane must not run for the last required worker' }
+
+        $result = Remove-OrchestraWorkerPane -ManifestPath $manifestPath -Label 'worker-1'
+        $result.Changed | Should -BeFalse
+        $result.Reason | Should -Be 'last_required_worker'
+
+        $entry = [pscustomobject]@{ Label = 'worker-1'; Role = 'Worker'; PaneId = '%3' }
+        $refusal = Get-WinsmuxArchivePaneRefusal -Entry $entry -Label 'worker-1' -Manifest (Read-PaneScalerManifest -ManifestPath $manifestPath)
+        $refusal.ReasonCode | Should -Be 'last_required_worker'
+
+        [System.IO.File]::ReadAllBytes($manifestPath) | Should -Be $beforeManifest
+        [System.IO.File]::ReadAllBytes($registryPath) | Should -Be $beforeRegistry
+        Should -Invoke Invoke-MonitorWinsmux -Times 0
+    }
+
+    It 'fail-closes spawn when Team Profile projection <Case>' -ForEach @(
+        @{ Case = 'mistyped_slot'; ProjectionError = "Team Profile launch projection failed for slot 'worker-99': unknown slot" }
+        @{ Case = 'invalid_profile'; ProjectionError = "Team Profile launch projection failed for slot 'worker-2': invalid profile" }
+        @{ Case = 'bridge_error'; ProjectionError = "Team Profile launch projection failed for slot 'worker-2': winsmux binary was not found." }
+    ) {
+        $script:task789ProjectionError = $ProjectionError
+        Mock Get-OrchestraModeDocument {
+            [pscustomobject]@{ schema_version = 1; mode = 'team'; valid = $true; source = 'file' }
+        }
+        Mock Get-OrchestraLiveWorkerRolePaneCount { 1 }
+        Mock Get-BridgeSettings { $null }
+        Mock Get-WinsmuxManifest { $null }
+        Mock Invoke-TeamProfileLaunchProjection { throw $script:task789ProjectionError }
+        Mock Add-OrchestraPane { throw 'should not spawn an unconfigured worker' }
+
+        $result = Ensure-DispatchTaskLiveWorkerPane -ProjectDir $script:task789FixRoot -Label 'worker-2' -ManifestEntry $null
+        $result.Spawned | Should -BeFalse
+        $result.ReasonCode | Should -Be 'team_profile_projection_unavailable'
+        $result.Diagnostic | Should -Be $ProjectionError
+        Should -Invoke Add-OrchestraPane -Times 0
     }
 }

--- a/tests/bridge/CommandReviewDispatch.Tests.ps1
+++ b/tests/bridge/CommandReviewDispatch.Tests.ps1
@@ -2307,6 +2307,56 @@ panes:
         [System.IO.File]::ReadAllBytes($manifestPath) | Should -Be $before
     }
 
+    It 'TASK-789 spawn ignores concurrent registry lease bytes during projection' {
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        [System.IO.File]::WriteAllText($manifestPath, "version: 1`nsession:`n  name: keep`npanes: {}`n")
+        $supervisor = script:Get-Task789SupervisorIdentity
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid $supervisor.Pid `
+            -SupervisorProcessStartedAt $supervisor.StartedAt -ExpectedPaneCount 1 -LeaseSeconds 300 `
+            -Panes @(script:New-Task789V2RegistryPane -Label 'worker-1' -PaneId '%3' -BootstrapPid 4200)
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
+        $beforePanes = @((Read-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot).panes).Count
+        Mock Get-OrchestraModeDocument {
+            [pscustomobject]@{ schema_version = 1; mode = 'team'; valid = $true; source = 'file' }
+        }
+        Mock Get-OrchestraLiveWorkerRolePaneCount { 1 }
+        Mock Get-OrchestraMaxLiveWorkerPaneCount { 6 }
+        Mock Get-BridgeSettings { $null }
+        Mock Get-WinsmuxManifest { $null }
+        Mock Invoke-TeamProfileLaunchProjection {
+            $current = Read-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot
+            $current.lease.expires_at = '2099-01-01T00:00:00.0000000Z'
+            $current.updated_at = '2099-01-01T00:00:00.0000000Z'
+            Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $current | Out-Null
+            [pscustomobject]@{
+                bundle_path = '.winsmux/runtime/prompt-bundles/sess/worker-2.md'
+                projection  = [pscustomobject]@{
+                    pane = [pscustomobject]@{
+                        assignment = [pscustomobject]@{ provider = 'codex'; worker_backend = 'codex' }
+                    }
+                }
+            }
+        }
+        Mock New-TeamProfileSlotAgentConfig {
+            [pscustomobject]@{ Agent = 'codex'; Model = 'gpt-5.4'; WorkerBackend = 'codex'; PaneTitle = $SlotId }
+        }
+        Mock Add-OrchestraPane {
+            return [pscustomobject]@{ Changed = $true; Label = $SlotId; PaneId = '%5' }
+        }
+        Mock Get-DispatchTaskManifestEntry {
+            script:New-Task789LiveEntry -Label 'worker-2' -PaneId '%5'
+        }
+
+        $result = Ensure-DispatchTaskLiveWorkerPane -ProjectDir $script:task789FixRoot -Label 'worker-2' -ManifestEntry $null
+        $result.Spawned | Should -BeTrue
+        Should -Invoke Add-OrchestraPane -Times 1
+        $after = Read-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot
+        $after.lease.expires_at | Should -Be '2099-01-01T00:00:00.0000000Z'
+        @($after.panes).Count | Should -Be $beforePanes
+        $after.panes[0].slot_id | Should -Be 'worker-1'
+    }
+
     It 'does not publish a new registry when the guarded manifest save fails' {
         $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
         $registryPath = Get-WinsmuxRuntimeRegistryPath -ProjectDir $script:task789FixRoot

--- a/tests/bridge/CommandReviewDispatch.Tests.ps1
+++ b/tests/bridge/CommandReviewDispatch.Tests.ps1
@@ -1884,6 +1884,8 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
         $body | Should -Match 'C-c'
         $body | Should -Match 'pane\.idle'
         $body | Should -Match 'Get-PaneAgentStatus'
+        $body | Should -Match 'Get-WinsmuxArchivePaneReadinessAgent'
+        $body | Should -Match 'Get-PaneAgentStatus -PaneId \$paneId -Role ''Worker'' -Agent \$readinessAgent'
         $body.IndexOf('Get-WinsmuxArchivePaneRuntimeRefusal') | Should -BeLessThan $body.IndexOf('C-c')
         $script:task789DispatchContent | Should -Match "Operation stop_transition"
         $body | Should -Not -Match 'Invoke-WorkersStop'
@@ -3216,9 +3218,14 @@ Write-Output 'reached-after-exit'
         }
         $spawnBody = $script:task789PaneScalerContent.Substring($scalerIndex, $next - $scalerIndex)
         $spawnBody | Should -Match 'Get-PaneScalerReadinessAgent'
+        $spawnBody | Should -Match 'New-PaneScalerWorkerLaunchApproval'
         $spawnBody | Should -Match 'Wait-OrchestraSpawnAgentReady -PaneId \$newPaneId -Agent \$readinessAgent'
         $spawnBody | Should -Not -Match 'Wait-OrchestraSpawnAgentReady -PaneId \$newPaneId -Agent \$agent'
+        $spawnBody | Should -Match "newPane\['approved_launch'\]"
+        $spawnBody | Should -Match "newPane\['capability_adapter'\]"
         $script:task789PaneScalerContent | Should -Match 'function Get-PaneScalerReadinessAgent'
+        $script:task789PaneScalerContent | Should -Match 'function New-PaneScalerWorkerLaunchApproval'
+        $script:task789DispatchContent | Should -Match 'function Get-WinsmuxArchivePaneReadinessAgent'
 
         Get-PaneScalerReadinessAgent -SlotAgentConfig ([pscustomobject]@{
             Agent = 'openrouter'; CapabilityAdapter = 'openai-compatible'
@@ -3300,6 +3307,18 @@ panes:
         })
         $saved = Read-PaneScalerManifest -ManifestPath $manifestPath
         $saved.Panes['worker-2'].status | Should -Be 'ready'
+        [string]$saved.Panes['worker-2'].capability_adapter | Should -Be 'openai-compatible'
+        $rawApproved = $saved.Panes['worker-2'].approved_launch
+        $approved = $rawApproved
+        if ($approved -is [string]) {
+            if (Get-Command ConvertFrom-PaneControlSecurityPolicy -ErrorAction SilentlyContinue) {
+                $approved = ConvertFrom-PaneControlSecurityPolicy -Value $approved
+            } else {
+                $approved = ($approved | ConvertFrom-Json)
+            }
+        }
+        [string](Get-WinsmuxRuntimeValue -InputObject $approved -Name 'agent' -Default '') | Should -Be 'openrouter'
+        [string](Get-WinsmuxRuntimeValue -InputObject $approved -Name 'packet_type' -Default '') | Should -Be 'worker_launch_approval'
         Should -Invoke Get-PaneAgentStatus -Times 1 -Exactly -ParameterFilter {
             $PaneId -eq '%5' -and $Agent -eq 'openai-compatible' -and $Role -eq 'Worker'
         }
@@ -3520,6 +3539,83 @@ Write-Output 'reached-after-exit'
         ($output | Out-String) | Should -Not -Match 'reached-after-exit'
         Test-Path -LiteralPath $sentPath | Should -BeTrue
         Test-Path -LiteralPath $killedPath | Should -BeFalse
+    }
+
+    It 'passes the capability adapter to Get-PaneAgentStatus after archive interrupt' {
+        Get-WinsmuxArchivePaneReadinessAgent -Entry ([pscustomobject]@{
+            CapabilityAdapter = 'openai-compatible'
+            ApprovedLaunch    = [pscustomobject]@{ agent = 'openrouter' }
+        }) | Should -Be 'openai-compatible'
+        Get-WinsmuxArchivePaneReadinessAgent -Entry ([pscustomobject]@{
+            CapabilityAdapter = ''
+            ApprovedLaunch    = [pscustomobject]@{ agent = 'openrouter' }
+        }) | Should -Be 'openrouter'
+
+        $probePath = Join-Path $script:task789FixRoot 'archive-adapter-probe.ps1'
+        $dispatchPath = $script:task789DispatchPath
+        $sentPath = Join-Path $script:task789FixRoot 'cc-sent.txt'
+        $killedPath = Join-Path $script:task789FixRoot 'killed.txt'
+        $agentPath = Join-Path $script:task789FixRoot 'agent-seen.txt'
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        script:Write-Task789V2Manifest -Path $manifestPath -ProjectDir $script:task789FixRoot -Panes @(
+            script:New-Task789V2Pane -Label 'worker-1' -PaneId '%3' -Status 'ready'
+            script:New-Task789V2Pane -Label 'worker-2' -PaneId '%9' -Status 'busy'
+        )
+        $probe = @"
+`$ErrorActionPreference = 'Stop'
+function Stop-WithError { param([string]`$Message) throw `$Message }
+function Get-Labels { return @{ 'worker-2' = '%9' } }
+. '$($dispatchPath.Replace("'", "''"))'
+function Test-PaneControlRuntimeContext {
+    param(`$ProjectDir, `$ManifestEntry, `$Operation)
+    return [pscustomobject]@{ valid = `$true; reason_code = 'stop_transition_verified'; diagnostic = 'ok'; context = [pscustomobject]@{ generation_id = 'generation-789' } }
+}
+function Get-PaneControlManifestEntries {
+    param(`$ProjectDir)
+    return @(
+        [pscustomobject]@{
+            Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%3'; Role = 'Worker'
+            WorkerRole = 'worker'; WorkerBackend = 'openrouter'; Title = 'worker-1'
+            Status = 'ready'; LastEvent = 'pane.idle'; CapabilityAdapter = 'openai-compatible'
+        },
+        [pscustomobject]@{
+            Label = 'worker-2'; SlotId = 'worker-2'; PaneId = '%9'; Role = 'Worker'
+            WorkerRole = 'worker'; WorkerBackend = 'openrouter'; Title = 'worker-2'
+            Status = 'busy'; LastEvent = 'pane.progress'; CapabilityAdapter = 'openai-compatible'
+        }
+    )
+}
+function Get-PaneAgentStatus {
+    param(`$PaneId, `$Agent, `$Role)
+    Set-Content -LiteralPath '$($agentPath.Replace("'", "''"))' -Value ([string]`$Agent) -Encoding utf8
+    return [pscustomobject]@{ Status = 'ready'; PaneId = `$PaneId; SnapshotTail = ''; ExitReason = '' }
+}
+function Invoke-WinsmuxRaw {
+    param(`$Arguments)
+    if (@(`$Arguments) -contains 'C-c') { Set-Content -LiteralPath '$($sentPath.Replace("'", "''"))' -Value 'sent' -Encoding utf8 }
+}
+function Invoke-MonitorWinsmux {
+    param(`$Arguments)
+    if (@(`$Arguments) -contains 'C-c') { Set-Content -LiteralPath '$($sentPath.Replace("'", "''"))' -Value 'sent' -Encoding utf8 }
+    if (@(`$Arguments) -contains 'kill-pane') { Set-Content -LiteralPath '$($killedPath.Replace("'", "''"))' -Value 'killed' -Encoding utf8 }
+}
+function Remove-OrchestraPane {
+    param(`$ManifestPath, `$Role, `$Label)
+    Set-Content -LiteralPath '$($killedPath.Replace("'", "''"))' -Value 'removed' -Encoding utf8
+    return [pscustomobject]@{ Changed = `$true; Reason = '' }
+}
+function Test-OrchestraArchiveRemovesLastRequiredWorker { param(`$Manifest, `$Label) return `$false }
+Set-Location -LiteralPath '$($script:task789FixRoot.Replace("'", "''"))'
+Invoke-WinsmuxArchivePaneCommand -BridgeScriptRoot '$($script:task789FixRoot.Replace("'", "''"))' -CommandTarget 'worker-2' -CommandRest @()
+Write-Output 'reached-after-exit'
+"@
+        Set-Content -LiteralPath $probePath -Value $probe -Encoding utf8
+        $output = & pwsh -NoProfile -File $probePath 2>&1
+        $LASTEXITCODE | Should -Be 0
+        ($output | Out-String) | Should -Match 'reached-after-exit'
+        Test-Path -LiteralPath $sentPath | Should -BeTrue
+        Test-Path -LiteralPath $killedPath | Should -BeTrue
+        Get-Content -LiteralPath $agentPath -Raw | Should -Match 'openai-compatible'
     }
 
     It 'keeps a single control-plane flag as a one-element argument list' {

--- a/tests/bridge/CommandReviewDispatch.Tests.ps1
+++ b/tests/bridge/CommandReviewDispatch.Tests.ps1
@@ -1641,6 +1641,8 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
         $script:task789WinsmuxCoreContent = Get-Content -LiteralPath $script:task789WinsmuxCorePath -Raw -Encoding UTF8
         $script:task789PaneScalerPath = Join-Path $repoRoot 'winsmux-core\scripts\pane-scaler.ps1'
         $script:task789PaneScalerContent = Get-Content -LiteralPath $script:task789PaneScalerPath -Raw -Encoding UTF8
+        $script:task789ManifestPath = Join-Path $repoRoot 'winsmux-core\scripts\manifest.ps1'
+        . $script:task789ManifestPath
         . $script:task789DispatchPath
     }
 
@@ -1687,22 +1689,10 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
     }
 
     It 'fail-closes simple mode instead of spawning a second live worker pane' {
-        Get-Command Ensure-DispatchTaskLiveWorkerPane -ErrorAction Stop | Should -Not -BeNullOrEmpty
-        function Get-OrchestraModeDocument {
-            param([string]$ProjectDir)
+        Mock Get-OrchestraModeDocument {
             [pscustomobject]@{ schema_version = 1; mode = 'simple'; valid = $true; source = 'file' }
         }
-        function Get-OrchestraLiveWorkerRolePaneCount {
-            param($Manifest)
-            1
-        }
-        function Add-OrchestraPane {
-            throw 'simple mode must not spawn a second live worker pane'
-        }
-        function New-TeamProfileSlotAgentConfig {
-            throw 'simple mode must not spawn a second live worker pane'
-        }
-
+        Mock Get-OrchestraLiveWorkerRolePaneCount { 1 }
         $result = Ensure-DispatchTaskLiveWorkerPane -ProjectDir (Join-Path ([System.IO.Path]::GetTempPath()) 'winsmux-task789-missing') -Label 'worker-2' -ManifestEntry $null
         $result.Spawned | Should -BeFalse
         $result.ReasonCode | Should -Be 'simple_mode_live_worker_limit'

--- a/tests/bridge/CommandReviewDispatch.Tests.ps1
+++ b/tests/bridge/CommandReviewDispatch.Tests.ps1
@@ -1672,6 +1672,12 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
                 throw 'Start-OrchestraPaneBootstrap not mocked'
             }
         }
+        if (-not (Get-Command Get-BridgeEventRecords -ErrorAction SilentlyContinue)) {
+            function script:Get-BridgeEventRecords {
+                param([string]$ProjectDir)
+                return @()
+            }
+        }
 
         function script:Get-Task789SupervisorIdentity {
             $started = Get-WinsmuxRuntimeProcessStartedAt -ProcessId $PID
@@ -1794,6 +1800,8 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
         New-Item -ItemType Directory -Path (Join-Path $script:task789FixRoot '.winsmux') -Force | Out-Null
         $script:task789Observed = @()
         $script:task789Killed = @()
+        $script:task789AgentReadyProbes = 0
+        $script:task789WorktreeRemoved = $false
     }
 
     AfterEach {
@@ -2348,6 +2356,10 @@ panes:
         Mock Invoke-MonitorWinsmux {
             param($Arguments)
             if (@($Arguments) -contains 'split-window') { return '%5' }
+            if (@($Arguments) -contains 'capture-pane') {
+                $script:task789AgentReadyProbes++
+                return '>'
+            }
         }
         Mock Wait-MonitorPaneShellReady { }
         Mock Get-PaneScalerLaunchCommand { 'echo spawn-worker-2' }
@@ -2365,6 +2377,7 @@ panes:
         $saved.Panes['worker-2'].status | Should -Be 'ready'
         [bool]$saved.Panes['worker-2'].runtime_ready | Should -BeTrue
         [string]$saved.Panes['worker-2'].bootstrap_marker_path | Should -Be $markerPath
+        $script:task789AgentReadyProbes | Should -BeGreaterThan 0
 
         $marker = Get-Content -LiteralPath $markerPath -Raw -Encoding UTF8 | ConvertFrom-Json
         $processResolver = {
@@ -2499,6 +2512,7 @@ Write-Output 'reached-after-exit'
     }
 
     It 'treats unrecognized or empty archive status without an idle event as unavailable' {
+        Mock Get-BridgeEventRecords { @() }
         $empty = Test-WinsmuxArchivePaneIdle -Entry ([pscustomobject]@{
             Label = 'worker-2'; PaneId = '%5'; Status = ''; LastEvent = ''
         }) -ProjectDir $script:task789FixRoot
@@ -2516,6 +2530,68 @@ Write-Output 'reached-after-exit'
         }) -ProjectDir $script:task789FixRoot
         $ready.Idle | Should -BeTrue
         $ready.Evidence | Should -Be 'idle'
+    }
+
+    It 'lets a later matching pane.progress event override stale archive status=ready' {
+        $idleIndex = $script:task789DispatchContent.IndexOf('function Test-WinsmuxArchivePaneIdle')
+        $idleIndex | Should -BeGreaterThan -1
+        $next = $script:task789DispatchContent.IndexOf("`nfunction ", $idleIndex + 1)
+        if ($next -lt 0) {
+            $next = $script:task789DispatchContent.Length
+        }
+        $body = $script:task789DispatchContent.Substring($idleIndex, $next - $idleIndex)
+        $body.IndexOf('Get-BridgeEventRecords') | Should -BeGreaterThan -1
+        $body.IndexOf('Get-BridgeEventRecords') | Should -BeLessThan $body.IndexOf("'ready', 'waiting_for_dispatch'")
+
+        Mock Get-BridgeEventRecords {
+            @(
+                [ordered]@{ event = 'pane.idle'; label = 'worker-2'; pane_id = '%5' }
+                [ordered]@{ event = 'pane.progress'; label = 'worker-2'; pane_id = '%5' }
+            )
+        }
+        $busy = Test-WinsmuxArchivePaneIdle -Entry ([pscustomobject]@{
+            Label = 'worker-2'; PaneId = '%5'; Status = 'ready'; LastEvent = ''
+        }) -ProjectDir $script:task789FixRoot
+        $busy.Idle | Should -BeFalse
+        $busy.Evidence | Should -Be 'busy'
+        $busy.LastEvent | Should -Be 'pane.progress'
+    }
+
+    It 'keeps archive idle when status=ready and the newest matching event or lastEvent is idle' {
+        Mock Get-BridgeEventRecords {
+            @(
+                [ordered]@{ event = 'pane.progress'; label = 'worker-2'; pane_id = '%5' }
+                [ordered]@{ event = 'pane.idle'; label = 'worker-2'; pane_id = '%5' }
+            )
+        }
+        $newestIdle = Test-WinsmuxArchivePaneIdle -Entry ([pscustomobject]@{
+            Label = 'worker-2'; PaneId = '%5'; Status = 'ready'; LastEvent = ''
+        }) -ProjectDir $script:task789FixRoot
+        $newestIdle.Idle | Should -BeTrue
+        $newestIdle.Evidence | Should -Be 'idle'
+        $newestIdle.LastEvent | Should -Be 'pane.idle'
+
+        Mock Get-BridgeEventRecords { @() }
+        $lastEventIdle = Test-WinsmuxArchivePaneIdle -Entry ([pscustomobject]@{
+            Label = 'worker-2'; PaneId = '%5'; Status = 'ready'; LastEvent = 'pane.idle'
+        }) -ProjectDir $script:task789FixRoot
+        $lastEventIdle.Idle | Should -BeTrue
+        $lastEventIdle.Evidence | Should -Be 'idle'
+        $lastEventIdle.LastEvent | Should -Be 'pane.idle'
+    }
+
+    It 'keeps lastEvent busy ahead of a later idle event' {
+        Mock Get-BridgeEventRecords {
+            @(
+                [ordered]@{ event = 'pane.idle'; label = 'worker-2'; pane_id = '%5' }
+            )
+        }
+        $busy = Test-WinsmuxArchivePaneIdle -Entry ([pscustomobject]@{
+            Label = 'worker-2'; PaneId = '%5'; Status = 'ready'; LastEvent = 'pane.progress'
+        }) -ProjectDir $script:task789FixRoot
+        $busy.Idle | Should -BeFalse
+        $busy.Evidence | Should -Be 'busy'
+        $busy.LastEvent | Should -Be 'pane.progress'
     }
 
     It 'commits a v2 spawn after split when the guarded save sees the new observed pane' {
@@ -2774,6 +2850,10 @@ Write-Output 'reached-after-exit'
                 return '%5'
             }
             if ($argsList -contains 'select-pane') { return }
+            if ($argsList -contains 'capture-pane') {
+                $script:task789AgentReadyProbes++
+                return '>'
+            }
         }
         Mock Wait-MonitorPaneShellReady { }
         Mock Get-PaneScalerLaunchCommand { 'echo spawn-worker-2' }
@@ -2788,6 +2868,7 @@ Write-Output 'reached-after-exit'
         $saved = Read-PaneScalerManifest -ManifestPath $manifestPath
         $saved.Panes['worker-2'].status | Should -Be 'ready'
         [bool]$saved.Panes['worker-2'].runtime_ready | Should -BeTrue
+        $script:task789AgentReadyProbes | Should -BeGreaterThan 0
 
         $marker = Get-Content -LiteralPath $markerPath -Raw -Encoding UTF8 | ConvertFrom-Json
         $read = Read-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot
@@ -2812,6 +2893,101 @@ Write-Output 'reached-after-exit'
             } -Operation dispatch -Now ([datetime]::UtcNow.AddMinutes(1))
         $dispatchCheck.valid | Should -BeTrue -Because ("dispatch diagnostic: {0} {1}" -f $dispatchCheck.reason_code, $dispatchCheck.diagnostic)
         $dispatchCheck.reason_code | Should -Be 'live_runtime_verified'
+    }
+
+    It 'does not publish v2 status=ready when a marker PID exists but agent-readiness times out' {
+        $scalerIndex = $script:task789PaneScalerContent.IndexOf('function Add-OrchestraWorkerPane')
+        $scalerIndex | Should -BeGreaterThan -1
+        $next = $script:task789PaneScalerContent.IndexOf("`nfunction ", $scalerIndex + 1)
+        if ($next -lt 0) {
+            $next = $script:task789PaneScalerContent.Length
+        }
+        $spawnBody = $script:task789PaneScalerContent.Substring($scalerIndex, $next - $scalerIndex)
+        $spawnBody | Should -Match 'Wait-OrchestraSpawnAgentReady'
+        $script:task789PaneScalerContent | Should -Match 'function Wait-OrchestraSpawnAgentReady'
+        $script:task789PaneScalerContent | Should -Match 'Get-PaneAgentStatus -PaneId \$PaneId -Agent \$Agent -Role ''Worker'''
+
+        $markerDir = Join-Path $script:task789FixRoot '.winsmux\orchestra-bootstrap'
+        New-Item -ItemType Directory -Path $markerDir -Force | Out-Null
+        $markerPath = Join-Path $markerDir '5-generation-789.ready.json'
+        @{
+            state = 'bootstrap_pending'
+            generation_id = 'generation-789'
+            server_session_id = '$9'
+            slot_id = 'worker-2'
+            pane_id = '%5'
+            backend = 'codex'
+            role = 'worker'
+            title = 'worker-2'
+            bootstrap_pid = 4300
+            bootstrap_process_started_at = '2026-08-17T00:00:02.0000000Z'
+        } | ConvertTo-Json | Set-Content -LiteralPath $markerPath -Encoding utf8
+
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        $registryPath = Get-WinsmuxRuntimeRegistryPath -ProjectDir $script:task789FixRoot
+        $supervisor = script:Get-Task789SupervisorIdentity
+        script:Write-Task789V2Manifest -Path $manifestPath -ProjectDir $script:task789FixRoot -Panes @(
+            script:New-Task789V2Pane -Label 'worker-1' -PaneId '%3'
+        )
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid $supervisor.Pid `
+            -SupervisorProcessStartedAt $supervisor.StartedAt -ExpectedPaneCount 1 -LeaseSeconds 300 `
+            -Panes @(script:New-Task789V2RegistryPane -Label 'worker-1' -PaneId '%3' -BootstrapPid 4200)
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
+        $beforeRegistry = [System.IO.File]::ReadAllBytes($registryPath)
+        $beforeManifest = [System.IO.File]::ReadAllBytes($manifestPath)
+        $script:task789Observed = @(
+            script:New-Task789ObservedPane -PaneId '%1' -Title 'bootstrap'
+            script:New-Task789ObservedPane -PaneId '%3' -Title 'worker-1'
+        )
+        $script:task789Killed = @()
+        script:Mock-Task789LiveServer
+        $worktreePath = Join-Path $script:task789FixRoot '.worktrees\worker-2'
+        New-Item -ItemType Directory -Path $worktreePath -Force | Out-Null
+        Mock New-PaneScalerWorkerWorktree {
+            [pscustomobject]@{ WorktreePath = $worktreePath; BranchName = 'worktree-worker-2'; GitWorktreeDir = $worktreePath }
+        }
+        Mock Remove-PaneScalerBuilderWorktree { $script:task789WorktreeRemoved = $true }
+        Mock Invoke-MonitorWinsmux {
+            param($Arguments)
+            $argsList = @($Arguments)
+            if ($argsList -contains 'split-window') {
+                $script:task789Observed = @($script:task789Observed) + @(
+                    script:New-Task789ObservedPane -PaneId '%5' -Title 'worker-2'
+                )
+                return '%5'
+            }
+            if ($argsList -contains 'select-pane') { return }
+            if ($argsList -contains 'capture-pane') {
+                $script:task789AgentReadyProbes++
+                return 'executing task...'
+            }
+            if ($argsList -contains 'kill-pane') {
+                $target = $argsList[$argsList.IndexOf('-t') + 1]
+                $script:task789Killed += $target
+                $script:task789Observed = @($script:task789Observed | Where-Object { $_.PaneId -ne $target })
+                return
+            }
+        }
+        Mock Wait-MonitorPaneShellReady { }
+        Mock Get-PaneScalerLaunchCommand { 'echo spawn-worker-2' }
+        Mock New-OrchestraPaneBootstrapPlan { Join-Path $markerDir '5.json' }
+        Mock Get-OrchestraPaneBootstrapMarkerPath { $markerPath }
+        Mock Start-OrchestraPaneBootstrap { }
+        Mock Get-BridgeSettings { [ordered]@{ agent = 'codex'; model = 'gpt-5.4' } }
+
+        { Add-OrchestraWorkerPane -ManifestPath $manifestPath -SlotId 'worker-2' -SlotAgentConfig ([pscustomobject]@{
+            Agent = 'codex'; Model = 'gpt-5.4'; WorkerBackend = 'codex'; PaneTitle = 'worker-2'
+        }) -AgentReadyTimeoutSeconds 0 } | Should -Throw '*timed out waiting for agent ready*'
+
+        $script:task789AgentReadyProbes | Should -BeGreaterThan 0
+        [System.IO.File]::ReadAllBytes($manifestPath) | Should -Be $beforeManifest
+        [System.IO.File]::ReadAllBytes($registryPath) | Should -Be $beforeRegistry
+        $script:task789Killed | Should -Contain '%5'
+        $script:task789WorktreeRemoved | Should -BeTrue
+        ($script:task789Observed | ForEach-Object { $_.PaneId }) | Should -Not -Contain '%5'
+        $saved = Read-PaneScalerManifest -ManifestPath $manifestPath
+        $saved.Panes.Contains('worker-2') | Should -BeFalse
     }
 
     It 'restores v2 archive files when kill-pane fails and the pane is still listed' {
@@ -2957,6 +3133,74 @@ Write-Output 'reached-after-exit'
         ($output | Out-String) | Should -Match 'idle evidence is unavailable'
         ($output | Out-String) | Should -Not -Match 'reached-after-exit'
         Test-Path -LiteralPath $sentPath | Should -BeFalse
+        Test-Path -LiteralPath $killedPath | Should -BeFalse
+    }
+
+    It 'interrupts instead of skip-killing when archive-pane sees status=ready and a later pane.progress event' {
+        $probePath = Join-Path $script:task789FixRoot 'archive-ready-progress-probe.ps1'
+        $dispatchPath = $script:task789DispatchPath
+        $sentPath = Join-Path $script:task789FixRoot 'cc-sent.txt'
+        $killedPath = Join-Path $script:task789FixRoot 'killed.txt'
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        script:Write-Task789V2Manifest -Path $manifestPath -ProjectDir $script:task789FixRoot -Panes @(
+            script:New-Task789V2Pane -Label 'worker-1' -PaneId '%3' -Status 'ready'
+            script:New-Task789V2Pane -Label 'worker-2' -PaneId '%9' -Status 'ready'
+        )
+        $probe = @"
+`$ErrorActionPreference = 'Stop'
+function Stop-WithError { param([string]`$Message) throw `$Message }
+function Get-Labels { return @{ 'worker-2' = '%9' } }
+. '$($dispatchPath.Replace("'", "''"))'
+function Test-PaneControlRuntimeContext {
+    param(`$ProjectDir, `$ManifestEntry, `$Operation)
+    return [pscustomobject]@{ valid = `$true; reason_code = 'stop_transition_verified'; diagnostic = 'ok'; context = [pscustomobject]@{ generation_id = 'generation-789' } }
+}
+function Get-PaneControlManifestEntries {
+    param(`$ProjectDir)
+    return @(
+        [pscustomobject]@{
+            Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%3'; Role = 'Worker'
+            WorkerRole = 'worker'; WorkerBackend = 'codex'; Title = 'worker-1'
+            Status = 'ready'; LastEvent = 'pane.idle'
+        },
+        [pscustomobject]@{
+            Label = 'worker-2'; SlotId = 'worker-2'; PaneId = '%9'; Role = 'Worker'
+            WorkerRole = 'worker'; WorkerBackend = 'codex'; Title = 'worker-2'
+            Status = 'ready'; LastEvent = ''
+        }
+    )
+}
+function Get-BridgeEventRecords {
+    param(`$ProjectDir)
+    return @(
+        [ordered]@{ event = 'pane.idle'; label = 'worker-2'; pane_id = '%9' }
+        [ordered]@{ event = 'pane.progress'; label = 'worker-2'; pane_id = '%9' }
+    )
+}
+function Invoke-WinsmuxRaw {
+    param(`$Arguments)
+    if (@(`$Arguments) -contains 'C-c') { Set-Content -LiteralPath '$($sentPath.Replace("'", "''"))' -Value 'sent' -Encoding utf8 }
+}
+function Invoke-MonitorWinsmux {
+    param(`$Arguments)
+    if (@(`$Arguments) -contains 'C-c') { Set-Content -LiteralPath '$($sentPath.Replace("'", "''"))' -Value 'sent' -Encoding utf8 }
+    if (@(`$Arguments) -contains 'kill-pane') { Set-Content -LiteralPath '$($killedPath.Replace("'", "''"))' -Value 'killed' -Encoding utf8 }
+}
+function Remove-OrchestraPane {
+    param(`$ManifestPath, `$Role, `$Label)
+    Set-Content -LiteralPath '$($killedPath.Replace("'", "''"))' -Value 'removed' -Encoding utf8
+    return [pscustomobject]@{ Changed = `$true; Reason = '' }
+}
+Set-Location -LiteralPath '$($script:task789FixRoot.Replace("'", "''"))'
+Invoke-WinsmuxArchivePaneCommand -BridgeScriptRoot '$($script:task789FixRoot.Replace("'", "''"))' -CommandTarget 'worker-2' -CommandRest @()
+Write-Output 'reached-after-exit'
+"@
+        Set-Content -LiteralPath $probePath -Value $probe -Encoding utf8
+        $output = & pwsh -NoProfile -File $probePath 2>&1
+        $LASTEXITCODE | Should -Be 1
+        ($output | Out-String) | Should -Match 'interrupt did not make'
+        ($output | Out-String) | Should -Not -Match 'reached-after-exit'
+        Test-Path -LiteralPath $sentPath | Should -BeTrue
         Test-Path -LiteralPath $killedPath | Should -BeFalse
     }
 }

--- a/tests/bridge/CommandReviewDispatch.Tests.ps1
+++ b/tests/bridge/CommandReviewDispatch.Tests.ps1
@@ -1912,7 +1912,35 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
         $body | Should -Match 'team_profile_projection_mutated_live_manifest'
         $script:task789DispatchContent | Should -Match 'Ensure-DispatchTaskLiveWorkerPane'
         $script:task789DispatchContent | Should -Match 'function Get-DispatchTaskCatalogSlotIds'
+        $script:task789DispatchContent | Should -Match 'function Get-DispatchTaskResolvedTeamSlots'
         $script:task789DispatchContent | Should -Match 'function Get-DispatchTaskMissingCatalogSlotIds'
+        $catalogIndex = $script:task789DispatchContent.IndexOf('function Get-DispatchTaskCatalogSlotIds')
+        $catalogIndex | Should -BeGreaterThan -1
+        $catalogNext = $script:task789DispatchContent.IndexOf("`nfunction ", $catalogIndex + 1)
+        if ($catalogNext -lt 0) {
+            $catalogNext = $script:task789DispatchContent.Length
+        }
+        $catalogBody = $script:task789DispatchContent.Substring($catalogIndex, $catalogNext - $catalogIndex)
+        $catalogBody | Should -Match 'Get-DispatchTaskResolvedTeamSlots'
+        $catalogBody | Should -Not -Match 'Get-BridgeSettings'
+        $resolveIndex = $script:task789DispatchContent.IndexOf('function Get-DispatchTaskResolvedTeamPayload')
+        $resolveIndex | Should -BeGreaterThan -1
+        $resolveNext = $script:task789DispatchContent.IndexOf("`nfunction ", $resolveIndex + 1)
+        if ($resolveNext -lt 0) {
+            $resolveNext = $script:task789DispatchContent.Length
+        }
+        $resolveBody = $script:task789DispatchContent.Substring($resolveIndex, $resolveNext - $resolveIndex)
+        $resolveBody | Should -Match "--action', 'resolve'"
+        $script:task789PaneScalerContent | Should -Match 'Add-TeamProfileBundleToLaunchCommand'
+        $scalerIndex = $script:task789PaneScalerContent.IndexOf('function Add-OrchestraWorkerPane')
+        $scalerIndex | Should -BeGreaterThan -1
+        $scalerNext = $script:task789PaneScalerContent.IndexOf("`nfunction ", $scalerIndex + 1)
+        if ($scalerNext -lt 0) {
+            $scalerNext = $script:task789PaneScalerContent.Length
+        }
+        $scalerBody = $script:task789PaneScalerContent.Substring($scalerIndex, $scalerNext - $scalerIndex)
+        $scalerBody.IndexOf('New-PaneScalerWorkerWorktree') | Should -BeLessThan $scalerBody.IndexOf('Invoke-TeamProfileLaunchProjection')
+        $scalerBody | Should -Match '-Worktree \$worktree.WorktreePath'
         $script:task789DispatchContent | Should -Match 'Get-DispatchTaskAvailableTargets'
         $invokeIndex = $script:task789DispatchContent.IndexOf('function Invoke-WinsmuxDispatchTaskCommand')
         $invokeIndex | Should -BeGreaterThan -1
@@ -3953,6 +3981,102 @@ Write-Output 'reached-after-exit'
         $saved = Read-PaneScalerManifest -ManifestPath $manifestPath
         $saved.version | Should -Be 2
         $saved.Session.expected_pane_count | Should -Be 2
+    }
+
+    It 'TASK-789 empty agent_slots still exposes the resolved six-slot catalog' {
+        Mock Get-BridgeSettings {
+            [ordered]@{ agent_slots = @() }
+        }
+        Mock Get-DispatchTaskResolvedTeamSlots {
+            @('worker-1', 'worker-2', 'worker-3', 'worker-4', 'worker-5', 'worker-6')
+        }
+        $ids = @(Get-DispatchTaskCatalogSlotIds -ProjectDir $script:task789FixRoot)
+        $ids.Count | Should -Be 6
+        $ids[0] | Should -Be 'worker-1'
+        $ids[5] | Should -Be 'worker-6'
+    }
+
+    It 'TASK-789 regenerates Team Profile projection after the spawned worktree exists' {
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        $supervisor = script:Get-Task789SupervisorIdentity
+        script:Write-Task789V2Manifest -Path $manifestPath -ProjectDir $script:task789FixRoot -Panes @(
+            script:New-Task789V2Pane -Label 'worker-1' -PaneId '%3'
+        )
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid $supervisor.Pid `
+            -SupervisorProcessStartedAt $supervisor.StartedAt -ExpectedPaneCount 1 -LeaseSeconds 300 `
+            -Panes @(script:New-Task789V2RegistryPane -Label 'worker-1' -PaneId '%3' -BootstrapPid 4200)
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
+        $script:task789Observed = @(
+            script:New-Task789ObservedPane -PaneId '%1' -Title 'bootstrap'
+            script:New-Task789ObservedPane -PaneId '%3' -Title 'worker-1'
+        )
+        $script:task789BundleCalls = @()
+        $script:task789ProjectionWorktrees = @()
+        script:Mock-Task789LiveServer
+        $worktreePath = Join-Path $script:task789FixRoot '.worktrees\worker-2'
+        New-Item -ItemType Directory -Path $worktreePath -Force | Out-Null
+        Mock New-PaneScalerWorkerWorktree {
+            [pscustomobject]@{ WorktreePath = $worktreePath; BranchName = 'worktree-worker-2'; GitWorktreeDir = $worktreePath }
+        }
+        Mock Invoke-TeamProfileLaunchProjection {
+            param($ProjectDir, $SessionId, $SlotId, $Worktree, $ReadWriteScope, [switch]$Force)
+            $script:task789ProjectionWorktrees += [string]$Worktree
+            return [pscustomobject]@{
+                bundle_path = '.winsmux/team-profile/worker-2.md'
+                worktree    = [string]$Worktree
+                projection  = [pscustomobject]@{
+                    pane = [pscustomobject]@{
+                        prompt_bundle = [pscustomobject]@{ path = '.winsmux/team-profile/worker-2.md' }
+                    }
+                }
+            }
+        }
+        Mock Invoke-MonitorWinsmux {
+            param($Arguments)
+            $argsList = @($Arguments)
+            if ($argsList -contains 'split-window') {
+                $script:task789Observed = @($script:task789Observed) + @(
+                    script:New-Task789ObservedPane -PaneId '%5' -Title 'worker-2'
+                )
+                return '%5'
+            }
+            if ($argsList -contains 'select-pane') { return }
+        }
+        Mock Wait-MonitorPaneShellReady { }
+        Mock Get-PaneScalerLaunchCommand { 'echo spawn-worker-2' }
+        Mock Add-TeamProfileBundleToLaunchCommand {
+            param($LaunchCommand, $Projection, $ProjectDir)
+            $script:task789BundleCalls += [pscustomobject]@{
+                LaunchCommand = [string]$LaunchCommand
+                BundlePath    = [string]$Projection.bundle_path
+                Worktree      = [string]$Projection.worktree
+            }
+            return ($LaunchCommand + ' TEAM-PROFILE-BUNDLE')
+        }
+        Mock New-OrchestraPaneBootstrapPlan {
+            param($LaunchCommand)
+            $script:task789CapturedLaunch = [string]$LaunchCommand
+            $planDir = Join-Path $script:task789FixRoot '.winsmux\orchestra-bootstrap'
+            New-Item -ItemType Directory -Path $planDir -Force | Out-Null
+            $planPath = Join-Path $planDir '5.json'
+            Set-Content -LiteralPath $planPath -Value '{}' -Encoding utf8
+            return $planPath
+        }
+        Mock Get-OrchestraPaneBootstrapMarkerPath {
+            Join-Path $script:task789FixRoot '.winsmux\orchestra-bootstrap\5-generation-789.ready.json'
+        }
+        Mock Start-OrchestraPaneBootstrap { }
+        Mock Get-BridgeSettings { [ordered]@{ agent = 'codex'; model = 'gpt-5.4' } }
+
+        $stale = [pscustomobject]@{ bundle_path = 'stale'; worktree = '' }
+        $result = Add-OrchestraWorkerPane -ManifestPath $manifestPath -SlotId 'worker-2' -SlotAgentConfig ([pscustomobject]@{
+            Agent = 'codex'; Model = 'gpt-5.4'; WorkerBackend = 'codex'; PaneTitle = 'worker-2'
+        }) -Projection $stale
+        $result.Changed | Should -BeTrue
+        $script:task789ProjectionWorktrees.Count | Should -Be 1
+        $script:task789ProjectionWorktrees[0] | Should -Be $worktreePath
+        $script:task789BundleCalls[0].Worktree | Should -Be $worktreePath
     }
 
     It 'E09 Get-DispatchTaskAvailableTargets still excludes reviewer-only live slots after catalog union' {

--- a/tests/bridge/CommandReviewDispatch.Tests.ps1
+++ b/tests/bridge/CommandReviewDispatch.Tests.ps1
@@ -1672,11 +1672,128 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
                 throw 'Start-OrchestraPaneBootstrap not mocked'
             }
         }
+
+        function script:Get-Task789SupervisorIdentity {
+            $started = Get-WinsmuxRuntimeProcessStartedAt -ProcessId $PID
+            if ([string]::IsNullOrWhiteSpace([string]$started)) {
+                throw 'TASK-789 v2 fixture could not read the current process start time.'
+            }
+            return [pscustomobject]@{ Pid = [int]$PID; StartedAt = [string]$started }
+        }
+
+        function script:New-Task789V2Pane {
+            param(
+                [Parameter(Mandatory = $true)][string]$Label,
+                [Parameter(Mandatory = $true)][string]$PaneId,
+                [string]$Role = 'Worker',
+                [string]$WorkerRole = 'worker',
+                [string]$WorkerBackend = 'codex',
+                [string]$Status = 'ready'
+            )
+            return [pscustomobject]@{
+                Label         = $Label
+                PaneId        = $PaneId
+                Role          = $Role
+                WorkerRole    = $WorkerRole
+                WorkerBackend = $WorkerBackend
+                Title         = $Label
+                Status        = $Status
+            }
+        }
+
+        function script:New-Task789V2RegistryPane {
+            param(
+                [Parameter(Mandatory = $true)][string]$Label,
+                [Parameter(Mandatory = $true)][string]$PaneId,
+                [string]$Backend = 'codex',
+                [string]$Role = 'worker',
+                [int]$BootstrapPid = 0,
+                [string]$BootstrapStartedAt = '2026-08-17T00:00:01.0000000Z'
+            )
+            return [PSCustomObject]@{
+                label                        = $Label
+                slot_id                      = $Label
+                pane_id                      = $PaneId
+                backend                      = $Backend
+                role                         = $Role
+                title                        = $Label
+                state                        = $(if ($BootstrapPid -gt 0) { 'live' } else { 'bootstrap_pending' })
+                bootstrap_pid                = $BootstrapPid
+                bootstrap_process_started_at = $(if ($BootstrapPid -gt 0) { $BootstrapStartedAt } else { '' })
+                marker_path                  = ''
+            }
+        }
+
+        function script:New-Task789ObservedPane {
+            param(
+                [Parameter(Mandatory = $true)][string]$PaneId,
+                [Parameter(Mandatory = $true)][string]$Title,
+                [string]$SessionId = '$9',
+                [string]$SessionName = 'winsmux-orchestra'
+            )
+            return [pscustomobject]@{
+                SessionId   = $SessionId
+                SessionName = $SessionName
+                PaneId      = $PaneId
+                Title       = $Title
+            }
+        }
+
+        function script:Write-Task789V2Manifest {
+            param(
+                [Parameter(Mandatory = $true)][string]$Path,
+                [Parameter(Mandatory = $true)][string]$ProjectDir,
+                [Parameter(Mandatory = $true)][object[]]$Panes
+            )
+            $lines = [System.Collections.Generic.List[string]]::new()
+            $lines.Add('version: 2') | Out-Null
+            $lines.Add('saved_at: 2026-08-17T00:00:00Z') | Out-Null
+            $lines.Add('session:') | Out-Null
+            $lines.Add('  name: winsmux-orchestra') | Out-Null
+            $lines.Add("  project_dir: $ProjectDir") | Out-Null
+            $lines.Add('  generation_id: generation-789') | Out-Null
+            $lines.Add("  server_session_id: '`$9'") | Out-Null
+            $lines.Add("  bootstrap_pane_id: '%1'") | Out-Null
+            $lines.Add(('  expected_pane_count: {0}' -f @($Panes).Count)) | Out-Null
+            $lines.Add('panes:') | Out-Null
+            foreach ($pane in @($Panes)) {
+                $lines.Add(('  {0}:' -f $pane.Label)) | Out-Null
+                $lines.Add(('    label: {0}' -f $pane.Label)) | Out-Null
+                $lines.Add(('    slot_id: {0}' -f $pane.Label)) | Out-Null
+                $lines.Add(("    pane_id: '{0}'" -f $pane.PaneId)) | Out-Null
+                $lines.Add(('    role: {0}' -f $pane.Role)) | Out-Null
+                $lines.Add(('    worker_role: {0}' -f $pane.WorkerRole)) | Out-Null
+                $lines.Add(('    worker_backend: {0}' -f $pane.WorkerBackend)) | Out-Null
+                $lines.Add(('    title: {0}' -f $pane.Title)) | Out-Null
+                $lines.Add(('    status: {0}' -f $pane.Status)) | Out-Null
+            }
+            Set-Content -LiteralPath $Path -Value ($lines -join "`n") -Encoding utf8
+        }
+
+        function script:Get-Task789ObservedLines {
+            return @(
+                $script:task789Observed | ForEach-Object {
+                    "{0}`t{1}`t{2}`t{3}" -f $_.SessionId, $_.SessionName, $_.PaneId, $_.Title
+                }
+            )
+        }
+
+        function script:Mock-Task789LiveServer {
+            Mock Invoke-PaneControlWinsmux {
+                param($Arguments)
+                if (@($Arguments) -contains 'list-panes') {
+                    return script:Get-Task789ObservedLines
+                }
+                throw ("unexpected pane-control winsmux: {0}" -f (@($Arguments) -join ' '))
+            }
+        }
     }
 
     BeforeEach {
         $script:task789FixRoot = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-task789-fix-' + [guid]::NewGuid().ToString('N'))
         New-Item -ItemType Directory -Path (Join-Path $script:task789FixRoot '.winsmux') -Force | Out-Null
+        $script:task789Observed = @()
+        $script:task789Killed = @()
     }
 
     AfterEach {
@@ -2018,31 +2135,14 @@ panes:
     It 'does not publish a new registry when the guarded manifest save fails' {
         $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
         $registryPath = Get-WinsmuxRuntimeRegistryPath -ProjectDir $script:task789FixRoot
-        @"
-version: 2
-saved_at: 2026-08-17T00:00:00Z
-session:
-  name: winsmux-orchestra
-  generation_id: generation-789
-  server_session_id: '`$9'
-  bootstrap_pane_id: '%1'
-  expected_pane_count: 1
-panes:
-  worker-1:
-    slot_id: worker-1
-    pane_id: '%3'
-    role: Worker
-    worker_role: worker
-    worker_backend: codex
-    title: worker-1
-    status: ready
-"@ | Set-Content -LiteralPath $manifestPath -Encoding utf8
+        $supervisor = script:Get-Task789SupervisorIdentity
+        script:Write-Task789V2Manifest -Path $manifestPath -ProjectDir $script:task789FixRoot -Panes @(
+            script:New-Task789V2Pane -Label 'worker-1' -PaneId '%3'
+        )
         $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
-            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid 4100 `
-            -SupervisorProcessStartedAt '2026-08-17T00:00:00.0000000Z' -ExpectedPaneCount 1 `
-            -Panes @(
-                [PSCustomObject]@{ label = 'worker-1'; slot_id = 'worker-1'; pane_id = '%3'; backend = 'codex'; role = 'worker'; title = 'worker-1'; state = 'live'; bootstrap_pid = 4200; bootstrap_process_started_at = '2026-08-17T00:00:01.0000000Z'; marker_path = '' }
-            )
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid $supervisor.Pid `
+            -SupervisorProcessStartedAt $supervisor.StartedAt -ExpectedPaneCount 1 -LeaseSeconds 300 `
+            -Panes @(script:New-Task789V2RegistryPane -Label 'worker-1' -PaneId '%3' -BootstrapPid 4200)
         Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
         $beforeRegistry = [System.IO.File]::ReadAllBytes($registryPath)
         $beforeManifest = [System.IO.File]::ReadAllBytes($manifestPath)
@@ -2052,10 +2152,16 @@ panes:
             slot_id = 'worker-2'; pane_id = '%4'; role = 'Worker'; worker_role = 'worker'
             worker_backend = 'codex'; title = 'worker-2'; status = 'ready'
         }
+        $script:task789Observed = @(
+            script:New-Task789ObservedPane -PaneId '%1' -Title 'bootstrap'
+            script:New-Task789ObservedPane -PaneId '%3' -Title 'worker-1'
+            script:New-Task789ObservedPane -PaneId '%4' -Title 'worker-2'
+        )
+        script:Mock-Task789LiveServer
         Mock Save-PaneScalerManifest { throw 'injected manifest save failure' }
         Mock Save-WinsmuxRuntimeRegistry { throw 'registry must not publish after a failed manifest save' }
 
-        { Save-OrchestraLivePaneSetTransition -ManifestPath $manifestPath -Manifest $manifest -ProjectDir $script:task789FixRoot -ExpectedGenerationId 'generation-789' } |
+        { Save-OrchestraLivePaneSetTransition -ManifestPath $manifestPath -Manifest $manifest -ProjectDir $script:task789FixRoot -ExpectedGenerationId 'generation-789' -RuntimePaneId '%3' } |
             Should -Throw '*injected manifest save failure*'
 
         [System.IO.File]::ReadAllBytes($registryPath) | Should -Be $beforeRegistry
@@ -2390,5 +2496,467 @@ Write-Output 'reached-after-exit'
         ($output | Out-String) | Should -Match 'unverified pane'
         ($output | Out-String) | Should -Not -Match 'reached-after-exit'
         Test-Path -LiteralPath $sentPath | Should -BeFalse
+    }
+
+    It 'treats unrecognized or empty archive status without an idle event as unavailable' {
+        $empty = Test-WinsmuxArchivePaneIdle -Entry ([pscustomobject]@{
+            Label = 'worker-2'; PaneId = '%5'; Status = ''; LastEvent = ''
+        }) -ProjectDir $script:task789FixRoot
+        $empty.Idle | Should -BeFalse
+        $empty.Evidence | Should -Be 'unavailable'
+
+        $unknown = Test-WinsmuxArchivePaneIdle -Entry ([pscustomobject]@{
+            Label = 'worker-2'; PaneId = '%5'; Status = 'unknown'; LastEvent = ''
+        }) -ProjectDir $script:task789FixRoot
+        $unknown.Idle | Should -BeFalse
+        $unknown.Evidence | Should -Be 'unavailable'
+
+        $ready = Test-WinsmuxArchivePaneIdle -Entry ([pscustomobject]@{
+            Label = 'worker-2'; PaneId = '%5'; Status = 'ready'; LastEvent = ''
+        }) -ProjectDir $script:task789FixRoot
+        $ready.Idle | Should -BeTrue
+        $ready.Evidence | Should -Be 'idle'
+    }
+
+    It 'commits a v2 spawn after split when the guarded save sees the new observed pane' {
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        $registryPath = Get-WinsmuxRuntimeRegistryPath -ProjectDir $script:task789FixRoot
+        $supervisor = script:Get-Task789SupervisorIdentity
+        script:Write-Task789V2Manifest -Path $manifestPath -ProjectDir $script:task789FixRoot -Panes @(
+            script:New-Task789V2Pane -Label 'worker-1' -PaneId '%3'
+        )
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid $supervisor.Pid `
+            -SupervisorProcessStartedAt $supervisor.StartedAt -ExpectedPaneCount 1 -LeaseSeconds 300 `
+            -Panes @(script:New-Task789V2RegistryPane -Label 'worker-1' -PaneId '%3' -BootstrapPid 4200)
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
+
+        $script:task789Observed = @(
+            script:New-Task789ObservedPane -PaneId '%1' -Title 'bootstrap'
+            script:New-Task789ObservedPane -PaneId '%3' -Title 'worker-1'
+        )
+        script:Mock-Task789LiveServer
+        $worktreePath = Join-Path $script:task789FixRoot '.worktrees\worker-2'
+        New-Item -ItemType Directory -Path $worktreePath -Force | Out-Null
+        Mock New-PaneScalerWorkerWorktree {
+            [pscustomobject]@{ WorktreePath = $worktreePath; BranchName = 'worktree-worker-2'; GitWorktreeDir = $worktreePath }
+        }
+        Mock Invoke-MonitorWinsmux {
+            param($Arguments)
+            $argsList = @($Arguments)
+            if ($argsList -contains 'split-window') {
+                $script:task789Observed = @($script:task789Observed) + @(
+                    script:New-Task789ObservedPane -PaneId '%5' -Title 'worker-2'
+                )
+                return '%5'
+            }
+            if ($argsList -contains 'select-pane') { return }
+            if ($argsList -contains 'kill-pane') { throw 'spawn success must not kill the new pane' }
+        }
+        Mock Wait-MonitorPaneShellReady { }
+        Mock Get-PaneScalerLaunchCommand { 'echo spawn-worker-2' }
+        Mock New-OrchestraPaneBootstrapPlan {
+            $planDir = Join-Path $script:task789FixRoot '.winsmux\orchestra-bootstrap'
+            New-Item -ItemType Directory -Path $planDir -Force | Out-Null
+            $planPath = Join-Path $planDir '5.json'
+            Set-Content -LiteralPath $planPath -Value '{}' -Encoding utf8
+            return $planPath
+        }
+        Mock Get-OrchestraPaneBootstrapMarkerPath {
+            Join-Path $script:task789FixRoot '.winsmux\orchestra-bootstrap\5-generation-789.ready.json'
+        }
+        Mock Start-OrchestraPaneBootstrap { }
+        Mock Get-BridgeSettings { [ordered]@{ agent = 'codex'; model = 'gpt-5.4' } }
+
+        $result = Add-OrchestraWorkerPane -ManifestPath $manifestPath -SlotId 'worker-2' -SlotAgentConfig ([pscustomobject]@{
+            Agent = 'codex'; Model = 'gpt-5.4'; WorkerBackend = 'codex'; PaneTitle = 'worker-2'
+        })
+        $result.Changed | Should -BeTrue
+        $result.PaneId | Should -Be '%5'
+
+        $saved = Read-PaneScalerManifest -ManifestPath $manifestPath
+        $saved.version | Should -Be 2
+        @($saved.Panes.Keys) | Should -Be @('worker-1', 'worker-2')
+        $saved.Panes['worker-2'].pane_id | Should -Be '%5'
+        $saved.Session.expected_pane_count | Should -Be 2
+        $saved.Panes['worker-2'].status | Should -Be 'deferred_starting'
+
+        $read = Read-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot
+        $read.expected_pane_count | Should -Be 2
+        @($read.panes | ForEach-Object { [string]$_.pane_id }) | Should -Be @('%3', '%5')
+        ($script:task789Observed | ForEach-Object { $_.PaneId }) | Should -Contain '%5'
+    }
+
+    It 'kills the new v2 pane and restores file bytes when guarded spawn save fails after split' {
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        $registryPath = Get-WinsmuxRuntimeRegistryPath -ProjectDir $script:task789FixRoot
+        $supervisor = script:Get-Task789SupervisorIdentity
+        script:Write-Task789V2Manifest -Path $manifestPath -ProjectDir $script:task789FixRoot -Panes @(
+            script:New-Task789V2Pane -Label 'worker-1' -PaneId '%3'
+        )
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid $supervisor.Pid `
+            -SupervisorProcessStartedAt $supervisor.StartedAt -ExpectedPaneCount 1 -LeaseSeconds 300 `
+            -Panes @(script:New-Task789V2RegistryPane -Label 'worker-1' -PaneId '%3' -BootstrapPid 4200)
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
+        $beforeRegistry = [System.IO.File]::ReadAllBytes($registryPath)
+        $beforeManifest = [System.IO.File]::ReadAllBytes($manifestPath)
+
+        $script:task789Observed = @(
+            script:New-Task789ObservedPane -PaneId '%1' -Title 'bootstrap'
+            script:New-Task789ObservedPane -PaneId '%3' -Title 'worker-1'
+        )
+        $script:task789Killed = @()
+        script:Mock-Task789LiveServer
+        $worktreePath = Join-Path $script:task789FixRoot '.worktrees\worker-2'
+        New-Item -ItemType Directory -Path $worktreePath -Force | Out-Null
+        Mock New-PaneScalerWorkerWorktree {
+            [pscustomobject]@{ WorktreePath = $worktreePath; BranchName = 'worktree-worker-2'; GitWorktreeDir = $worktreePath }
+        }
+        Mock Invoke-MonitorWinsmux {
+            param($Arguments)
+            $argsList = @($Arguments)
+            if ($argsList -contains 'split-window') {
+                $script:task789Observed = @($script:task789Observed) + @(
+                    script:New-Task789ObservedPane -PaneId '%5' -Title 'worker-2'
+                )
+                return '%5'
+            }
+            if ($argsList -contains 'select-pane') { return }
+            if ($argsList -contains 'kill-pane') {
+                $target = $argsList[$argsList.IndexOf('-t') + 1]
+                $script:task789Killed += $target
+                $script:task789Observed = @($script:task789Observed | Where-Object { $_.PaneId -ne $target })
+                return
+            }
+        }
+        Mock Wait-MonitorPaneShellReady { }
+        Mock Get-PaneScalerLaunchCommand { 'echo spawn-worker-2' }
+        Mock New-OrchestraPaneBootstrapPlan { Join-Path $script:task789FixRoot '.winsmux\orchestra-bootstrap\5.json' }
+        Mock Get-OrchestraPaneBootstrapMarkerPath {
+            Join-Path $script:task789FixRoot '.winsmux\orchestra-bootstrap\5-generation-789.ready.json'
+        }
+        Mock Start-OrchestraPaneBootstrap { }
+        Mock Get-BridgeSettings { [ordered]@{ agent = 'codex'; model = 'gpt-5.4' } }
+        Mock Save-PaneScalerManifest { throw 'injected spawn save failure' }
+
+        { Add-OrchestraWorkerPane -ManifestPath $manifestPath -SlotId 'worker-2' -SlotAgentConfig ([pscustomobject]@{
+            Agent = 'codex'; Model = 'gpt-5.4'; WorkerBackend = 'codex'; PaneTitle = 'worker-2'
+        }) } | Should -Throw '*injected spawn save failure*'
+
+        [System.IO.File]::ReadAllBytes($manifestPath) | Should -Be $beforeManifest
+        [System.IO.File]::ReadAllBytes($registryPath) | Should -Be $beforeRegistry
+        $script:task789Killed | Should -Contain '%5'
+        ($script:task789Observed | ForEach-Object { $_.PaneId }) | Should -Not -Contain '%5'
+    }
+
+    It 'does not dispatch a v2 spawned worker as ready without a bootstrap marker PID' {
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        $supervisor = script:Get-Task789SupervisorIdentity
+        script:Write-Task789V2Manifest -Path $manifestPath -ProjectDir $script:task789FixRoot -Panes @(
+            script:New-Task789V2Pane -Label 'worker-1' -PaneId '%3'
+        )
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid $supervisor.Pid `
+            -SupervisorProcessStartedAt $supervisor.StartedAt -ExpectedPaneCount 1 -LeaseSeconds 300 `
+            -Panes @(script:New-Task789V2RegistryPane -Label 'worker-1' -PaneId '%3' -BootstrapPid 4200)
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
+        $script:task789Observed = @(
+            script:New-Task789ObservedPane -PaneId '%1' -Title 'bootstrap'
+            script:New-Task789ObservedPane -PaneId '%3' -Title 'worker-1'
+        )
+        script:Mock-Task789LiveServer
+        $worktreePath = Join-Path $script:task789FixRoot '.worktrees\worker-2'
+        New-Item -ItemType Directory -Path $worktreePath -Force | Out-Null
+        Mock New-PaneScalerWorkerWorktree {
+            [pscustomobject]@{ WorktreePath = $worktreePath; BranchName = 'worktree-worker-2'; GitWorktreeDir = $worktreePath }
+        }
+        Mock Invoke-MonitorWinsmux {
+            param($Arguments)
+            $argsList = @($Arguments)
+            if ($argsList -contains 'split-window') {
+                $script:task789Observed = @($script:task789Observed) + @(
+                    script:New-Task789ObservedPane -PaneId '%5' -Title 'worker-2'
+                )
+                return '%5'
+            }
+            if ($argsList -contains 'select-pane') { return }
+        }
+        Mock Wait-MonitorPaneShellReady { }
+        Mock Get-PaneScalerLaunchCommand { 'echo spawn-worker-2' }
+        Mock New-OrchestraPaneBootstrapPlan { Join-Path $script:task789FixRoot '.winsmux\orchestra-bootstrap\5.json' }
+        Mock Get-OrchestraPaneBootstrapMarkerPath {
+            Join-Path $script:task789FixRoot '.winsmux\orchestra-bootstrap\5-generation-789.ready.json'
+        }
+        Mock Start-OrchestraPaneBootstrap { }
+        Mock Get-BridgeSettings { [ordered]@{ agent = 'codex'; model = 'gpt-5.4' } }
+
+        $null = Add-OrchestraWorkerPane -ManifestPath $manifestPath -SlotId 'worker-2' -SlotAgentConfig ([pscustomobject]@{
+            Agent = 'codex'; Model = 'gpt-5.4'; WorkerBackend = 'codex'; PaneTitle = 'worker-2'
+        })
+        $saved = Read-PaneScalerManifest -ManifestPath $manifestPath
+        $saved.Panes['worker-2'].status | Should -Be 'deferred_starting'
+        $readyRaw = $saved.Panes['worker-2'].runtime_ready
+        ($readyRaw -eq $true -or [string]$readyRaw -ceq 'true') | Should -BeFalse
+
+        $read = Read-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot
+        $spawned = @($read.panes | Where-Object { [string]$_.label -eq 'worker-2' })[0]
+        [int]$spawned.bootstrap_pid | Should -Be 0
+
+        $script:task789DispatchStartedAt = Get-WinsmuxRuntimeProcessStartedAt -ProcessId $PID
+        $dispatchCheck = Test-WinsmuxRuntimeContext -Manifest (Get-WinsmuxManifest -ProjectDir $script:task789FixRoot) `
+            -Registry $read -ObservedServerSessionId '$9' -ObservedPanes @(
+                [pscustomobject]@{ pane_id = '%1'; title = 'bootstrap' }
+                [pscustomobject]@{ pane_id = '%3'; title = 'worker-1' }
+                [pscustomobject]@{ pane_id = '%5'; title = 'worker-2' }
+            ) -ManifestEntry ([pscustomobject]@{
+                Label = 'worker-2'; SlotId = 'worker-2'; PaneId = '%5'; WorkerBackend = 'codex'
+                WorkerRole = 'worker'; Role = 'Worker'; Title = 'worker-2'; Status = 'ready'
+            }) -PaneMarker $null -ProcessResolver {
+                param([int]$Id)
+                if ($Id -eq $PID) {
+                    return [PSCustomObject]@{ Id = $PID; StartTime = $script:task789DispatchStartedAt; ParentProcessId = 1; Name = 'pwsh.exe' }
+                }
+                if ($Id -eq 4200) {
+                    return [PSCustomObject]@{ Id = 4200; StartTime = '2026-08-17T00:00:01.0000000Z'; ParentProcessId = 1; Name = 'pwsh.exe' }
+                }
+                return $null
+            } -Operation dispatch -Now ([datetime]::UtcNow.AddMinutes(1))
+        $dispatchCheck.valid | Should -BeFalse
+        $dispatchCheck.reason_code | Should -Be 'runtime_target_mismatch'
+    }
+
+    It 'lets v2 dispatch runtime succeed after a spawned worker persists a bootstrap marker PID' {
+        $markerDir = Join-Path $script:task789FixRoot '.winsmux\orchestra-bootstrap'
+        New-Item -ItemType Directory -Path $markerDir -Force | Out-Null
+        $markerPath = Join-Path $markerDir '5-generation-789.ready.json'
+        $startedAt = '2026-08-17T00:00:02.0000000Z'
+        @{
+            state = 'bootstrap_pending'
+            generation_id = 'generation-789'
+            server_session_id = '$9'
+            slot_id = 'worker-2'
+            pane_id = '%5'
+            backend = 'codex'
+            role = 'worker'
+            title = 'worker-2'
+            bootstrap_pid = 4300
+            bootstrap_process_started_at = $startedAt
+        } | ConvertTo-Json | Set-Content -LiteralPath $markerPath -Encoding utf8
+
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        $supervisor = script:Get-Task789SupervisorIdentity
+        script:Write-Task789V2Manifest -Path $manifestPath -ProjectDir $script:task789FixRoot -Panes @(
+            script:New-Task789V2Pane -Label 'worker-1' -PaneId '%3'
+        )
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid $supervisor.Pid `
+            -SupervisorProcessStartedAt $supervisor.StartedAt -ExpectedPaneCount 1 -LeaseSeconds 300 `
+            -Panes @(script:New-Task789V2RegistryPane -Label 'worker-1' -PaneId '%3' -BootstrapPid 4200)
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
+        $script:task789Observed = @(
+            script:New-Task789ObservedPane -PaneId '%1' -Title 'bootstrap'
+            script:New-Task789ObservedPane -PaneId '%3' -Title 'worker-1'
+        )
+        script:Mock-Task789LiveServer
+        $worktreePath = Join-Path $script:task789FixRoot '.worktrees\worker-2'
+        New-Item -ItemType Directory -Path $worktreePath -Force | Out-Null
+        Mock New-PaneScalerWorkerWorktree {
+            [pscustomobject]@{ WorktreePath = $worktreePath; BranchName = 'worktree-worker-2'; GitWorktreeDir = $worktreePath }
+        }
+        Mock Invoke-MonitorWinsmux {
+            param($Arguments)
+            $argsList = @($Arguments)
+            if ($argsList -contains 'split-window') {
+                $script:task789Observed = @($script:task789Observed) + @(
+                    script:New-Task789ObservedPane -PaneId '%5' -Title 'worker-2'
+                )
+                return '%5'
+            }
+            if ($argsList -contains 'select-pane') { return }
+        }
+        Mock Wait-MonitorPaneShellReady { }
+        Mock Get-PaneScalerLaunchCommand { 'echo spawn-worker-2' }
+        Mock New-OrchestraPaneBootstrapPlan { Join-Path $markerDir '5.json' }
+        Mock Get-OrchestraPaneBootstrapMarkerPath { $markerPath }
+        Mock Start-OrchestraPaneBootstrap { }
+        Mock Get-BridgeSettings { [ordered]@{ agent = 'codex'; model = 'gpt-5.4' } }
+
+        $null = Add-OrchestraWorkerPane -ManifestPath $manifestPath -SlotId 'worker-2' -SlotAgentConfig ([pscustomobject]@{
+            Agent = 'codex'; Model = 'gpt-5.4'; WorkerBackend = 'codex'; PaneTitle = 'worker-2'
+        })
+        $saved = Read-PaneScalerManifest -ManifestPath $manifestPath
+        $saved.Panes['worker-2'].status | Should -Be 'ready'
+        [bool]$saved.Panes['worker-2'].runtime_ready | Should -BeTrue
+
+        $marker = Get-Content -LiteralPath $markerPath -Raw -Encoding UTF8 | ConvertFrom-Json
+        $read = Read-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot
+        $script:task789DispatchStartedAt = Get-WinsmuxRuntimeProcessStartedAt -ProcessId $PID
+        $dispatchCheck = Test-WinsmuxRuntimeContext -Manifest (Get-WinsmuxManifest -ProjectDir $script:task789FixRoot) `
+            -Registry $read -ObservedServerSessionId '$9' -ObservedPanes @(
+                [pscustomobject]@{ pane_id = '%1'; title = 'bootstrap' }
+                [pscustomobject]@{ pane_id = '%3'; title = 'worker-1' }
+                [pscustomobject]@{ pane_id = '%5'; title = 'worker-2' }
+            ) -ManifestEntry ([pscustomobject]@{
+                Label = 'worker-2'; SlotId = 'worker-2'; PaneId = '%5'; WorkerBackend = 'codex'
+                WorkerRole = 'worker'; Role = 'Worker'; Title = 'worker-2'; Status = 'ready'
+                BootstrapMarkerPath = $markerPath
+            }) -PaneMarker $marker -ProcessResolver {
+                param([int]$Id)
+                switch ($Id) {
+                    $PID { return [PSCustomObject]@{ Id = $PID; StartTime = $script:task789DispatchStartedAt; ParentProcessId = 1; Name = 'pwsh.exe' } }
+                    4200 { return [PSCustomObject]@{ Id = 4200; StartTime = '2026-08-17T00:00:01.0000000Z'; ParentProcessId = 1; Name = 'pwsh.exe' } }
+                    4300 { return [PSCustomObject]@{ Id = 4300; StartTime = [datetime]'2026-08-17T00:00:02Z'; ParentProcessId = 1; Name = 'pwsh.exe' } }
+                    default { return $null }
+                }
+            } -Operation dispatch -Now ([datetime]::UtcNow.AddMinutes(1))
+        $dispatchCheck.valid | Should -BeTrue -Because ("dispatch diagnostic: {0} {1}" -f $dispatchCheck.reason_code, $dispatchCheck.diagnostic)
+        $dispatchCheck.reason_code | Should -Be 'live_runtime_verified'
+    }
+
+    It 'restores v2 archive files when kill-pane fails and the pane is still listed' {
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        $registryPath = Get-WinsmuxRuntimeRegistryPath -ProjectDir $script:task789FixRoot
+        $supervisor = script:Get-Task789SupervisorIdentity
+        script:Write-Task789V2Manifest -Path $manifestPath -ProjectDir $script:task789FixRoot -Panes @(
+            script:New-Task789V2Pane -Label 'worker-1' -PaneId '%3'
+            script:New-Task789V2Pane -Label 'worker-2' -PaneId '%5'
+        )
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid $supervisor.Pid `
+            -SupervisorProcessStartedAt $supervisor.StartedAt -ExpectedPaneCount 2 -LeaseSeconds 300 `
+            -Panes @(
+                script:New-Task789V2RegistryPane -Label 'worker-1' -PaneId '%3' -BootstrapPid 4200
+                script:New-Task789V2RegistryPane -Label 'worker-2' -PaneId '%5' -BootstrapPid 4300
+            )
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
+        $beforeRegistry = [System.IO.File]::ReadAllBytes($registryPath)
+        $beforeManifest = [System.IO.File]::ReadAllBytes($manifestPath)
+        $script:task789Observed = @(
+            script:New-Task789ObservedPane -PaneId '%1' -Title 'bootstrap'
+            script:New-Task789ObservedPane -PaneId '%3' -Title 'worker-1'
+            script:New-Task789ObservedPane -PaneId '%5' -Title 'worker-2'
+        )
+        script:Mock-Task789LiveServer
+        Mock Invoke-MonitorWinsmux {
+            param($Arguments)
+            if (@($Arguments) -contains 'kill-pane') {
+                throw 'injected kill-pane failure'
+            }
+        }
+
+        { Remove-OrchestraWorkerPane -ManifestPath $manifestPath -Label 'worker-2' } |
+            Should -Throw '*still live*'
+
+        [System.IO.File]::ReadAllBytes($manifestPath) | Should -Be $beforeManifest
+        [System.IO.File]::ReadAllBytes($registryPath) | Should -Be $beforeRegistry
+        $saved = Read-PaneScalerManifest -ManifestPath $manifestPath
+        $saved.Panes.Contains('worker-2') | Should -BeTrue
+    }
+
+    It 'does not re-advertise a dead v2 pane when kill-pane succeeds and the guarded save fails' {
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        $registryPath = Get-WinsmuxRuntimeRegistryPath -ProjectDir $script:task789FixRoot
+        $supervisor = script:Get-Task789SupervisorIdentity
+        script:Write-Task789V2Manifest -Path $manifestPath -ProjectDir $script:task789FixRoot -Panes @(
+            script:New-Task789V2Pane -Label 'worker-1' -PaneId '%3'
+            script:New-Task789V2Pane -Label 'worker-2' -PaneId '%5'
+        )
+        $registry = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-orchestra' -ServerSessionId '$9' `
+            -BootstrapPaneId '%1' -GenerationId 'generation-789' -SupervisorPid $supervisor.Pid `
+            -SupervisorProcessStartedAt $supervisor.StartedAt -ExpectedPaneCount 2 -LeaseSeconds 300 `
+            -Panes @(
+                script:New-Task789V2RegistryPane -Label 'worker-1' -PaneId '%3' -BootstrapPid 4200
+                script:New-Task789V2RegistryPane -Label 'worker-2' -PaneId '%5' -BootstrapPid 4300
+            )
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot -Registry $registry | Out-Null
+        $script:task789Observed = @(
+            script:New-Task789ObservedPane -PaneId '%1' -Title 'bootstrap'
+            script:New-Task789ObservedPane -PaneId '%3' -Title 'worker-1'
+            script:New-Task789ObservedPane -PaneId '%5' -Title 'worker-2'
+        )
+        script:Mock-Task789LiveServer
+        Mock Invoke-MonitorWinsmux {
+            param($Arguments)
+            $argsList = @($Arguments)
+            if ($argsList -contains 'kill-pane') {
+                $target = $argsList[$argsList.IndexOf('-t') + 1]
+                $script:task789Observed = @($script:task789Observed | Where-Object { $_.PaneId -ne $target })
+                return
+            }
+        }
+        Mock Save-PaneScalerManifest { throw 'injected archive save failure' }
+
+        { Remove-OrchestraWorkerPane -ManifestPath $manifestPath -Label 'worker-2' } |
+            Should -Throw '*failed to persist*'
+
+        $saved = Read-PaneScalerManifest -ManifestPath $manifestPath
+        $saved.Panes.Contains('worker-2') | Should -BeFalse
+        @($saved.Panes.Keys) | Should -Be @('worker-1')
+        $read = Read-WinsmuxRuntimeRegistry -ProjectDir $script:task789FixRoot
+        @($read.panes | ForEach-Object { [string]$_.label }) | Should -Be @('worker-1')
+        $read.expected_pane_count | Should -Be 1
+        (Get-Content -LiteralPath $manifestPath -Raw -Encoding UTF8) | Should -Not -Match "pane_id: '%5'"
+    }
+
+    It 'does not send C-c or kill when archive-pane has no idle evidence' {
+        $probePath = Join-Path $script:task789FixRoot 'archive-idle-probe.ps1'
+        $dispatchPath = $script:task789DispatchPath
+        $sentPath = Join-Path $script:task789FixRoot 'cc-sent.txt'
+        $killedPath = Join-Path $script:task789FixRoot 'killed.txt'
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        script:Write-Task789V2Manifest -Path $manifestPath -ProjectDir $script:task789FixRoot -Panes @(
+            script:New-Task789V2Pane -Label 'worker-1' -PaneId '%3' -Status 'ready'
+            script:New-Task789V2Pane -Label 'worker-2' -PaneId '%9' -Status 'unknown'
+        )
+        $probe = @"
+`$ErrorActionPreference = 'Stop'
+function Stop-WithError { param([string]`$Message) throw `$Message }
+function Get-Labels { return @{ 'worker-2' = '%9' } }
+. '$($dispatchPath.Replace("'", "''"))'
+function Test-PaneControlRuntimeContext {
+    param(`$ProjectDir, `$ManifestEntry, `$Operation)
+    return [pscustomobject]@{ valid = `$true; reason_code = 'stop_transition_verified'; diagnostic = 'ok'; context = [pscustomobject]@{ generation_id = 'generation-789' } }
+}
+function Get-PaneControlManifestEntries {
+    param(`$ProjectDir)
+    return @(
+        [pscustomobject]@{
+            Label = 'worker-1'; SlotId = 'worker-1'; PaneId = '%3'; Role = 'Worker'
+            WorkerRole = 'worker'; WorkerBackend = 'codex'; Title = 'worker-1'
+            Status = 'ready'; LastEvent = 'pane.idle'
+        },
+        [pscustomobject]@{
+            Label = 'worker-2'; SlotId = 'worker-2'; PaneId = '%9'; Role = 'Worker'
+            WorkerRole = 'worker'; WorkerBackend = 'codex'; Title = 'worker-2'
+            Status = 'unknown'; LastEvent = ''
+        }
+    )
+}
+function Invoke-WinsmuxRaw {
+    param(`$Arguments)
+    if (@(`$Arguments) -contains 'C-c') { Set-Content -LiteralPath '$($sentPath.Replace("'", "''"))' -Value 'sent' -Encoding utf8 }
+}
+function Invoke-MonitorWinsmux {
+    param(`$Arguments)
+    if (@(`$Arguments) -contains 'C-c') { Set-Content -LiteralPath '$($sentPath.Replace("'", "''"))' -Value 'sent' -Encoding utf8 }
+    if (@(`$Arguments) -contains 'kill-pane') { Set-Content -LiteralPath '$($killedPath.Replace("'", "''"))' -Value 'killed' -Encoding utf8 }
+}
+function Remove-OrchestraPane {
+    param(`$ManifestPath, `$Role, `$Label)
+    Set-Content -LiteralPath '$($killedPath.Replace("'", "''"))' -Value 'removed' -Encoding utf8
+    return [pscustomobject]@{ Changed = `$true; Reason = '' }
+}
+Set-Location -LiteralPath '$($script:task789FixRoot.Replace("'", "''"))'
+Invoke-WinsmuxArchivePaneCommand -BridgeScriptRoot '$($script:task789FixRoot.Replace("'", "''"))' -CommandTarget 'worker-2' -CommandRest @()
+Write-Output 'reached-after-exit'
+"@
+        Set-Content -LiteralPath $probePath -Value $probe -Encoding utf8
+        $output = & pwsh -NoProfile -File $probePath 2>&1
+        $LASTEXITCODE | Should -Be 1
+        ($output | Out-String) | Should -Match 'idle evidence is unavailable'
+        ($output | Out-String) | Should -Not -Match 'reached-after-exit'
+        Test-Path -LiteralPath $sentPath | Should -BeFalse
+        Test-Path -LiteralPath $killedPath | Should -BeFalse
     }
 }

--- a/tests/bridge/CommandReviewDispatch.Tests.ps1
+++ b/tests/bridge/CommandReviewDispatch.Tests.ps1
@@ -1883,6 +1883,7 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
         $body | Should -Match 'Get-WinsmuxArchivePaneRuntimeRefusal'
         $body | Should -Match 'C-c'
         $body | Should -Match 'pane\.idle'
+        $body | Should -Match 'Get-PaneAgentStatus'
         $body.IndexOf('Get-WinsmuxArchivePaneRuntimeRefusal') | Should -BeLessThan $body.IndexOf('C-c')
         $script:task789DispatchContent | Should -Match "Operation stop_transition"
         $body | Should -Not -Match 'Invoke-WorkersStop'
@@ -1908,6 +1909,7 @@ Describe 'TASK-789 dispatch spawn and archive-pane' {
         $body | Should -Not -Match 'requiredBackend'
         $body | Should -Match 'simple_mode_live_worker_limit'
         $body | Should -Match 'team_profile_projection_unavailable'
+        $body | Should -Match 'team_profile_projection_mutated_live_manifest'
         $script:task789DispatchContent | Should -Match 'Ensure-DispatchTaskLiveWorkerPane'
         $script:task789DispatchContent | Should -Match 'function Get-DispatchTaskCatalogSlotIds'
         $script:task789DispatchContent | Should -Match 'function Get-DispatchTaskMissingCatalogSlotIds'
@@ -2206,6 +2208,75 @@ panes:
         $result.ReasonCode | Should -Be 'team_profile_projection_unavailable'
         $result.Diagnostic | Should -Be $ProjectionError
         Should -Invoke Add-OrchestraPane -Times 0
+    }
+
+    It 'E10 fail-closes spawn when Team Profile projection mutates the live manifest' {
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        $original = "version: 1`nsession:`n  name: keep`npanes: {}`n"
+        [System.IO.File]::WriteAllText($manifestPath, $original)
+        $before = [System.IO.File]::ReadAllBytes($manifestPath)
+        Mock Get-OrchestraModeDocument {
+            [pscustomobject]@{ schema_version = 1; mode = 'team'; valid = $true; source = 'file' }
+        }
+        Mock Get-OrchestraLiveWorkerRolePaneCount { 1 }
+        Mock Get-OrchestraMaxLiveWorkerPaneCount { 6 }
+        Mock Get-BridgeSettings { $null }
+        Mock Get-WinsmuxManifest { $null }
+        Mock Invoke-TeamProfileLaunchProjection {
+            [System.IO.File]::AppendAllText($manifestPath, "session:`n  team_profile:`n    preset: leaked`n")
+            [pscustomobject]@{
+                bundle_path = '.winsmux/runtime/prompt-bundles/sess/worker-2.md'
+                projection  = [pscustomobject]@{
+                    pane = [pscustomobject]@{
+                        assignment = [pscustomobject]@{ provider = 'codex'; worker_backend = 'codex' }
+                    }
+                }
+            }
+        }
+        Mock Add-OrchestraPane { throw 'E10 must not spawn after live manifest mutation' }
+
+        $result = Ensure-DispatchTaskLiveWorkerPane -ProjectDir $script:task789FixRoot -Label 'worker-2' -ManifestEntry $null
+        $result.Spawned | Should -BeFalse
+        $result.ReasonCode | Should -Be 'team_profile_projection_mutated_live_manifest'
+        Should -Invoke Add-OrchestraPane -Times 0
+        [System.IO.File]::ReadAllBytes($manifestPath) | Should -Be $before
+    }
+
+    It 'E10 continues spawn when Team Profile projection leaves live pane-set files unchanged' {
+        $manifestPath = Join-Path $script:task789FixRoot '.winsmux\manifest.yaml'
+        [System.IO.File]::WriteAllText($manifestPath, "version: 1`nsession:`n  name: keep`npanes: {}`n")
+        $before = [System.IO.File]::ReadAllBytes($manifestPath)
+        Mock Get-OrchestraModeDocument {
+            [pscustomobject]@{ schema_version = 1; mode = 'team'; valid = $true; source = 'file' }
+        }
+        Mock Get-OrchestraLiveWorkerRolePaneCount { 1 }
+        Mock Get-OrchestraMaxLiveWorkerPaneCount { 6 }
+        Mock Get-BridgeSettings { $null }
+        Mock Get-WinsmuxManifest { $null }
+        Mock Invoke-TeamProfileLaunchProjection {
+            [pscustomobject]@{
+                bundle_path = '.winsmux/runtime/prompt-bundles/sess/worker-2.md'
+                projection  = [pscustomobject]@{
+                    pane = [pscustomobject]@{
+                        assignment = [pscustomobject]@{ provider = 'codex'; worker_backend = 'codex' }
+                    }
+                }
+            }
+        }
+        Mock New-TeamProfileSlotAgentConfig {
+            [pscustomobject]@{ Agent = 'codex'; Model = 'gpt-5.4'; WorkerBackend = 'codex'; PaneTitle = $SlotId }
+        }
+        Mock Add-OrchestraPane {
+            return [pscustomobject]@{ Changed = $true; Label = $SlotId; PaneId = '%5' }
+        }
+        Mock Get-DispatchTaskManifestEntry {
+            script:New-Task789LiveEntry -Label 'worker-2' -PaneId '%5'
+        }
+
+        $result = Ensure-DispatchTaskLiveWorkerPane -ProjectDir $script:task789FixRoot -Label 'worker-2' -ManifestEntry $null
+        $result.Spawned | Should -BeTrue
+        Should -Invoke Add-OrchestraPane -Times 1
+        [System.IO.File]::ReadAllBytes($manifestPath) | Should -Be $before
     }
 
     It 'does not publish a new registry when the guarded manifest save fails' {
@@ -3272,8 +3343,16 @@ Write-Output 'reached-after-exit'
         Test-Path -LiteralPath $killedPath | Should -BeFalse
     }
 
+    It 'keeps a single control-plane flag as a one-element argument list' {
+        $parts = ConvertTo-WinsmuxControlPlaneArgumentList -Value (
+            Get-WinsmuxControlPlaneArguments -CommandTarget '--json' -CommandRest @()
+        )
+        $parts.Count | Should -Be 1
+        $parts[0] | Should -Be '--json'
+    }
+
     It 'E03 public argv parse keeps --slot-id and --project-dir as separate tokens' {
-        $parts = @(
+        $parts = ConvertTo-WinsmuxControlPlaneArgumentList -Value (
             Get-WinsmuxControlPlaneArguments -CommandTarget '--slot-id' -CommandRest @(
                 'worker-2', '--project-dir', $script:task789FixRoot, 'implement the focused change'
             )
@@ -3282,7 +3361,7 @@ Write-Output 'reached-after-exit'
         $parsed.SlotId | Should -Be 'worker-2'
         $parsed.ProjectDir | Should -Be $script:task789FixRoot
         $parsed.TaskText | Should -Be 'implement the focused change'
-        @($parts).Count | Should -Be 5
+        $parts.Count | Should -Be 5
         $parts[0] | Should -Be '--slot-id'
         $parts[1] | Should -Be 'worker-2'
     }

--- a/tests/bridge/CommandStatus.RuntimeIdentity.Tests.ps1
+++ b/tests/bridge/CommandStatus.RuntimeIdentity.Tests.ps1
@@ -759,6 +759,8 @@ panes:
             -SupervisorPid 4100 -SupervisorProcessStartedAt '2026-07-15T00:00:00.0000000Z' `
             -Now ([datetime]'2026-07-15T00:05:05Z') -LeaseSeconds 15
         $refreshed.lease.expires_at | Should -Be '2026-07-15T00:05:20.0000000Z'
+        @($refreshed.panes).Count | Should -Be @($registry.panes).Count
+        $refreshed.panes[0].slot_id | Should -Be $registry.panes[0].slot_id
 
         $foreignSessionClose = Close-WinsmuxRuntimeRegistry -ProjectDir $script:task781TempRoot -GenerationId 'generation-1' `
             -SupervisorPid 4100 -SupervisorProcessStartedAt '2026-07-15T00:00:00.0000000Z' `

--- a/tests/bridge/CommandStatus.RuntimeIdentity.Tests.ps1
+++ b/tests/bridge/CommandStatus.RuntimeIdentity.Tests.ps1
@@ -761,6 +761,23 @@ panes:
         $refreshed.lease.expires_at | Should -Be '2026-07-15T00:05:20.0000000Z'
         @($refreshed.panes).Count | Should -Be @($registry.panes).Count
         $refreshed.panes[0].slot_id | Should -Be $registry.panes[0].slot_id
+        (Get-Content -LiteralPath (Join-Path (Split-Path -Parent $script:BridgeTestsRoot) 'winsmux-core\scripts\manifest.ps1') -Raw) |
+            Should -Match 'Invoke-WinsmuxWithFileLock -Path \$path'
+
+        $spawned = New-WinsmuxRuntimeRegistryDocument -SessionName 'winsmux-task781-test' -ServerSessionId '$9' `
+            -GenerationId 'generation-1' -SupervisorPid 4100 `
+            -SupervisorProcessStartedAt '2026-07-15T00:00:00.0000000Z' -ExpectedPaneCount 2 `
+            -Panes @(
+                $registry.panes[0]
+                [pscustomobject]@{ label = 'worker-2'; slot_id = 'worker-2'; pane_id = '%5'; backend = 'codex'; role = 'worker'; title = 'worker-2'; state = 'live'; bootstrap_pid = 4300; bootstrap_process_started_at = '2026-07-15T00:00:02.0000000Z' }
+            ) -Now ([datetime]'2026-07-15T00:05:06Z') -LeaseSeconds 15
+        Save-WinsmuxRuntimeRegistry -ProjectDir $script:task781TempRoot -Registry $spawned | Out-Null
+        $afterSpawn = Update-WinsmuxRuntimeRegistryLease -ProjectDir $script:task781TempRoot -GenerationId 'generation-1' `
+            -SupervisorPid 4100 -SupervisorProcessStartedAt '2026-07-15T00:00:00.0000000Z' `
+            -Now ([datetime]'2026-07-15T00:05:10Z') -LeaseSeconds 15
+        $afterSpawn.expected_pane_count | Should -Be 2
+        @($afterSpawn.panes).Count | Should -Be 2
+        $afterSpawn.panes[1].slot_id | Should -Be 'worker-2'
 
         $foreignSessionClose = Close-WinsmuxRuntimeRegistry -ProjectDir $script:task781TempRoot -GenerationId 'generation-1' `
             -SupervisorPid 4100 -SupervisorProcessStartedAt '2026-07-15T00:00:00.0000000Z' `

--- a/tests/bridge/Foundation.Tests.ps1
+++ b/tests/bridge/Foundation.Tests.ps1
@@ -182,7 +182,7 @@ Describe 'Get-OrchestraLayoutSettings' {
         $layout.ExternalOperator | Should -Be $true
         $layout.LegacyRoleLayout | Should -Be $false
         $layout.Operators | Should -Be 0
-        $layout.Workers | Should -Be 6
+        $layout.Workers | Should -Be 1
         $layout.Builders | Should -Be 0
         $layout.Researchers | Should -Be 0
         $layout.Reviewers | Should -Be 0
@@ -209,7 +209,7 @@ Describe 'Get-OrchestraLayoutSettings' {
         $layout.ExternalOperator | Should -Be $true
         $layout.LegacyRoleLayout | Should -Be $false
         $layout.Operators | Should -Be 0
-        $layout.Workers | Should -Be 3
+        $layout.Workers | Should -Be 1
     }
 
     It 'allows agent slots without agent or model fields under strict mode' {
@@ -238,7 +238,7 @@ Describe 'Get-OrchestraLayoutSettings' {
         $layout.ExternalOperator | Should -Be $true
         $layout.LegacyRoleLayout | Should -Be $false
         $layout.Operators | Should -Be 0
-        $layout.Workers | Should -Be 2
+        $layout.Workers | Should -Be 1
     }
 
     It 'rejects unsupported non-worker runtime_role overrides until slot runtime wiring expands' {
@@ -1648,7 +1648,7 @@ Describe 'TASK658 R37 project-settings startup and workspace-plan differential c
 
             if ($Startup -eq 'accept') {
                 $startupError | Should -BeNullOrEmpty
-                $startupLayout.Workers | Should -Be @($startupSettings.agent_slots).Count
+                $startupLayout.Workers | Should -Be 1
                 @($startupSettings.agent_slots | ForEach-Object { [string]$_.slot_id }) | Should -Contain 'worker-1'
             } else {
                 $startupError | Should -Not -BeNullOrEmpty

--- a/tests/bridge/ProviderCommands.Tests.ps1
+++ b/tests/bridge/ProviderCommands.Tests.ps1
@@ -1986,6 +1986,16 @@ Describe 'winsmux orchestra-smoke command' {
         $script:orchestraSmokeContent | Should -Match 'stale_process_count'
     }
 
+    It 'TASK-789 accepts live expected_pane_count and fail-closes simple mode with extra worker panes' {
+        $script:orchestraSmokeContent | Should -Not -Match '\$workers\s*=\s*\$agentSlots\.Count'
+        $script:orchestraSmokeContent | Should -Match 'Get-OrchestraModeDocument'
+        $script:orchestraSmokeContent | Should -Match 'Test-OrchestraSimpleModeLiveWorkerLimit'
+        $script:orchestraSmokeContent | Should -Match 'simple_mode_live_worker_limit'
+        $script:orchestraSmokeContent | Should -Match 'Get-OrchestraLiveWorkerRolePaneCount'
+        $script:orchestraSmokeContent | Should -Not -Match 'expected_pane_count.*=\s*7'
+    }
+
+
     It 'reports process contract counts for worker shells background helpers attach hosts and warm processes' {
         $snapshot = [pscustomobject]@{
             Processes = @(

--- a/tests/bridge/WorkerWorkspaceSandbox.Tests.ps1
+++ b/tests/bridge/WorkerWorkspaceSandbox.Tests.ps1
@@ -44,6 +44,10 @@ Describe 'TASK781 supervisor deferred runtime promotion' {
         $script:task781SupervisorContent | Should -Match '-ExpectedPaneCount \$expectedPaneCount -Panes \$runtimePanes'
     }
 
+    It 'TASK-789 supervisor lease refresh does not rewrite registry panes from a snapshot' {
+        $script:task781SupervisorContent | Should -Not -Match '-Panes @\(\$runtimeSnapshot\.panes\)'
+    }
+
     It 'TASK781 C29 keeps deferred_starting deferred until its marker exists' {
         $panes = @(New-OrchestraSupervisorRuntimePanes -Manifest $script:task781PromotionManifest `
             -GenerationId 'generation-1' -ServerSessionId '$9' -ProcessResolver $script:task781PromotionProcessResolver)

--- a/tests/bridge/WorkerWorkspaceSandbox.Tests.ps1
+++ b/tests/bridge/WorkerWorkspaceSandbox.Tests.ps1
@@ -46,6 +46,7 @@ Describe 'TASK781 supervisor deferred runtime promotion' {
 
     It 'TASK-789 supervisor lease refresh does not rewrite registry panes from a snapshot' {
         $script:task781SupervisorContent | Should -Not -Match '-Panes @\(\$runtimeSnapshot\.panes\)'
+        $script:task781SupervisorContent | Should -Match 'Update-WinsmuxRuntimeRegistryLease'
     }
 
     It 'TASK781 C29 keeps deferred_starting deferred until its marker exists' {

--- a/winsmux-core/scripts/clm-safe-io.ps1
+++ b/winsmux-core/scripts/clm-safe-io.ps1
@@ -185,7 +185,8 @@ function Write-WinsmuxTextFile {
         [Parameter(Mandatory = $true)][string]$Path,
         [AllowEmptyString()][string]$Content = '',
         [AllowNull()][scriptblock]$ValidateLocked = $null,
-        [switch]$Append
+        [switch]$Append,
+        [switch]$AlreadyLocked
     )
 
     $parent = Split-Path -Parent $Path
@@ -194,7 +195,7 @@ function Write-WinsmuxTextFile {
     }
 
     $escapedPath = $Path -replace '"', '""'
-    Invoke-WinsmuxWithFileLock -Path $Path -Action {
+    $writeAction = {
         if ($null -ne $ValidateLocked) {
             & $ValidateLocked
         }
@@ -245,4 +246,11 @@ function Write-WinsmuxTextFile {
             }
         }
     }
+
+    if ($AlreadyLocked) {
+        & $writeAction
+        return
+    }
+
+    Invoke-WinsmuxWithFileLock -Path $Path -Action $writeAction
 }

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -999,6 +999,50 @@ function Ensure-DispatchTaskLiveWorkerPane {
     }
 }
 
+function New-WinsmuxArchivePaneIdleResult {
+    param(
+        [Parameter(Mandatory = $true)][bool]$Idle,
+        [Parameter(Mandatory = $true)][ValidateSet('idle', 'busy', 'unavailable')][string]$Evidence,
+        [AllowEmptyString()][string]$Status = '',
+        [AllowEmptyString()][string]$LastEvent = ''
+    )
+
+    return [pscustomobject]@{
+        Idle      = $Idle
+        Evidence  = $Evidence
+        Status    = $Status
+        LastEvent = $LastEvent
+    }
+}
+
+function Resolve-WinsmuxArchivePaneIdleState {
+    param([AllowNull()]$Result = $null)
+
+    if ($Result -is [bool]) {
+        return New-WinsmuxArchivePaneIdleResult -Idle ([bool]$Result) -Evidence $(if ($Result) { 'idle' } else { 'busy' })
+    }
+    if ($null -eq $Result) {
+        return New-WinsmuxArchivePaneIdleResult -Idle $false -Evidence 'unavailable'
+    }
+
+    $evidence = [string](Get-WinsmuxRuntimeValue -InputObject $Result -Name 'Evidence' -Default '')
+    $idle = $false
+    $idleRaw = Get-WinsmuxRuntimeValue -InputObject $Result -Name 'Idle' -Default $null
+    if ($idleRaw -is [bool]) {
+        $idle = [bool]$idleRaw
+    }
+    if ([string]::IsNullOrWhiteSpace($evidence)) {
+        $evidence = if ($idle) { 'idle' } else { 'unavailable' }
+    }
+    if ($evidence -cnotin @('idle', 'busy', 'unavailable')) {
+        $evidence = 'unavailable'
+        $idle = $false
+    }
+    return New-WinsmuxArchivePaneIdleResult -Idle $idle -Evidence $evidence `
+        -Status ([string](Get-WinsmuxRuntimeValue -InputObject $Result -Name 'Status' -Default '')) `
+        -LastEvent ([string](Get-WinsmuxRuntimeValue -InputObject $Result -Name 'LastEvent' -Default ''))
+}
+
 function Test-WinsmuxArchivePaneIdle {
     param(
         [AllowNull()]$Entry = $null,
@@ -1034,16 +1078,16 @@ function Test-WinsmuxArchivePaneIdle {
     $idleEvents = @('pane.idle', 'pane.completed', 'pane.ready')
     $busyEvents = @('pane.progress', 'pane.approval_waiting', 'pane.busy', 'pane.hung', 'pane.stalled')
     if ($busyEvents -contains $lastEvent) {
-        return $false
+        return New-WinsmuxArchivePaneIdleResult -Idle $false -Evidence 'busy' -Status $status -LastEvent $lastEvent
     }
     if ($idleEvents -contains $lastEvent) {
-        return $true
+        return New-WinsmuxArchivePaneIdleResult -Idle $true -Evidence 'idle' -Status $status -LastEvent $lastEvent
     }
     if ($status -in @('busy', 'approval_waiting', 'hung', 'stalled')) {
-        return $false
+        return New-WinsmuxArchivePaneIdleResult -Idle $false -Evidence 'busy' -Status $status -LastEvent $lastEvent
     }
     if ($status -in @('ready', 'waiting_for_dispatch', 'deferred_start', 'deferred_starting')) {
-        return $true
+        return New-WinsmuxArchivePaneIdleResult -Idle $true -Evidence 'idle' -Status $status -LastEvent $lastEvent
     }
 
     if (Get-Command Get-BridgeEventRecords -ErrorAction SilentlyContinue) {
@@ -1059,15 +1103,15 @@ function Test-WinsmuxArchivePaneIdle {
         if ($matching.Count -gt 0) {
             $eventName = [string]$matching[-1]['event']
             if ($busyEvents -contains $eventName) {
-                return $false
+                return New-WinsmuxArchivePaneIdleResult -Idle $false -Evidence 'busy' -Status $status -LastEvent $eventName
             }
             if ($idleEvents -contains $eventName) {
-                return $true
+                return New-WinsmuxArchivePaneIdleResult -Idle $true -Evidence 'idle' -Status $status -LastEvent $eventName
             }
         }
     }
 
-    return $true
+    return New-WinsmuxArchivePaneIdleResult -Idle $false -Evidence 'unavailable' -Status $status -LastEvent $lastEvent
 }
 
 function Get-WinsmuxArchivePaneRefusal {
@@ -1234,9 +1278,26 @@ function Invoke-WinsmuxArchivePaneCommand {
         exit 1
     }
 
-    $idle = Test-WinsmuxArchivePaneIdle -Entry $entry -ProjectDir $projectDir
+    $idleState = Resolve-WinsmuxArchivePaneIdleState -Result (Test-WinsmuxArchivePaneIdle -Entry $entry -ProjectDir $projectDir)
+    # Unknown/empty status with no recognized idle event is not interruptible busy.
+    if ($idleState.Evidence -ceq 'unavailable') {
+        $payload = [ordered]@{
+            ok          = $false
+            action      = 'archive-pane'
+            slot        = $slot
+            pane_id     = $paneId
+            reason_code = 'archive_idle_required'
+            diagnostic  = "archive-pane: idle evidence is unavailable for '$slot'; pane was left in place."
+        }
+        if ($json) {
+            $payload | ConvertTo-Json -Compress
+        } else {
+            Write-Output $payload.diagnostic
+        }
+        exit 1
+    }
     # Collect requires pane.idle (or equivalent idle status) after interrupt before kill-pane.
-    if (-not $idle) {
+    if (-not [bool]$idleState.Idle) {
         if (Get-Command Invoke-WinsmuxRaw -ErrorAction SilentlyContinue) {
             Invoke-WinsmuxRaw -Arguments @('keys', $paneId, 'C-c') | Out-Null
         } elseif (Get-Command Invoke-MonitorWinsmux -ErrorAction SilentlyContinue) {
@@ -1249,7 +1310,8 @@ function Invoke-WinsmuxArchivePaneCommand {
         for ($attempt = 1; $attempt -le 8; $attempt++) {
             Start-Sleep -Milliseconds 250
             $entry = Get-DispatchTaskManifestEntry -ProjectDir $projectDir -Label $slot
-            if (Test-WinsmuxArchivePaneIdle -Entry $entry -ProjectDir $projectDir) {
+            $waitState = Resolve-WinsmuxArchivePaneIdleState -Result (Test-WinsmuxArchivePaneIdle -Entry $entry -ProjectDir $projectDir)
+            if ([bool]$waitState.Idle -and $waitState.Evidence -ceq 'idle') {
                 $becameIdle = $true
                 break
             }

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -373,46 +373,112 @@ function Get-DispatchTaskLiveSpawnBudget {
     }
 }
 
-function Get-DispatchTaskCatalogSlotIds {
+function Get-DispatchTaskWinsmuxBin {
+    if (Get-Command Get-WinsmuxBin -ErrorAction SilentlyContinue) {
+        try {
+            return [string](Get-WinsmuxBin)
+        } catch {
+            return ''
+        }
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:WINSMUX_BIN) -and (Test-Path -LiteralPath $env:WINSMUX_BIN -PathType Leaf)) {
+        return [System.IO.Path]::GetFullPath($env:WINSMUX_BIN)
+    }
+    $repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    foreach ($candidatePath in @(
+            (Join-Path $repoRoot 'target\release\winsmux.exe'),
+            (Join-Path $repoRoot 'target\debug\winsmux.exe')
+        )) {
+        if (Test-Path -LiteralPath $candidatePath -PathType Leaf) {
+            return [System.IO.Path]::GetFullPath($candidatePath)
+        }
+    }
+    $command = Get-Command winsmux -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($null -ne $command -and -not [string]::IsNullOrWhiteSpace([string]$command.Source)) {
+        return [string]$command.Source
+    }
+    return ''
+}
+
+function Get-DispatchTaskResolvedTeamPayload {
     param([Parameter(Mandatory = $true)][string]$ProjectDir)
 
-    $settingsPath = Join-Path $ProjectDir '.winsmux.yaml'
-    if (-not (Test-Path -LiteralPath $settingsPath -PathType Leaf)) {
-        return @()
+    $bin = Get-DispatchTaskWinsmuxBin
+    if ([string]::IsNullOrWhiteSpace($bin)) {
+        return $null
     }
-    if (-not (Get-Command Get-BridgeSettings -ErrorAction SilentlyContinue)) {
-        return @()
+    $resolveArgs = @('team-profile', '--action', 'resolve', '--json', '--project-dir', $ProjectDir)
+    $output = $null
+    $code = 1
+    if (Get-Command Invoke-WinsmuxBridgeCommand -ErrorAction SilentlyContinue) {
+        $output = Invoke-WinsmuxBridgeCommand -WinsmuxBin $bin -Arguments $resolveArgs 2>&1
+        $code = $LASTEXITCODE
+    } else {
+        $output = & $bin @resolveArgs 2>&1
+        $code = $LASTEXITCODE
     }
-
-    $slots = @()
+    if ($code -ne 0) {
+        return $null
+    }
+    $text = ($output | Out-String).Trim()
+    if ([string]::IsNullOrWhiteSpace($text)) {
+        return $null
+    }
     try {
-        $settings = Get-BridgeSettings -RootPath $ProjectDir
-        if ($settings -is [System.Collections.IDictionary] -and $settings.Contains('agent_slots')) {
-            $slots = @($settings['agent_slots'])
-        } elseif ($null -ne $settings -and $null -ne $settings.PSObject -and $settings.PSObject.Properties.Name -contains 'agent_slots') {
-            $slots = @($settings.agent_slots)
-        }
+        return ($text | ConvertFrom-Json)
     } catch {
+        return $null
+    }
+}
+
+function Get-DispatchTaskResolvedTeamSlots {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $payload = Get-DispatchTaskResolvedTeamPayload -ProjectDir $ProjectDir
+    if ($null -eq $payload) {
         return @()
+    }
+    $okText = Get-DispatchTaskObjectText -InputObject $payload -Names @('ok')
+    if ([string]::Equals($okText, 'false', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return @()
+    }
+    $team = $null
+    if ($payload -is [System.Collections.IDictionary] -and $payload.Contains('team')) {
+        $team = $payload['team']
+    } elseif ($null -ne $payload.PSObject -and $payload.PSObject.Properties.Name -contains 'team') {
+        $team = $payload.team
+    }
+    if ($null -eq $team) {
+        return @()
+    }
+    $optedIn = Get-DispatchTaskObjectText -InputObject $team -Names @('opted_in', 'opted-in')
+    if ([string]::Equals($optedIn, 'false', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return @()
+    }
+    $slots = @()
+    if ($team -is [System.Collections.IDictionary] -and $team.Contains('slots')) {
+        $slots = @($team['slots'])
+    } elseif ($null -ne $team.PSObject -and $team.PSObject.Properties.Name -contains 'slots') {
+        $slots = @($team.slots)
     }
 
     $ids = New-Object System.Collections.Generic.List[string]
     $seen = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
     foreach ($slot in @($slots)) {
-        $slotId = Get-DispatchTaskObjectText -InputObject $slot -Names @('slot_id', 'SlotId', 'label', 'Label')
+        $slotId = Get-DispatchTaskObjectText -InputObject $slot -Names @('slot-id', 'slot_id', 'SlotId', 'label', 'Label')
         if ([string]::IsNullOrWhiteSpace($slotId)) {
             continue
         }
         $entry = [pscustomobject]@{
             Label      = $slotId
             Role       = (Get-DispatchTaskObjectText -InputObject $slot -Names @('role', 'Role'))
-            WorkerRole = (Get-DispatchTaskObjectText -InputObject $slot -Names @('worker_role', 'WorkerRole'))
-            AgentRole  = (Get-DispatchTaskObjectText -InputObject $slot -Names @('agent_role', 'AgentRole'))
+            WorkerRole = (Get-DispatchTaskObjectText -InputObject $slot -Names @('worker_role', 'WorkerRole', 'worker-role'))
+            AgentRole  = (Get-DispatchTaskObjectText -InputObject $slot -Names @('agent_role', 'AgentRole', 'agent-role'))
         }
         if (Test-DispatchTaskReviewerManifestEntry -Entry $entry) {
             continue
         }
-        $runtimeRole = Get-DispatchTaskObjectText -InputObject $slot -Names @('runtime_role', 'RuntimeRole')
+        $runtimeRole = Get-DispatchTaskObjectText -InputObject $slot -Names @('runtime_role', 'RuntimeRole', 'runtime-role')
         if (-not [string]::IsNullOrWhiteSpace($runtimeRole) -and
             -not [string]::Equals($runtimeRole, 'worker', [System.StringComparison]::OrdinalIgnoreCase)) {
             continue
@@ -421,8 +487,14 @@ function Get-DispatchTaskCatalogSlotIds {
             $ids.Add($slotId) | Out-Null
         }
     }
-
     return @($ids)
+}
+
+function Get-DispatchTaskCatalogSlotIds {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    # Team Profile resolve owns worker-1..6. YAML agent_slots is an overlay, not the catalog.
+    return @(Get-DispatchTaskResolvedTeamSlots -ProjectDir $ProjectDir)
 }
 
 function Get-DispatchTaskMissingCatalogSlotIds {

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -1108,6 +1108,42 @@ function Get-WinsmuxArchivePaneRefusal {
     return $null
 }
 
+function Get-WinsmuxArchivePaneRuntimeRefusal {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [AllowNull()]$Entry = $null
+    )
+
+    if (-not (Get-Command Test-PaneControlRuntimeContext -ErrorAction SilentlyContinue)) {
+        return [pscustomobject]@{
+            ReasonCode = 'runtime_target_mismatch'
+            Diagnostic = 'archive-pane: runtime ownership validation is unavailable.'
+        }
+    }
+
+    $runtimeResult = Test-PaneControlRuntimeContext -ProjectDir $ProjectDir -ManifestEntry $Entry -Operation stop_transition
+    if ($null -ne $runtimeResult -and [bool]$runtimeResult.valid) {
+        return $null
+    }
+
+    $reasonCode = 'runtime_target_mismatch'
+    $diagnostic = 'archive-pane: runtime ownership validation failed.'
+    if ($null -ne $runtimeResult) {
+        $candidateReason = [string](Get-WinsmuxRuntimeValue -InputObject $runtimeResult -Name 'reason_code' -Default '')
+        $candidateDiagnostic = [string](Get-WinsmuxRuntimeValue -InputObject $runtimeResult -Name 'diagnostic' -Default '')
+        if (-not [string]::IsNullOrWhiteSpace($candidateReason)) {
+            $reasonCode = $candidateReason
+        }
+        if (-not [string]::IsNullOrWhiteSpace($candidateDiagnostic)) {
+            $diagnostic = $candidateDiagnostic
+        }
+    }
+    return [pscustomobject]@{
+        ReasonCode = $reasonCode
+        Diagnostic = $diagnostic
+    }
+}
+
 function Invoke-WinsmuxArchivePaneCommand {
     param(
         [Parameter(Mandatory = $true)][string]$BridgeScriptRoot,
@@ -1171,6 +1207,24 @@ function Invoke-WinsmuxArchivePaneCommand {
             pane_id     = $paneId
             reason_code = [string]$refusal.ReasonCode
             diagnostic  = [string]$refusal.Diagnostic
+        }
+        if ($json) {
+            $payload | ConvertTo-Json -Compress
+        } else {
+            Write-Output $payload.diagnostic
+        }
+        exit 1
+    }
+
+    $runtimeRefusal = Get-WinsmuxArchivePaneRuntimeRefusal -ProjectDir $projectDir -Entry $entry
+    if ($null -ne $runtimeRefusal) {
+        $payload = [ordered]@{
+            ok          = $false
+            action      = 'archive-pane'
+            slot        = $slot
+            pane_id     = $paneId
+            reason_code = [string]$runtimeRefusal.ReasonCode
+            diagnostic  = [string]$runtimeRefusal.Diagnostic
         }
         if ($json) {
             $payload | ConvertTo-Json -Compress

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -1,3 +1,13 @@
+# Pane scaler helpers must land in this script's scope. Dot-sourcing
+# orchestra-start.ps1 / pane-scaler.ps1 inside a function would leave
+# Add-OrchestraPane / Remove-OrchestraPane defined only in that function.
+if (-not (Get-Command Get-OrchestraModeDocument -ErrorAction SilentlyContinue)) {
+    . (Join-Path $PSScriptRoot 'manifest.ps1')
+}
+if (-not (Get-Command Add-OrchestraPane -ErrorAction SilentlyContinue)) {
+    . (Join-Path $PSScriptRoot 'pane-scaler.ps1')
+}
+
 function Get-WinsmuxControlPlaneArguments {
     param(
         [AllowNull()][string]$CommandTarget,
@@ -820,16 +830,35 @@ function Invoke-WinsmuxAssignCommand {
 function Import-Task789OrchestraHelpers {
     param([switch]$IncludePaneScaler)
 
-    if (-not (Get-Command Get-OrchestraModeDocument -ErrorAction SilentlyContinue)) {
-        . (Join-Path $PSScriptRoot 'manifest.ps1')
+    # Manifest + pane-scaler are loaded at script scope above. Promoting
+    # Team Profile helpers here keeps New-TeamProfileSlotAgentConfig and
+    # Invoke-TeamProfileLaunchProjection available after this function returns.
+    if (-not $IncludePaneScaler) {
+        return
     }
-    if ($IncludePaneScaler) {
-        if (-not (Get-Command New-TeamProfileSlotAgentConfig -ErrorAction SilentlyContinue)) {
-            . (Join-Path $PSScriptRoot 'orchestra-start.ps1')
+    if (Get-Command New-TeamProfileSlotAgentConfig -ErrorAction SilentlyContinue) {
+        return
+    }
+
+    $orchestraStartPath = Join-Path $PSScriptRoot 'orchestra-start.ps1'
+    if (-not (Test-Path -LiteralPath $orchestraStartPath -PathType Leaf)) {
+        return
+    }
+
+    $before = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($name in @((Get-ChildItem -Path Function:).Name)) {
+        [void]$before.Add([string]$name)
+    }
+
+    # Bind RequestedRootPath so leftover CLI args cannot become the project dir.
+    . $orchestraStartPath -RequestedRootPath ''
+
+    foreach ($fn in @(Get-ChildItem -Path Function:)) {
+        $name = [string]$fn.Name
+        if ($before.Contains($name)) {
+            continue
         }
-        if (-not (Get-Command Add-OrchestraPane -ErrorAction SilentlyContinue)) {
-            . (Join-Path $PSScriptRoot 'pane-scaler.ps1')
-        }
+        Set-Item -LiteralPath ("Function:script:{0}" -f $name) -Value $fn.ScriptBlock
     }
 }
 
@@ -913,22 +942,50 @@ function Ensure-DispatchTaskLiveWorkerPane {
     if (Get-Command Get-BridgeSettings -ErrorAction SilentlyContinue) {
         $settings = Get-BridgeSettings -RootPath $ProjectDir
     }
+    if (-not (Get-Command Invoke-TeamProfileLaunchProjection -ErrorAction SilentlyContinue)) {
+        return [pscustomobject]@{
+            Spawned        = $false
+            ManifestEntry  = $null
+            ReasonCode     = 'team_profile_projection_unavailable'
+            Diagnostic     = "Team Profile launch projection is unavailable for slot '$Label'."
+        }
+    }
+
     $assignment = $null
-    if (Get-Command Invoke-TeamProfileLaunchProjection -ErrorAction SilentlyContinue) {
-        try {
-            $projection = Invoke-TeamProfileLaunchProjection -ProjectDir $ProjectDir -SessionId 'winsmux-orchestra' -SlotId $Label -Worktree '' -ReadWriteScope 'session'
-            if ($null -ne $projection -and $null -ne $projection.projection -and $null -ne $projection.projection.pane) {
-                $assignment = $projection.projection.pane.assignment
+    try {
+        $projection = Invoke-TeamProfileLaunchProjection -ProjectDir $ProjectDir -SessionId 'winsmux-orchestra' -SlotId $Label -Worktree '' -ReadWriteScope 'session' -Force
+        if ($null -ne $projection -and $null -ne $projection.projection -and $null -ne $projection.projection.pane) {
+            $assignment = $projection.projection.pane.assignment
+        }
+        if ($null -eq $assignment) {
+            return [pscustomobject]@{
+                Spawned        = $false
+                ManifestEntry  = $null
+                ReasonCode     = 'team_profile_projection_unavailable'
+                Diagnostic     = "Team Profile launch projection did not produce an assignment for slot '$Label'."
             }
-        } catch {
-            $assignment = $null
+        }
+    } catch {
+        return [pscustomobject]@{
+            Spawned        = $false
+            ManifestEntry  = $null
+            ReasonCode     = 'team_profile_projection_unavailable'
+            Diagnostic     = [string]$_.Exception.Message
         }
     }
 
     $slotAgentConfig = $null
-    if ($null -ne $assignment -and (Get-Command New-TeamProfileSlotAgentConfig -ErrorAction SilentlyContinue)) {
+    if (Get-Command New-TeamProfileSlotAgentConfig -ErrorAction SilentlyContinue) {
         # Spawn uses Team Profile assignment.worker_backend via New-TeamProfileSlotAgentConfig.
         $slotAgentConfig = New-TeamProfileSlotAgentConfig -Role 'Worker' -SlotId $Label -Assignment $assignment -Settings $settings -RootPath $ProjectDir
+    }
+    if ($null -eq $slotAgentConfig) {
+        return [pscustomobject]@{
+            Spawned        = $false
+            ManifestEntry  = $null
+            ReasonCode     = 'team_profile_projection_unavailable'
+            Diagnostic     = "Team Profile slot agent config is unavailable for slot '$Label'."
+        }
     }
 
     $manifestPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'manifest.yaml'
@@ -1013,6 +1070,44 @@ function Test-WinsmuxArchivePaneIdle {
     return $true
 }
 
+function Get-WinsmuxArchivePaneRefusal {
+    param(
+        [AllowNull()]$Entry = $null,
+        [Parameter(Mandatory = $true)][string]$Label,
+        [AllowNull()]$Manifest = $null
+    )
+
+    $paneId = Get-DispatchTaskEntryPaneId -Entry $Entry
+    if ($null -eq $Entry -or [string]::IsNullOrWhiteSpace($paneId)) {
+        return [pscustomobject]@{
+            ReasonCode = 'pane_not_live'
+            Diagnostic = "archive-pane: slot '$Label' has no live pane."
+        }
+    }
+
+    $role = ''
+    if (Get-Command Get-OrchestraCanonicalPaneRole -ErrorAction SilentlyContinue) {
+        $role = [string](Get-OrchestraCanonicalPaneRole -Pane $Entry -Label $Label)
+    }
+    if ($role -cne 'Worker') {
+        return [pscustomobject]@{
+            ReasonCode = 'archive_role_not_worker'
+            Diagnostic = "archive-pane: slot '$Label' is not a Worker pane."
+        }
+    }
+
+    if (Get-Command Test-OrchestraArchiveRemovesLastRequiredWorker -ErrorAction SilentlyContinue) {
+        if (Test-OrchestraArchiveRemovesLastRequiredWorker -Manifest $Manifest -Label $Label) {
+            return [pscustomobject]@{
+                ReasonCode = 'last_required_worker'
+                Diagnostic = "archive-pane: refusing to archive the last required worker pane '$Label'."
+            }
+        }
+    }
+
+    return $null
+}
+
 function Invoke-WinsmuxArchivePaneCommand {
     param(
         [Parameter(Mandatory = $true)][string]$BridgeScriptRoot,
@@ -1058,13 +1153,24 @@ function Invoke-WinsmuxArchivePaneCommand {
     Import-Task789OrchestraHelpers -IncludePaneScaler
     $entry = Get-DispatchTaskManifestEntry -ProjectDir $projectDir -Label $slot
     $paneId = Get-DispatchTaskEntryPaneId -Entry $entry
-    if ($null -eq $entry -or [string]::IsNullOrWhiteSpace($paneId)) {
+    $manifestPath = Join-Path (Join-Path $projectDir '.winsmux') 'manifest.yaml'
+    $manifest = $null
+    if (Get-Command Read-PaneScalerManifest -ErrorAction SilentlyContinue -and (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+        try {
+            $manifest = Read-PaneScalerManifest -ManifestPath $manifestPath
+        } catch {
+            $manifest = $null
+        }
+    }
+    $refusal = Get-WinsmuxArchivePaneRefusal -Entry $entry -Label $slot -Manifest $manifest
+    if ($null -ne $refusal) {
         $payload = [ordered]@{
             ok          = $false
             action      = 'archive-pane'
             slot        = $slot
-            reason_code = 'pane_not_live'
-            diagnostic  = "archive-pane: slot '$slot' has no live pane."
+            pane_id     = $paneId
+            reason_code = [string]$refusal.ReasonCode
+            diagnostic  = [string]$refusal.Diagnostic
         }
         if ($json) {
             $payload | ConvertTo-Json -Compress
@@ -1112,7 +1218,6 @@ function Invoke-WinsmuxArchivePaneCommand {
         }
     }
 
-    $manifestPath = Join-Path (Join-Path $projectDir '.winsmux') 'manifest.yaml'
     $removed = Remove-OrchestraPane -ManifestPath $manifestPath -Role 'Worker' -Label $slot
     $payload = [ordered]@{
         ok          = [bool]$removed.Changed

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -1080,15 +1080,6 @@ function Test-WinsmuxArchivePaneIdle {
     if ($busyEvents -contains $lastEvent) {
         return New-WinsmuxArchivePaneIdleResult -Idle $false -Evidence 'busy' -Status $status -LastEvent $lastEvent
     }
-    if ($idleEvents -contains $lastEvent) {
-        return New-WinsmuxArchivePaneIdleResult -Idle $true -Evidence 'idle' -Status $status -LastEvent $lastEvent
-    }
-    if ($status -in @('busy', 'approval_waiting', 'hung', 'stalled')) {
-        return New-WinsmuxArchivePaneIdleResult -Idle $false -Evidence 'busy' -Status $status -LastEvent $lastEvent
-    }
-    if ($status -in @('ready', 'waiting_for_dispatch', 'deferred_start', 'deferred_starting')) {
-        return New-WinsmuxArchivePaneIdleResult -Idle $true -Evidence 'idle' -Status $status -LastEvent $lastEvent
-    }
 
     if (Get-Command Get-BridgeEventRecords -ErrorAction SilentlyContinue) {
         $events = @(Get-BridgeEventRecords -ProjectDir $ProjectDir)
@@ -1109,6 +1100,16 @@ function Test-WinsmuxArchivePaneIdle {
                 return New-WinsmuxArchivePaneIdleResult -Idle $true -Evidence 'idle' -Status $status -LastEvent $eventName
             }
         }
+    }
+
+    if ($idleEvents -contains $lastEvent) {
+        return New-WinsmuxArchivePaneIdleResult -Idle $true -Evidence 'idle' -Status $status -LastEvent $lastEvent
+    }
+    if ($status -in @('busy', 'approval_waiting', 'hung', 'stalled')) {
+        return New-WinsmuxArchivePaneIdleResult -Idle $false -Evidence 'busy' -Status $status -LastEvent $lastEvent
+    }
+    if ($status -in @('ready', 'waiting_for_dispatch', 'deferred_start', 'deferred_starting')) {
+        return New-WinsmuxArchivePaneIdleResult -Idle $true -Evidence 'idle' -Status $status -LastEvent $lastEvent
     }
 
     return New-WinsmuxArchivePaneIdleResult -Idle $false -Evidence 'unavailable' -Status $status -LastEvent $lastEvent

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -232,7 +232,6 @@ function Test-DispatchTaskReviewerManifestEntry {
 function Get-DispatchTaskAvailableTargets {
     param([Parameter(Mandatory = $true)][string]$ProjectDir)
 
-    Import-Task789OrchestraHelpers
     $availableTargets = @()
     $manifestTargetsResolved = $false
     if (Get-Command Get-PaneControlManifestEntries -ErrorAction SilentlyContinue) {
@@ -253,38 +252,6 @@ function Get-DispatchTaskAvailableTargets {
     }
     if (-not $manifestTargetsResolved -and $availableTargets.Count -eq 0) {
         $availableTargets = @((Get-Labels).Keys | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
-    }
-
-    if (Get-Command Get-OrchestraModeDocument -ErrorAction SilentlyContinue) {
-        $mode = ''
-        try {
-            $mode = [string](Get-OrchestraModeDocument -ProjectDir $ProjectDir).mode
-        } catch {
-            $mode = ''
-        }
-        if ($mode -ceq 'team' -and (Get-Command Get-BridgeSettings -ErrorAction SilentlyContinue)) {
-            try {
-                $settings = Get-BridgeSettings -RootPath $ProjectDir
-                $slots = @()
-                if ($settings -is [System.Collections.IDictionary] -and $settings.Contains('agent_slots')) {
-                    $slots = @($settings.agent_slots)
-                } elseif ($null -ne $settings -and $null -ne $settings.PSObject -and $settings.PSObject.Properties.Name -contains 'agent_slots') {
-                    $slots = @($settings.agent_slots)
-                }
-                foreach ($slot in $slots) {
-                    $slotId = ''
-                    if ($slot -is [System.Collections.IDictionary] -and $slot.Contains('slot_id')) {
-                        $slotId = [string]$slot['slot_id']
-                    } elseif ($null -ne $slot -and $null -ne $slot.PSObject -and $slot.PSObject.Properties.Name -contains 'slot_id') {
-                        $slotId = [string]$slot.slot_id
-                    }
-                    if (-not [string]::IsNullOrWhiteSpace($slotId) -and $availableTargets -notcontains $slotId) {
-                        $availableTargets += $slotId
-                    }
-                }
-            } catch {
-            }
-        }
     }
 
     return @($availableTargets)

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -1561,6 +1561,42 @@ function Test-WinsmuxArchivePaneIdle {
     return New-WinsmuxArchivePaneIdleResult -Idle $false -Evidence 'unavailable' -Status $status -LastEvent $lastEvent
 }
 
+function Get-WinsmuxArchivePaneReadinessAgent {
+    param([AllowNull()]$Entry = $null)
+
+    $adapter = Get-DispatchTaskObjectText -InputObject $Entry -Names @('CapabilityAdapter', 'capability_adapter')
+    if (-not [string]::IsNullOrWhiteSpace($adapter)) {
+        return $adapter
+    }
+
+    $approved = $null
+    if ($null -ne $Entry) {
+        if (Get-Command Get-WinsmuxRuntimeValue -ErrorAction SilentlyContinue) {
+            $approved = Get-WinsmuxRuntimeValue -InputObject $Entry -Name 'ApprovedLaunch' -Default $null
+            if ($null -eq $approved) {
+                $approved = Get-WinsmuxRuntimeValue -InputObject $Entry -Name 'approved_launch' -Default $null
+            }
+        } elseif ($null -ne $Entry.PSObject) {
+            if ($Entry.PSObject.Properties.Name -contains 'ApprovedLaunch') {
+                $approved = $Entry.ApprovedLaunch
+            } elseif ($Entry.PSObject.Properties.Name -contains 'approved_launch') {
+                $approved = $Entry.approved_launch
+            }
+        }
+    }
+
+    $agent = Get-DispatchTaskObjectText -InputObject $approved -Names @('agent', 'Agent')
+    if (-not [string]::IsNullOrWhiteSpace($agent)) {
+        return $agent
+    }
+
+    if (Get-Command Get-PaneScalerReadinessAgent -ErrorAction SilentlyContinue) {
+        return [string](Get-PaneScalerReadinessAgent -SlotAgentConfig $Entry -FallbackAgent '')
+    }
+
+    return Get-DispatchTaskObjectText -InputObject $Entry -Names @('Agent', 'agent')
+}
+
 function Get-WinsmuxArchivePaneRefusal {
     param(
         [AllowNull()]$Entry = $null,
@@ -1754,12 +1790,13 @@ function Invoke-WinsmuxArchivePaneCommand {
         }
 
         $becameIdle = $false
+        $readinessAgent = Get-WinsmuxArchivePaneReadinessAgent -Entry $entry
         for ($attempt = 1; $attempt -le 8; $attempt++) {
             Start-Sleep -Milliseconds 250
             if (Get-Command Get-PaneAgentStatus -ErrorAction SilentlyContinue) {
                 $liveStatus = ''
                 try {
-                    $live = Get-PaneAgentStatus -PaneId $paneId -Role 'Worker'
+                    $live = Get-PaneAgentStatus -PaneId $paneId -Role 'Worker' -Agent $readinessAgent
                     $liveStatus = [string](Get-WinsmuxRuntimeValue -InputObject $live -Name 'Status' -Default '')
                 } catch {
                     $liveStatus = ''

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -14,11 +14,40 @@ function Get-WinsmuxControlPlaneArguments {
         [AllowNull()][string[]]$CommandRest
     )
 
-    return @(@($CommandTarget) + @($CommandRest) | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) })
+    $items = [System.Collections.Generic.List[string]]::new()
+    foreach ($part in @(@($CommandTarget) + @($CommandRest))) {
+        if ([string]::IsNullOrWhiteSpace([string]$part)) {
+            continue
+        }
+        $items.Add([string]$part)
+    }
+    return $items
+}
+
+function ConvertTo-WinsmuxControlPlaneArgumentList {
+    param([AllowNull()]$Value)
+
+    $items = [System.Collections.Generic.List[string]]::new()
+    if ($null -eq $Value) {
+        return , $items
+    }
+    if ($Value -is [string]) {
+        if (-not [string]::IsNullOrWhiteSpace($Value)) {
+            $items.Add($Value)
+        }
+        return , $items
+    }
+    foreach ($part in $Value) {
+        if ([string]::IsNullOrWhiteSpace([string]$part)) {
+            continue
+        }
+        $items.Add([string]$part)
+    }
+    return , $items
 }
 
 function Split-WinsmuxDispatchTaskArguments {
-    param([AllowNull()][string[]]$Parts)
+    param([AllowNull()]$Parts)
 
     $slotId = ''
     $taskClass = ''
@@ -26,7 +55,16 @@ function Split-WinsmuxDispatchTaskArguments {
     $projectDir = ''
     $textParts = New-Object System.Collections.Generic.List[string]
     $index = 0
-    $items = @($Parts)
+    $items = [System.Collections.Generic.List[string]]::new()
+    if ($null -ne $Parts) {
+        if ($Parts -is [string]) {
+            $items.Add([string]$Parts)
+        } else {
+            foreach ($part in $Parts) {
+                $items.Add([string]$part)
+            }
+        }
+    }
     while ($index -lt $items.Count) {
         $current = [string]$items[$index]
         if ($current -ceq '--') {
@@ -69,14 +107,26 @@ function Split-WinsmuxDispatchTaskArguments {
 }
 
 function Join-WinsmuxControlPlaneText {
-    param([AllowNull()][object[]]$Arguments)
+    param([AllowNull()]$Arguments)
 
-    return (@(
-        @($Arguments) |
-            Where-Object { $_ } |
-            ForEach-Object { ([string]$_).Trim() } |
-            Where-Object { $_ }
-    ) -join ' ')
+    $parts = [System.Collections.Generic.List[string]]::new()
+    if ($null -eq $Arguments) {
+        return ''
+    }
+    if ($Arguments -is [string]) {
+        $text = $Arguments.Trim()
+        if ($text) {
+            $parts.Add($text)
+        }
+        return ($parts -join ' ')
+    }
+    foreach ($arg in $Arguments) {
+        $text = ([string]$arg).Trim()
+        if ($text) {
+            $parts.Add($text)
+        }
+    }
+    return ($parts -join ' ')
 }
 
 function Get-WinsmuxControlPlaneScriptPath {
@@ -112,7 +162,9 @@ function Invoke-WinsmuxGithubPreflightCommand {
     )
 
     $preflightArgs = @()
-    $remaining = Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest
+    $remaining = ConvertTo-WinsmuxControlPlaneArgumentList -Value (
+            Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest
+        )
     for ($index = 0; $index -lt $remaining.Count; $index++) {
         switch ($remaining[$index]) {
             '--repo' {
@@ -812,7 +864,9 @@ function Invoke-WinsmuxOrchestraSmokeCommand {
     )
 
     $smokeArgs = @()
-    $remaining = Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest
+    $remaining = ConvertTo-WinsmuxControlPlaneArgumentList -Value (
+            Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest
+        )
     for ($index = 0; $index -lt $remaining.Count; $index++) {
         switch ($remaining[$index]) {
             '--json' { $smokeArgs += '-AsJson' }
@@ -843,7 +897,9 @@ function Invoke-WinsmuxOrchestraAttachCommand {
     )
 
     $attachArgs = @()
-    $remaining = Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest
+    $remaining = ConvertTo-WinsmuxControlPlaneArgumentList -Value (
+            Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest
+        )
     for ($index = 0; $index -lt $remaining.Count; $index++) {
         switch ($remaining[$index]) {
             '--json' { $attachArgs += '-AsJson' }
@@ -873,7 +929,9 @@ function Invoke-WinsmuxHarnessCheckCommand {
     )
 
     $checkArgs = @()
-    $remaining = Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest
+    $remaining = ConvertTo-WinsmuxControlPlaneArgumentList -Value (
+            Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest
+        )
     for ($index = 0; $index -lt $remaining.Count; $index++) {
         switch ($remaining[$index]) {
             '--json' { $checkArgs += '-AsJson' }
@@ -903,7 +961,9 @@ function Invoke-WinsmuxShadowCutoverGateCommand {
         [AllowNull()][string[]]$CommandRest
     )
 
-    $remaining = Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest
+    $remaining = ConvertTo-WinsmuxControlPlaneArgumentList -Value (
+            Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest
+        )
     $expectedPath = ''
     $actualPath = ''
     $surface = 'unspecified'
@@ -960,7 +1020,9 @@ function Invoke-WinsmuxPowerShellDeescalationCommand {
     )
 
     $contractArgs = @()
-    $remaining = Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest
+    $remaining = ConvertTo-WinsmuxControlPlaneArgumentList -Value (
+            Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest
+        )
     foreach ($argument in $remaining) {
         switch ($argument) {
             '--json' { $contractArgs += '-AsJson' }
@@ -983,7 +1045,9 @@ function Invoke-WinsmuxAssignCommand {
     )
 
     $assignArgs = @()
-    $remaining = Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest
+    $remaining = ConvertTo-WinsmuxControlPlaneArgumentList -Value (
+            Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest
+        )
     for ($index = 0; $index -lt $remaining.Count; $index++) {
         switch ($remaining[$index]) {
             '--task' {
@@ -1067,6 +1131,43 @@ function Get-DispatchTaskEntryPaneId {
     return ''
 }
 
+function Test-DispatchTaskLiveFileBytesEqual {
+    param($Before, $After)
+    if ($null -eq $Before -and $null -eq $After) {
+        return $true
+    }
+    if ($null -eq $Before -or $null -eq $After) {
+        return $false
+    }
+    if ($Before.Length -ne $After.Length) {
+        return $false
+    }
+    for ($i = 0; $i -lt $Before.Length; $i++) {
+        if ($Before[$i] -ne $After[$i]) {
+            return $false
+        }
+    }
+    return $true
+}
+
+function Restore-DispatchTaskLiveFileBytes {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        $Bytes
+    )
+    if ($null -eq $Bytes) {
+        if (Test-Path -LiteralPath $Path) {
+            Remove-Item -LiteralPath $Path -Force
+        }
+        return
+    }
+    $parent = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrWhiteSpace($parent) -and -not (Test-Path -LiteralPath $parent)) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+    [System.IO.File]::WriteAllBytes($Path, $Bytes)
+}
+
 function Ensure-DispatchTaskLiveWorkerPane {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -1139,12 +1240,54 @@ function Ensure-DispatchTaskLiveWorkerPane {
         }
     }
 
+    $liveManifestPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'manifest.yaml'
+    $liveRegistryPath = $null
+    if (Get-Command Get-WinsmuxRuntimeRegistryPath -ErrorAction SilentlyContinue) {
+        $liveRegistryPath = Get-WinsmuxRuntimeRegistryPath -ProjectDir $ProjectDir
+    } else {
+        $liveRegistryPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'runtime\registry.json'
+    }
+    $beforeManifest = $null
+    $beforeRegistry = $null
+    if (Test-Path -LiteralPath $liveManifestPath -PathType Leaf) {
+        $beforeManifest = [System.IO.File]::ReadAllBytes($liveManifestPath)
+    }
+    if (-not [string]::IsNullOrWhiteSpace([string]$liveRegistryPath) -and (Test-Path -LiteralPath $liveRegistryPath -PathType Leaf)) {
+        $beforeRegistry = [System.IO.File]::ReadAllBytes($liveRegistryPath)
+    }
+
     $assignment = $null
     try {
         $projection = Invoke-TeamProfileLaunchProjection -ProjectDir $ProjectDir -SessionId 'winsmux-orchestra' -SlotId $Label -Worktree '' -ReadWriteScope 'session' -Force
-        if ($null -ne $projection -and $null -ne $projection.projection -and $null -ne $projection.projection.pane) {
-            $assignment = $projection.projection.pane.assignment
+        $afterManifest = $null
+        $afterRegistry = $null
+        if (Test-Path -LiteralPath $liveManifestPath -PathType Leaf) {
+            $afterManifest = [System.IO.File]::ReadAllBytes($liveManifestPath)
         }
+        if (-not [string]::IsNullOrWhiteSpace([string]$liveRegistryPath) -and (Test-Path -LiteralPath $liveRegistryPath -PathType Leaf)) {
+            $afterRegistry = [System.IO.File]::ReadAllBytes($liveRegistryPath)
+        }
+        $manifestMutated = -not (Test-DispatchTaskLiveFileBytesEqual -Before $beforeManifest -After $afterManifest)
+        $registryMutated = -not (Test-DispatchTaskLiveFileBytesEqual -Before $beforeRegistry -After $afterRegistry)
+        if ($manifestMutated -or $registryMutated) {
+            Restore-DispatchTaskLiveFileBytes -Path $liveManifestPath -Bytes $beforeManifest
+            if (-not [string]::IsNullOrWhiteSpace([string]$liveRegistryPath)) {
+                Restore-DispatchTaskLiveFileBytes -Path $liveRegistryPath -Bytes $beforeRegistry
+            }
+            return [pscustomobject]@{
+                Spawned        = $false
+                ManifestEntry  = $null
+                ReasonCode     = 'team_profile_projection_mutated_live_manifest'
+                Diagnostic     = "Team Profile launch projection mutated live pane-set files for slot '$Label'."
+            }
+        }
+        $projRoot = $projection
+        $nestedProjection = Get-WinsmuxRuntimeValue -InputObject $projection -Name 'projection'
+        if ($null -ne $nestedProjection) {
+            $projRoot = $nestedProjection
+        }
+        $projectedPane = Get-WinsmuxRuntimeValue -InputObject $projRoot -Name 'pane'
+        $assignment = Get-WinsmuxRuntimeValue -InputObject $projectedPane -Name 'assignment'
         if ($null -eq $assignment) {
             return [pscustomobject]@{
                 Spawned        = $false
@@ -1154,6 +1297,10 @@ function Ensure-DispatchTaskLiveWorkerPane {
             }
         }
     } catch {
+        Restore-DispatchTaskLiveFileBytes -Path $liveManifestPath -Bytes $beforeManifest
+        if (-not [string]::IsNullOrWhiteSpace([string]$liveRegistryPath)) {
+            Restore-DispatchTaskLiveFileBytes -Path $liveRegistryPath -Bytes $beforeRegistry
+        }
         return [pscustomobject]@{
             Spawned        = $false
             ManifestEntry  = $null
@@ -1498,6 +1645,19 @@ function Invoke-WinsmuxArchivePaneCommand {
         $becameIdle = $false
         for ($attempt = 1; $attempt -le 8; $attempt++) {
             Start-Sleep -Milliseconds 250
+            if (Get-Command Get-PaneAgentStatus -ErrorAction SilentlyContinue) {
+                $liveStatus = ''
+                try {
+                    $live = Get-PaneAgentStatus -PaneId $paneId -Role 'Worker'
+                    $liveStatus = [string](Get-WinsmuxRuntimeValue -InputObject $live -Name 'Status' -Default '')
+                } catch {
+                    $liveStatus = ''
+                }
+                if ($liveStatus -in @('ready', 'waiting_for_dispatch')) {
+                    $becameIdle = $true
+                    break
+                }
+            }
             $entry = Get-DispatchTaskManifestEntry -ProjectDir $projectDir -Label $slot
             $waitState = Resolve-WinsmuxArchivePaneIdleState -Result (Test-WinsmuxArchivePaneIdle -Entry $entry -ProjectDir $projectDir)
             if ([bool]$waitState.Idle -and $waitState.Evidence -ceq 'idle') {

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -14,7 +14,7 @@ function Get-WinsmuxControlPlaneArguments {
         [AllowNull()][string[]]$CommandRest
     )
 
-    return ,@(@($CommandTarget) + @($CommandRest) | Where-Object { $_ })
+    return @(@($CommandTarget) + @($CommandRest) | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) })
 }
 
 function Split-WinsmuxDispatchTaskArguments {
@@ -221,6 +221,41 @@ function Get-DispatchTaskManifestEntry {
     return $null
 }
 
+function Get-DispatchTaskObjectText {
+    param(
+        [AllowNull()]$InputObject = $null,
+        [Parameter(Mandatory = $true)][string[]]$Names,
+        [AllowEmptyString()][string]$Default = ''
+    )
+
+    if ($null -eq $InputObject) {
+        return $Default
+    }
+
+    foreach ($name in @($Names)) {
+        if ([string]::IsNullOrWhiteSpace($name)) {
+            continue
+        }
+        $value = $null
+        if ($InputObject -is [System.Collections.IDictionary]) {
+            if ($InputObject.Contains($name)) {
+                $value = $InputObject[$name]
+            }
+        } elseif ($null -ne $InputObject.PSObject -and $InputObject.PSObject.Properties.Name -contains $name) {
+            $value = $InputObject.PSObject.Properties[$name].Value
+        }
+        if ($null -eq $value) {
+            continue
+        }
+        $text = [string]$value
+        if (-not [string]::IsNullOrWhiteSpace($text)) {
+            return $text
+        }
+    }
+
+    return $Default
+}
+
 function Test-DispatchTaskReviewerManifestEntry {
     param([AllowNull()]$Entry = $null)
 
@@ -228,15 +263,127 @@ function Test-DispatchTaskReviewerManifestEntry {
         return $false
     }
 
-    $role = [string](Get-SendConfigValue -InputObject $Entry -Name 'Role' -Default '')
-    $workerRole = [string](Get-SendConfigValue -InputObject $Entry -Name 'WorkerRole' -Default '')
-    $agentRole = [string](Get-SendConfigValue -InputObject $Entry -Name 'AgentRole' -Default '')
+    $role = Get-DispatchTaskObjectText -InputObject $Entry -Names @('Role', 'role')
+    $workerRole = Get-DispatchTaskObjectText -InputObject $Entry -Names @('WorkerRole', 'worker_role')
+    $agentRole = Get-DispatchTaskObjectText -InputObject $Entry -Names @('AgentRole', 'agent_role')
 
     return (
         [string]::Equals($role, 'Reviewer', [System.StringComparison]::OrdinalIgnoreCase) -or
         [string]::Equals($workerRole, 'reviewer', [System.StringComparison]::OrdinalIgnoreCase) -or
         [string]::Equals($agentRole, 'reviewer', [System.StringComparison]::OrdinalIgnoreCase)
     )
+}
+
+function Get-DispatchTaskLiveSpawnBudget {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $mode = 'team'
+    if (Get-Command Get-OrchestraModeDocument -ErrorAction SilentlyContinue) {
+        try {
+            $mode = [string](Get-OrchestraModeDocument -ProjectDir $ProjectDir).mode
+        } catch {
+            return [pscustomobject]@{
+                Mode        = ''
+                LiveWorkers = 0
+                MaxLive     = 0
+                Allowed     = $false
+            }
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($mode)) {
+        $mode = 'team'
+    }
+
+    $maxLive = 6
+    if (Get-Command Get-OrchestraMaxLiveWorkerPaneCount -ErrorAction SilentlyContinue) {
+        $maxLive = [int](Get-OrchestraMaxLiveWorkerPaneCount -Mode $mode)
+    } elseif ($mode -ceq 'simple') {
+        $maxLive = 1
+    }
+
+    $liveWorkers = 0
+    $hasManifestReader = [bool](Get-Command Get-WinsmuxManifest -ErrorAction SilentlyContinue)
+    $hasLiveWorkerCounter = [bool](Get-Command Get-OrchestraLiveWorkerRolePaneCount -ErrorAction SilentlyContinue)
+    if ($hasManifestReader -and $hasLiveWorkerCounter) {
+        try {
+            $manifest = Get-WinsmuxManifest -ProjectDir $ProjectDir
+            $liveWorkers = [int](Get-OrchestraLiveWorkerRolePaneCount -Manifest $manifest)
+        } catch {
+            $liveWorkers = 0
+        }
+    }
+
+    return [pscustomobject]@{
+        Mode        = $mode
+        LiveWorkers = $liveWorkers
+        MaxLive     = $maxLive
+        Allowed     = ($liveWorkers -lt $maxLive)
+    }
+}
+
+function Get-DispatchTaskCatalogSlotIds {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $settingsPath = Join-Path $ProjectDir '.winsmux.yaml'
+    if (-not (Test-Path -LiteralPath $settingsPath -PathType Leaf)) {
+        return @()
+    }
+    if (-not (Get-Command Get-BridgeSettings -ErrorAction SilentlyContinue)) {
+        return @()
+    }
+
+    $slots = @()
+    try {
+        $settings = Get-BridgeSettings -RootPath $ProjectDir
+        if ($settings -is [System.Collections.IDictionary] -and $settings.Contains('agent_slots')) {
+            $slots = @($settings['agent_slots'])
+        } elseif ($null -ne $settings -and $null -ne $settings.PSObject -and $settings.PSObject.Properties.Name -contains 'agent_slots') {
+            $slots = @($settings.agent_slots)
+        }
+    } catch {
+        return @()
+    }
+
+    $ids = New-Object System.Collections.Generic.List[string]
+    $seen = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($slot in @($slots)) {
+        $slotId = Get-DispatchTaskObjectText -InputObject $slot -Names @('slot_id', 'SlotId', 'label', 'Label')
+        if ([string]::IsNullOrWhiteSpace($slotId)) {
+            continue
+        }
+        $entry = [pscustomobject]@{
+            Label      = $slotId
+            Role       = (Get-DispatchTaskObjectText -InputObject $slot -Names @('role', 'Role'))
+            WorkerRole = (Get-DispatchTaskObjectText -InputObject $slot -Names @('worker_role', 'WorkerRole'))
+            AgentRole  = (Get-DispatchTaskObjectText -InputObject $slot -Names @('agent_role', 'AgentRole'))
+        }
+        if (Test-DispatchTaskReviewerManifestEntry -Entry $entry) {
+            continue
+        }
+        $runtimeRole = Get-DispatchTaskObjectText -InputObject $slot -Names @('runtime_role', 'RuntimeRole')
+        if (-not [string]::IsNullOrWhiteSpace($runtimeRole) -and
+            -not [string]::Equals($runtimeRole, 'worker', [System.StringComparison]::OrdinalIgnoreCase)) {
+            continue
+        }
+        if ($seen.Add($slotId)) {
+            $ids.Add($slotId) | Out-Null
+        }
+    }
+
+    return @($ids)
+}
+
+function Get-DispatchTaskMissingCatalogSlotIds {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $missing = New-Object System.Collections.Generic.List[string]
+    foreach ($slotId in @(Get-DispatchTaskCatalogSlotIds -ProjectDir $ProjectDir)) {
+        $entry = Get-DispatchTaskManifestEntry -ProjectDir $ProjectDir -Label $slotId
+        if ([string]::IsNullOrWhiteSpace((Get-DispatchTaskEntryPaneId -Entry $entry))) {
+            $missing.Add($slotId) | Out-Null
+        }
+    }
+    return @($missing)
 }
 
 function Get-DispatchTaskAvailableTargets {
@@ -262,6 +409,21 @@ function Get-DispatchTaskAvailableTargets {
     }
     if (-not $manifestTargetsResolved -and $availableTargets.Count -eq 0) {
         $availableTargets = @((Get-Labels).Keys | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+
+    $budget = Get-DispatchTaskLiveSpawnBudget -ProjectDir $ProjectDir
+    if (-not [bool]$budget.Allowed) {
+        return @($availableTargets)
+    }
+
+    $seen = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($label in @($availableTargets)) {
+        [void]$seen.Add([string]$label)
+    }
+    foreach ($slotId in @(Get-DispatchTaskMissingCatalogSlotIds -ProjectDir $ProjectDir)) {
+        if ($seen.Add($slotId)) {
+            $availableTargets += $slotId
+        }
     }
 
     return @($availableTargets)
@@ -303,9 +465,11 @@ function Invoke-WinsmuxDispatchTaskCommand {
     $paneId = ''
     $resolvedRole = 'Worker'
     $classifiedSlotId = [string]$parsed.SlotId
+    $route = $null
     if (-not [string]::IsNullOrWhiteSpace($classifiedSlotId)) {
         $selectedLabel = $classifiedSlotId
         $resolvedRole = 'Worker'
+        $route = Get-DispatchRoute -Text $taskText -AvailableTargets @($classifiedSlotId) -DefaultRole 'Worker'
     } else {
         $route = Get-DispatchRoute -Text $taskText -AvailableTargets $availableTargets -DefaultRole 'Worker'
         if ($route.HandleLocally) {
@@ -316,6 +480,29 @@ function Invoke-WinsmuxDispatchTaskCommand {
 
         $selectedLabel = [string]$route.SelectedTarget
         $resolvedRole = [string]$route.SelectedRole
+        if ($resolvedRole -ne 'Reviewer' -and $resolvedRole -ne 'Operator') {
+            $budget = Get-DispatchTaskLiveSpawnBudget -ProjectDir $projectDir
+            $missingSlots = @(Get-DispatchTaskMissingCatalogSlotIds -ProjectDir $projectDir)
+            if ([bool]$budget.Allowed -and $missingSlots.Count -gt 0) {
+                $selectedIsMissing = $false
+                foreach ($missingId in $missingSlots) {
+                    if ([string]::Equals([string]$missingId, $selectedLabel, [System.StringComparison]::OrdinalIgnoreCase)) {
+                        $selectedIsMissing = $true
+                        break
+                    }
+                }
+                if (-not $selectedIsMissing) {
+                    $preferredMissing = Get-DispatchRouterPreferredLabel -Role 'Worker' -AvailableTargets $missingSlots
+                    if (-not [string]::IsNullOrWhiteSpace([string]$preferredMissing)) {
+                        $selectedLabel = [string]$preferredMissing
+                        $resolvedRole = 'Worker'
+                    }
+                }
+            }
+        }
+    }
+    if ($null -eq $route) {
+        $route = Get-DispatchRoute -Text $taskText -AvailableTargets @($selectedLabel) -DefaultRole 'Worker'
     }
 
     $manifestEntry = $null
@@ -836,7 +1023,8 @@ function Import-Task789OrchestraHelpers {
     if (-not $IncludePaneScaler) {
         return
     }
-    if (Get-Command New-TeamProfileSlotAgentConfig -ErrorAction SilentlyContinue) {
+    if ((Get-Command New-TeamProfileSlotAgentConfig -ErrorAction SilentlyContinue) -and
+        (Get-Command Add-TeamProfileBundleToLaunchCommand -ErrorAction SilentlyContinue)) {
         return
     }
 
@@ -989,7 +1177,7 @@ function Ensure-DispatchTaskLiveWorkerPane {
     }
 
     $manifestPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'manifest.yaml'
-    $null = Add-OrchestraPane -ManifestPath $manifestPath -Role 'Worker' -SlotId $Label -Settings $settings -SlotAgentConfig $slotAgentConfig -Assignment $assignment
+    $null = Add-OrchestraPane -ManifestPath $manifestPath -Role 'Worker' -SlotId $Label -Settings $settings -SlotAgentConfig $slotAgentConfig -Assignment $assignment -Projection $projection
     $spawnedEntry = Get-DispatchTaskManifestEntry -ProjectDir $ProjectDir -Label $Label
     return [pscustomobject]@{
         Spawned        = $true

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -232,6 +232,7 @@ function Test-DispatchTaskReviewerManifestEntry {
 function Get-DispatchTaskAvailableTargets {
     param([Parameter(Mandatory = $true)][string]$ProjectDir)
 
+    Import-Task789OrchestraHelpers
     $availableTargets = @()
     $manifestTargetsResolved = $false
     if (Get-Command Get-PaneControlManifestEntries -ErrorAction SilentlyContinue) {
@@ -252,6 +253,38 @@ function Get-DispatchTaskAvailableTargets {
     }
     if (-not $manifestTargetsResolved -and $availableTargets.Count -eq 0) {
         $availableTargets = @((Get-Labels).Keys | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    }
+
+    if (Get-Command Get-OrchestraModeDocument -ErrorAction SilentlyContinue) {
+        $mode = ''
+        try {
+            $mode = [string](Get-OrchestraModeDocument -ProjectDir $ProjectDir).mode
+        } catch {
+            $mode = ''
+        }
+        if ($mode -ceq 'team' -and (Get-Command Get-BridgeSettings -ErrorAction SilentlyContinue)) {
+            try {
+                $settings = Get-BridgeSettings -RootPath $ProjectDir
+                $slots = @()
+                if ($settings -is [System.Collections.IDictionary] -and $settings.Contains('agent_slots')) {
+                    $slots = @($settings.agent_slots)
+                } elseif ($null -ne $settings -and $null -ne $settings.PSObject -and $settings.PSObject.Properties.Name -contains 'agent_slots') {
+                    $slots = @($settings.agent_slots)
+                }
+                foreach ($slot in $slots) {
+                    $slotId = ''
+                    if ($slot -is [System.Collections.IDictionary] -and $slot.Contains('slot_id')) {
+                        $slotId = [string]$slot['slot_id']
+                    } elseif ($null -ne $slot -and $null -ne $slot.PSObject -and $slot.PSObject.Properties.Name -contains 'slot_id') {
+                        $slotId = [string]$slot.slot_id
+                    }
+                    if (-not [string]::IsNullOrWhiteSpace($slotId) -and $availableTargets -notcontains $slotId) {
+                        $availableTargets += $slotId
+                    }
+                }
+            } catch {
+            }
+        }
     }
 
     return @($availableTargets)
@@ -321,13 +354,25 @@ function Invoke-WinsmuxDispatchTaskCommand {
         $paneId = [string]$manifestEntry.PaneId
     } else {
         $manifestEntry = Get-DispatchTaskManifestEntry -ProjectDir $projectDir -Label $selectedLabel
-        if ($null -eq $manifestEntry -or [string]::IsNullOrWhiteSpace([string]$manifestEntry.PaneId)) {
-            $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status unavailable -Backend noop -SubmissionId $submissionId -ReasonCode 'target_unavailable' -Diagnostic "dispatch-task could not resolve target '$selectedLabel' to a pane."
-            ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
-            exit 1
+        $paneId = Get-DispatchTaskEntryPaneId -Entry $manifestEntry
+        if ($null -eq $manifestEntry -or [string]::IsNullOrWhiteSpace($paneId)) {
+            $spawn = Ensure-DispatchTaskLiveWorkerPane -ProjectDir $projectDir -Label $selectedLabel -ManifestEntry $manifestEntry
+            if (-not [bool]$spawn.Spawned) {
+                $reason = [string]$spawn.ReasonCode
+                if ([string]::IsNullOrWhiteSpace($reason)) {
+                    $reason = 'target_unavailable'
+                }
+                $diagnostic = [string]$spawn.Diagnostic
+                if ([string]::IsNullOrWhiteSpace($diagnostic)) {
+                    $diagnostic = "dispatch-task could not resolve target '$selectedLabel' to a pane."
+                }
+                $receipt = New-WinsmuxSubmissionReceipt -Kind task -Status unavailable -Backend noop -SubmissionId $submissionId -ReasonCode $reason -Diagnostic $diagnostic
+                ConvertTo-WinsmuxSubmissionReceiptJson -Receipt $receipt | Write-Output
+                exit 1
+            }
+            $manifestEntry = $spawn.ManifestEntry
+            $paneId = Get-DispatchTaskEntryPaneId -Entry $manifestEntry
         }
-
-        $paneId = [string]$manifestEntry.PaneId
     }
 
     $entryStatus = [string](Get-WinsmuxSubmissionValue -InputObject $manifestEntry -Name 'Status' -Default '')
@@ -802,4 +847,320 @@ function Invoke-WinsmuxAssignCommand {
         -ScriptPath (Get-WinsmuxControlPlaneScriptPath -BridgeScriptRoot $BridgeScriptRoot -ScriptName 'assignment-policy.ps1') `
         -Arguments $assignArgs `
         -PropagateExitCode
+}
+
+
+function Import-Task789OrchestraHelpers {
+    param([switch]$IncludePaneScaler)
+
+    if (-not (Get-Command Get-OrchestraModeDocument -ErrorAction SilentlyContinue)) {
+        . (Join-Path $PSScriptRoot 'manifest.ps1')
+    }
+    if ($IncludePaneScaler) {
+        if (-not (Get-Command New-TeamProfileSlotAgentConfig -ErrorAction SilentlyContinue)) {
+            . (Join-Path $PSScriptRoot 'orchestra-start.ps1')
+        }
+        if (-not (Get-Command Add-OrchestraPane -ErrorAction SilentlyContinue)) {
+            . (Join-Path $PSScriptRoot 'pane-scaler.ps1')
+        }
+    }
+}
+
+function Get-DispatchTaskEntryPaneId {
+    param([AllowNull()]$Entry = $null)
+
+    if ($null -eq $Entry) {
+        return ''
+    }
+    foreach ($name in @('PaneId', 'pane_id')) {
+        if ($Entry -is [System.Collections.IDictionary] -and $Entry.Contains($name)) {
+            return [string]$Entry[$name]
+        }
+        if ($null -ne $Entry.PSObject -and $Entry.PSObject.Properties.Name -contains $name) {
+            return [string]$Entry.PSObject.Properties[$name].Value
+        }
+    }
+    return ''
+}
+
+function Ensure-DispatchTaskLiveWorkerPane {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][string]$Label,
+        [AllowNull()]$ManifestEntry = $null
+    )
+
+    $paneId = Get-DispatchTaskEntryPaneId -Entry $ManifestEntry
+    if (-not [string]::IsNullOrWhiteSpace($paneId)) {
+        return [pscustomobject]@{
+            Spawned        = $false
+            ManifestEntry  = $ManifestEntry
+            ReasonCode     = ''
+            Diagnostic     = ''
+        }
+    }
+
+    Import-Task789OrchestraHelpers
+    $mode = 'team'
+    try {
+        $mode = [string](Get-OrchestraModeDocument -ProjectDir $ProjectDir).mode
+    } catch {
+        return [pscustomobject]@{
+            Spawned        = $false
+            ManifestEntry  = $null
+            ReasonCode     = 'orchestra_mode_invalid'
+            Diagnostic     = [string]$_.Exception.Message
+        }
+    }
+
+    $manifest = $null
+    if (Get-Command Get-WinsmuxManifest -ErrorAction SilentlyContinue) {
+        try {
+            $manifest = Get-WinsmuxManifest -ProjectDir $ProjectDir
+        } catch {
+            $manifest = $null
+        }
+    }
+    $liveWorkers = 0
+    if (Get-Command Get-OrchestraLiveWorkerRolePaneCount -ErrorAction SilentlyContinue) {
+        $liveWorkers = [int](Get-OrchestraLiveWorkerRolePaneCount -Manifest $manifest)
+    }
+    $maxLive = 6
+    if (Get-Command Get-OrchestraMaxLiveWorkerPaneCount -ErrorAction SilentlyContinue) {
+        $maxLive = [int](Get-OrchestraMaxLiveWorkerPaneCount -Mode $mode)
+    } elseif ($mode -ceq 'simple') {
+        $maxLive = 1
+    }
+    if ($liveWorkers -ge $maxLive) {
+        $reason = if ($mode -ceq 'simple') { 'simple_mode_live_worker_limit' } else { 'team_mode_live_worker_limit' }
+        return [pscustomobject]@{
+            Spawned        = $false
+            ManifestEntry  = $null
+            ReasonCode     = $reason
+            Diagnostic     = ("{0}: live worker-role panes={1} max={2}" -f $reason, $liveWorkers, $maxLive)
+        }
+    }
+
+    Import-Task789OrchestraHelpers -IncludePaneScaler
+    $settings = $null
+    if (Get-Command Get-BridgeSettings -ErrorAction SilentlyContinue) {
+        $settings = Get-BridgeSettings -RootPath $ProjectDir
+    }
+    $assignment = $null
+    if (Get-Command Invoke-TeamProfileLaunchProjection -ErrorAction SilentlyContinue) {
+        try {
+            $projection = Invoke-TeamProfileLaunchProjection -ProjectDir $ProjectDir -SessionId 'winsmux-orchestra' -SlotId $Label -Worktree '' -ReadWriteScope 'session'
+            if ($null -ne $projection -and $null -ne $projection.projection -and $null -ne $projection.projection.pane) {
+                $assignment = $projection.projection.pane.assignment
+            }
+        } catch {
+            $assignment = $null
+        }
+    }
+
+    $slotAgentConfig = $null
+    if ($null -ne $assignment -and (Get-Command New-TeamProfileSlotAgentConfig -ErrorAction SilentlyContinue)) {
+        # Spawn uses Team Profile assignment.worker_backend via New-TeamProfileSlotAgentConfig.
+        $slotAgentConfig = New-TeamProfileSlotAgentConfig -Role 'Worker' -SlotId $Label -Assignment $assignment -Settings $settings -RootPath $ProjectDir
+    }
+
+    $manifestPath = Join-Path (Join-Path $ProjectDir '.winsmux') 'manifest.yaml'
+    $null = Add-OrchestraPane -ManifestPath $manifestPath -Role 'Worker' -SlotId $Label -Settings $settings -SlotAgentConfig $slotAgentConfig -Assignment $assignment
+    $spawnedEntry = Get-DispatchTaskManifestEntry -ProjectDir $ProjectDir -Label $Label
+    return [pscustomobject]@{
+        Spawned        = $true
+        ManifestEntry  = $spawnedEntry
+        ReasonCode     = ''
+        Diagnostic     = ''
+    }
+}
+
+function Test-WinsmuxArchivePaneIdle {
+    param(
+        [AllowNull()]$Entry = $null,
+        [Parameter(Mandatory = $true)][string]$ProjectDir
+    )
+
+    $status = ''
+    $lastEvent = ''
+    $label = ''
+    $paneId = ''
+    if ($null -ne $Entry) {
+        foreach ($pair in @(@('Status', 'status'), @('LastEvent', 'last_event'), @('Label', 'label'), @('PaneId', 'pane_id'))) {
+            $value = ''
+            foreach ($name in $pair) {
+                if ($Entry -is [System.Collections.IDictionary] -and $Entry.Contains($name)) {
+                    $value = [string]$Entry[$name]
+                    break
+                }
+                if ($null -ne $Entry.PSObject -and $Entry.PSObject.Properties.Name -contains $name) {
+                    $value = [string]$Entry.PSObject.Properties[$name].Value
+                    break
+                }
+            }
+            switch ($pair[0]) {
+                'Status' { $status = $value }
+                'LastEvent' { $lastEvent = $value }
+                'Label' { $label = $value }
+                'PaneId' { $paneId = $value }
+            }
+        }
+    }
+
+    $idleEvents = @('pane.idle', 'pane.completed', 'pane.ready')
+    $busyEvents = @('pane.progress', 'pane.approval_waiting', 'pane.busy', 'pane.hung', 'pane.stalled')
+    if ($busyEvents -contains $lastEvent) {
+        return $false
+    }
+    if ($idleEvents -contains $lastEvent) {
+        return $true
+    }
+    if ($status -in @('busy', 'approval_waiting', 'hung', 'stalled')) {
+        return $false
+    }
+    if ($status -in @('ready', 'waiting_for_dispatch', 'deferred_start', 'deferred_starting')) {
+        return $true
+    }
+
+    if (Get-Command Get-BridgeEventRecords -ErrorAction SilentlyContinue) {
+        $events = @(Get-BridgeEventRecords -ProjectDir $ProjectDir)
+        $matching = @(
+            $events | Where-Object {
+                $eventLabel = [string]$_['label']
+                $eventPane = [string]$_['pane_id']
+                ((-not [string]::IsNullOrWhiteSpace($label) -and $eventLabel -ceq $label) -or
+                 (-not [string]::IsNullOrWhiteSpace($paneId) -and $eventPane -ceq $paneId))
+            }
+        )
+        if ($matching.Count -gt 0) {
+            $eventName = [string]$matching[-1]['event']
+            if ($busyEvents -contains $eventName) {
+                return $false
+            }
+            if ($idleEvents -contains $eventName) {
+                return $true
+            }
+        }
+    }
+
+    return $true
+}
+
+function Invoke-WinsmuxArchivePaneCommand {
+    param(
+        [Parameter(Mandatory = $true)][string]$BridgeScriptRoot,
+        [AllowNull()][string]$CommandTarget,
+        [AllowNull()][string[]]$CommandRest
+    )
+
+    $parts = @(
+        Get-WinsmuxControlPlaneArguments -CommandTarget $CommandTarget -CommandRest $CommandRest |
+            ForEach-Object { ([string]$_).Trim() } |
+            Where-Object { $_ }
+    )
+    $projectDir = (Get-Location).Path
+    $json = $false
+    $slot = ''
+    $index = 0
+    while ($index -lt $parts.Count) {
+        $current = [string]$parts[$index]
+        if ($current -ceq '--project-dir') {
+            if ($index + 1 -ge $parts.Count) {
+                Stop-WithError 'usage: winsmux archive-pane <slot> [--json] [--project-dir <path>]'
+            }
+            $projectDir = [string]$parts[$index + 1]
+            $index += 2
+            continue
+        }
+        if ($current -ceq '--json') {
+            $json = $true
+            $index++
+            continue
+        }
+        if ([string]::IsNullOrWhiteSpace($slot)) {
+            $slot = $current
+            $index++
+            continue
+        }
+        Stop-WithError 'usage: winsmux archive-pane <slot> [--json] [--project-dir <path>]'
+    }
+    if ([string]::IsNullOrWhiteSpace($slot)) {
+        Stop-WithError 'usage: winsmux archive-pane <slot> [--json] [--project-dir <path>]'
+    }
+
+    Import-Task789OrchestraHelpers -IncludePaneScaler
+    $entry = Get-DispatchTaskManifestEntry -ProjectDir $projectDir -Label $slot
+    $paneId = Get-DispatchTaskEntryPaneId -Entry $entry
+    if ($null -eq $entry -or [string]::IsNullOrWhiteSpace($paneId)) {
+        $payload = [ordered]@{
+            ok          = $false
+            action      = 'archive-pane'
+            slot        = $slot
+            reason_code = 'pane_not_live'
+            diagnostic  = "archive-pane: slot '$slot' has no live pane."
+        }
+        if ($json) {
+            $payload | ConvertTo-Json -Compress
+        } else {
+            Write-Output $payload.diagnostic
+        }
+        exit 1
+    }
+
+    $idle = Test-WinsmuxArchivePaneIdle -Entry $entry -ProjectDir $projectDir
+    # Collect requires pane.idle (or equivalent idle status) after interrupt before kill-pane.
+    if (-not $idle) {
+        if (Get-Command Invoke-WinsmuxRaw -ErrorAction SilentlyContinue) {
+            Invoke-WinsmuxRaw -Arguments @('keys', $paneId, 'C-c') | Out-Null
+        } elseif (Get-Command Invoke-MonitorWinsmux -ErrorAction SilentlyContinue) {
+            Invoke-MonitorWinsmux -Arguments @('keys', $paneId, 'C-c') | Out-Null
+        } else {
+            throw "archive-pane could not send interrupt to pane $paneId"
+        }
+
+        $becameIdle = $false
+        for ($attempt = 1; $attempt -le 8; $attempt++) {
+            Start-Sleep -Milliseconds 250
+            $entry = Get-DispatchTaskManifestEntry -ProjectDir $projectDir -Label $slot
+            if (Test-WinsmuxArchivePaneIdle -Entry $entry -ProjectDir $projectDir) {
+                $becameIdle = $true
+                break
+            }
+        }
+        if (-not $becameIdle) {
+            $payload = [ordered]@{
+                ok          = $false
+                action      = 'archive-pane'
+                slot        = $slot
+                pane_id     = $paneId
+                reason_code = 'archive_idle_required'
+                diagnostic  = "archive-pane: interrupt did not make '$slot' idle; pane was left in place."
+            }
+            if ($json) {
+                $payload | ConvertTo-Json -Compress
+            } else {
+                Write-Output $payload.diagnostic
+            }
+            exit 1
+        }
+    }
+
+    $manifestPath = Join-Path (Join-Path $projectDir '.winsmux') 'manifest.yaml'
+    $removed = Remove-OrchestraPane -ManifestPath $manifestPath -Role 'Worker' -Label $slot
+    $payload = [ordered]@{
+        ok          = [bool]$removed.Changed
+        action      = 'archive-pane'
+        slot        = $slot
+        pane_id     = $paneId
+        removed     = [bool]$removed.Changed
+        reason_code = if ([bool]$removed.Changed) { '' } else { [string]$removed.Reason }
+    }
+    if ($json) {
+        $payload | ConvertTo-Json -Compress
+    } else {
+        Write-Output ("archive-pane {0}: {1}" -f $slot, $(if ($payload.ok) { 'archived' } else { 'unchanged' }))
+    }
+    if (-not $payload.ok) {
+        exit 1
+    }
 }

--- a/winsmux-core/scripts/control-plane-dispatch.ps1
+++ b/winsmux-core/scripts/control-plane-dispatch.ps1
@@ -1222,6 +1222,41 @@ function Test-DispatchTaskLiveFileBytesEqual {
     return $true
 }
 
+function Get-DispatchTaskLiveRegistryPaneSetToken {
+    param($Bytes)
+
+    if ($null -eq $Bytes -or $Bytes.Length -eq 0) {
+        return ''
+    }
+
+    try {
+        $text = [System.Text.Encoding]::UTF8.GetString($Bytes)
+        $registry = $text | ConvertFrom-Json
+    } catch {
+        return ''
+    }
+
+    $count = [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'expected_pane_count' -Default '')
+    $parts = [System.Collections.Generic.List[string]]::new()
+    foreach ($pane in @($registry.panes)) {
+        $slotId = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'slot_id' -Default '')
+        $paneId = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'pane_id' -Default '')
+        $parts.Add(('{0}:{1}' -f $slotId, $paneId)) | Out-Null
+    }
+    return '{0}|{1}' -f $count, ($parts -join ',')
+}
+
+function Test-DispatchTaskLiveRegistryPaneSetEqual {
+    param($Before, $After)
+
+    $beforeToken = Get-DispatchTaskLiveRegistryPaneSetToken -Bytes $Before
+    $afterToken = Get-DispatchTaskLiveRegistryPaneSetToken -Bytes $After
+    if ([string]::IsNullOrWhiteSpace($beforeToken) -or [string]::IsNullOrWhiteSpace($afterToken)) {
+        return (Test-DispatchTaskLiveFileBytesEqual -Before $Before -After $After)
+    }
+    return [string]::Equals($beforeToken, $afterToken, [System.StringComparison]::Ordinal)
+}
+
 function Restore-DispatchTaskLiveFileBytes {
     param(
         [Parameter(Mandatory = $true)][string]$Path,
@@ -1340,10 +1375,10 @@ function Ensure-DispatchTaskLiveWorkerPane {
             $afterRegistry = [System.IO.File]::ReadAllBytes($liveRegistryPath)
         }
         $manifestMutated = -not (Test-DispatchTaskLiveFileBytesEqual -Before $beforeManifest -After $afterManifest)
-        $registryMutated = -not (Test-DispatchTaskLiveFileBytesEqual -Before $beforeRegistry -After $afterRegistry)
-        if ($manifestMutated -or $registryMutated) {
+        $registryPaneSetMutated = -not (Test-DispatchTaskLiveRegistryPaneSetEqual -Before $beforeRegistry -After $afterRegistry)
+        if ($manifestMutated -or $registryPaneSetMutated) {
             Restore-DispatchTaskLiveFileBytes -Path $liveManifestPath -Bytes $beforeManifest
-            if (-not [string]::IsNullOrWhiteSpace([string]$liveRegistryPath)) {
+            if ($registryPaneSetMutated -and -not [string]::IsNullOrWhiteSpace([string]$liveRegistryPath)) {
                 Restore-DispatchTaskLiveFileBytes -Path $liveRegistryPath -Bytes $beforeRegistry
             }
             return [pscustomobject]@{
@@ -1370,7 +1405,11 @@ function Ensure-DispatchTaskLiveWorkerPane {
         }
     } catch {
         Restore-DispatchTaskLiveFileBytes -Path $liveManifestPath -Bytes $beforeManifest
-        if (-not [string]::IsNullOrWhiteSpace([string]$liveRegistryPath)) {
+        $currentRegistry = $null
+        if (-not [string]::IsNullOrWhiteSpace([string]$liveRegistryPath) -and (Test-Path -LiteralPath $liveRegistryPath -PathType Leaf)) {
+            $currentRegistry = [System.IO.File]::ReadAllBytes($liveRegistryPath)
+        }
+        if (-not (Test-DispatchTaskLiveRegistryPaneSetEqual -Before $beforeRegistry -After $currentRegistry)) {
             Restore-DispatchTaskLiveFileBytes -Path $liveRegistryPath -Bytes $beforeRegistry
         }
         return [pscustomobject]@{

--- a/winsmux-core/scripts/manifest.ps1
+++ b/winsmux-core/scripts/manifest.ps1
@@ -426,10 +426,11 @@ function Write-ManifestTextFile {
     param(
         [Parameter(Mandatory = $true)][string]$Path,
         [AllowEmptyString()][string]$Content = '',
-        [AllowNull()][scriptblock]$ValidateLocked = $null
+        [AllowNull()][scriptblock]$ValidateLocked = $null,
+        [switch]$AlreadyLocked
     )
 
-    Write-WinsmuxTextFile -Path $Path -Content $Content -ValidateLocked $ValidateLocked
+    Write-WinsmuxTextFile -Path $Path -Content $Content -ValidateLocked $ValidateLocked -AlreadyLocked:$AlreadyLocked
 }
 
 function Get-ManifestDir {
@@ -488,12 +489,13 @@ function Read-WinsmuxRuntimeRegistry {
 function Save-WinsmuxRuntimeRegistry {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
-        [Parameter(Mandatory = $true)]$Registry
+        [Parameter(Mandatory = $true)]$Registry,
+        [switch]$AlreadyLocked
     )
 
     $path = Get-WinsmuxRuntimeRegistryPath -ProjectDir $ProjectDir
     $json = $Registry | ConvertTo-Json -Depth 20
-    Write-ManifestTextFile -Path $path -Content ($json + "`n")
+    Write-ManifestTextFile -Path $path -Content ($json + "`n") -AlreadyLocked:$AlreadyLocked
     return $path
 }
 
@@ -654,31 +656,36 @@ function Update-WinsmuxRuntimeRegistryLease {
         [ValidateRange(5, 300)][int]$LeaseSeconds = 15
     )
 
-    $registry = Read-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir
-    $supervisor = Get-WinsmuxRuntimeValue -InputObject $registry -Name 'supervisor'
-    $ownerPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'pid' -Default $null)
-    $ownerStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'process_started_at' -Default '')
-    $expectedStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $SupervisorProcessStartedAt
-    if ($null -eq $registry -or
-        [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'status' -Default '') -cne 'active' -or
-        -not [string]::Equals(
-            [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'generation_id' -Default ''),
-            $GenerationId,
-            [System.StringComparison]::Ordinal) -or
-        $null -eq $ownerPid -or $ownerPid -ne $SupervisorPid -or
-        [string]::IsNullOrWhiteSpace($ownerStartedAt) -or $ownerStartedAt -cne $expectedStartedAt) {
-        throw 'Runtime registry lease update refused because the writer does not own this generation.'
-    }
+    $path = Get-WinsmuxRuntimeRegistryPath -ProjectDir $ProjectDir
+    $holder = @{ Registry = $null }
+    Invoke-WinsmuxWithFileLock -Path $path -Action {
+        $registry = Read-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir
+        $supervisor = Get-WinsmuxRuntimeValue -InputObject $registry -Name 'supervisor'
+        $ownerPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'pid' -Default $null)
+        $ownerStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'process_started_at' -Default '')
+        $expectedStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $SupervisorProcessStartedAt
+        if ($null -eq $registry -or
+            [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'status' -Default '') -cne 'active' -or
+            -not [string]::Equals(
+                [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'generation_id' -Default ''),
+                $GenerationId,
+                [System.StringComparison]::Ordinal) -or
+            $null -eq $ownerPid -or $ownerPid -ne $SupervisorPid -or
+            [string]::IsNullOrWhiteSpace($ownerStartedAt) -or $ownerStartedAt -cne $expectedStartedAt) {
+            throw 'Runtime registry lease update refused because the writer does not own this generation.'
+        }
 
-    $updatedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $Now
-    $registry.lease.state = 'active'
-    $registry.lease.expires_at = $Now.ToUniversalTime().AddSeconds($LeaseSeconds).ToString('o', [System.Globalization.CultureInfo]::InvariantCulture)
-    $registry.updated_at = $updatedAt
-    if ($null -ne $Panes) {
-        $registry.panes = @($Panes)
+        $updatedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $Now
+        $registry.lease.state = 'active'
+        $registry.lease.expires_at = $Now.ToUniversalTime().AddSeconds($LeaseSeconds).ToString('o', [System.Globalization.CultureInfo]::InvariantCulture)
+        $registry.updated_at = $updatedAt
+        if ($null -ne $Panes) {
+            $registry.panes = @($Panes)
+        }
+        Save-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir -Registry $registry -AlreadyLocked | Out-Null
+        $holder.Registry = $registry
     }
-    Save-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir -Registry $registry | Out-Null
-    return $registry
+    return $holder.Registry
 }
 
 function Close-WinsmuxRuntimeRegistry {
@@ -692,34 +699,41 @@ function Close-WinsmuxRuntimeRegistry {
         [datetime]$Now = (Get-Date)
     )
 
-    $registry = Read-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir
-    if ($null -eq $registry) {
-        return $false
-    }
+    $path = Get-WinsmuxRuntimeRegistryPath -ProjectDir $ProjectDir
+    $holder = @{ Closed = $false }
+    Invoke-WinsmuxWithFileLock -Path $path -Action {
+        $registry = Read-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir
+        if ($null -eq $registry) {
+            $holder.Closed = $false
+            return
+        }
 
-    $supervisor = Get-WinsmuxRuntimeValue -InputObject $registry -Name 'supervisor'
-    $ownerPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'pid' -Default $null)
-    $ownerStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'process_started_at' -Default '')
-    $expectedStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $SupervisorProcessStartedAt
-    if (-not [string]::Equals(
-            [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'generation_id' -Default ''),
-            $GenerationId,
-            [System.StringComparison]::Ordinal) -or
-        ((-not [string]::IsNullOrWhiteSpace($ExpectedSessionName)) -and
-            [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'session_name' -Default '') -cne $ExpectedSessionName) -or
-        ((-not [string]::IsNullOrWhiteSpace($ExpectedServerSessionId)) -and
-            [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'server_session_id' -Default '') -cne $ExpectedServerSessionId) -or
-        $null -eq $ownerPid -or $ownerPid -ne $SupervisorPid -or $ownerStartedAt -cne $expectedStartedAt) {
-        return $false
-    }
+        $supervisor = Get-WinsmuxRuntimeValue -InputObject $registry -Name 'supervisor'
+        $ownerPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'pid' -Default $null)
+        $ownerStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $supervisor -Name 'process_started_at' -Default '')
+        $expectedStartedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $SupervisorProcessStartedAt
+        if (-not [string]::Equals(
+                [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'generation_id' -Default ''),
+                $GenerationId,
+                [System.StringComparison]::Ordinal) -or
+            ((-not [string]::IsNullOrWhiteSpace($ExpectedSessionName)) -and
+                [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'session_name' -Default '') -cne $ExpectedSessionName) -or
+            ((-not [string]::IsNullOrWhiteSpace($ExpectedServerSessionId)) -and
+                [string](Get-WinsmuxRuntimeValue -InputObject $registry -Name 'server_session_id' -Default '') -cne $ExpectedServerSessionId) -or
+            $null -eq $ownerPid -or $ownerPid -ne $SupervisorPid -or $ownerStartedAt -cne $expectedStartedAt) {
+            $holder.Closed = $false
+            return
+        }
 
-    $endedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $Now
-    $registry.status = 'ended'
-    $registry.lease.state = 'ended'
-    $registry.lease.expires_at = $endedAt
-    $registry.updated_at = $endedAt
-    Save-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir -Registry $registry | Out-Null
-    return $true
+        $endedAt = ConvertTo-WinsmuxRuntimeUtcIdentity -Value $Now
+        $registry.status = 'ended'
+        $registry.lease.state = 'ended'
+        $registry.lease.expires_at = $endedAt
+        $registry.updated_at = $endedAt
+        Save-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir -Registry $registry -AlreadyLocked | Out-Null
+        $holder.Closed = $true
+    }
+    return [bool]$holder.Closed
 }
 
 function Get-WinsmuxRuntimeValue {

--- a/winsmux-core/scripts/manifest.ps1
+++ b/winsmux-core/scripts/manifest.ps1
@@ -2071,27 +2071,87 @@ function Test-OrchestraSimpleModeLiveWorkerLimit {
     return ($LiveWorkerPaneCount -le $max)
 }
 
+function ConvertTo-OrchestraLiveRegistryPanes {
+    param(
+        [AllowNull()]$Manifest = $null,
+        [AllowNull()]$ExistingRegistry = $null
+    )
+
+    $manifestPanes = ConvertTo-ManifestPropertyMap -Value (
+        Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'panes' -Default $null
+    )
+    $existingByLabel = [ordered]@{}
+    foreach ($pane in @((Get-WinsmuxRuntimeValue -InputObject $ExistingRegistry -Name 'panes' -Default @()))) {
+        $label = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'label' -Default '')
+        if (-not [string]::IsNullOrWhiteSpace($label)) {
+            $existingByLabel[$label] = $pane
+        }
+    }
+
+    $result = @()
+    foreach ($labelObj in @($manifestPanes.Keys)) {
+        $label = [string]$labelObj
+        $pane = $manifestPanes[$label]
+        $slotId = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'slot_id' -Default $label)
+        $paneId = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'pane_id' -Default '')
+        $backend = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'worker_backend' -Default '')
+        $role = Resolve-WinsmuxRuntimeRole `
+            -WorkerRole ([string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'worker_role' -Default '')) `
+            -CanonicalRole ([string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'role' -Default ''))
+        $title = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'title' -Default $label)
+        $prior = $null
+        if ($existingByLabel.Keys -contains $label) {
+            $prior = $existingByLabel[$label]
+        }
+        $state = 'live'
+        $bootstrapPid = 0
+        $bootstrapStartedAt = ''
+        $markerPath = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'bootstrap_marker_path' -Default '')
+        if ($null -ne $prior) {
+            $priorState = [string](Get-WinsmuxRuntimeValue -InputObject $prior -Name 'state' -Default '')
+            if (-not [string]::IsNullOrWhiteSpace($priorState)) {
+                $state = $priorState
+            }
+            $priorPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $prior -Name 'bootstrap_pid' -Default 0)
+            if ($null -ne $priorPid) {
+                $bootstrapPid = $priorPid
+            }
+            $priorStarted = [string](Get-WinsmuxRuntimeValue -InputObject $prior -Name 'bootstrap_process_started_at' -Default '')
+            if (-not [string]::IsNullOrWhiteSpace($priorStarted)) {
+                $bootstrapStartedAt = $priorStarted
+            }
+            $priorMarker = [string](Get-WinsmuxRuntimeValue -InputObject $prior -Name 'marker_path' -Default '')
+            if (-not [string]::IsNullOrWhiteSpace($priorMarker)) {
+                $markerPath = $priorMarker
+            }
+        }
+        $result += [PSCustomObject]@{
+            label                        = $label
+            slot_id                      = $slotId
+            pane_id                      = $paneId
+            backend                      = $backend
+            role                         = $role
+            title                        = $title
+            state                        = $state
+            bootstrap_pid                = $bootstrapPid
+            bootstrap_process_started_at = $bootstrapStartedAt
+            marker_path                  = $markerPath
+        }
+    }
+
+    return @($result)
+}
+
 function Set-OrchestraLiveExpectedPaneCount {
     param(
         [AllowNull()]$Manifest = $null,
         [AllowNull()]$Registry = $null,
-        [Parameter(Mandatory = $true)][int]$ExpectedPaneCount,
+        [int]$ExpectedPaneCount = 0,
         [Parameter(Mandatory = $true)][string]$ProjectDir
     )
 
-    if ($ExpectedPaneCount -lt 1) {
-        throw 'Live expected pane count must be 1 or greater.'
-    }
-
-    if ($null -ne $Manifest) {
-        $session = Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'session' -Default (Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'Session' -Default $null)
-        if ($null -ne $session) {
-            if ($session -is [System.Collections.IDictionary]) {
-                $session['expected_pane_count'] = $ExpectedPaneCount
-            } else {
-                $session | Add-Member -NotePropertyName 'expected_pane_count' -NotePropertyValue $ExpectedPaneCount -Force
-            }
-        }
+    if ($null -eq $Manifest) {
+        throw 'Live expected pane count requires the current pane set.'
     }
 
     if ($null -eq $Registry) {
@@ -2102,11 +2162,29 @@ function Set-OrchestraLiveExpectedPaneCount {
         }
     }
 
+    $registryPanes = @(ConvertTo-OrchestraLiveRegistryPanes -Manifest $Manifest -ExistingRegistry $Registry)
+    $derivedCount = @($registryPanes).Count
+    if ($derivedCount -lt 1) {
+        throw 'Live expected pane count must be 1 or greater.'
+    }
+    $ExpectedPaneCount = $derivedCount
+
+    $session = Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'session' -Default (Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'Session' -Default $null)
+    if ($null -ne $session) {
+        if ($session -is [System.Collections.IDictionary]) {
+            $session['expected_pane_count'] = $ExpectedPaneCount
+        } else {
+            $session | Add-Member -NotePropertyName 'expected_pane_count' -NotePropertyValue $ExpectedPaneCount -Force
+        }
+    }
+
     if ($null -ne $Registry) {
         if ($Registry -is [System.Collections.IDictionary]) {
             $Registry['expected_pane_count'] = $ExpectedPaneCount
+            $Registry['panes'] = $registryPanes
         } else {
             $Registry | Add-Member -NotePropertyName 'expected_pane_count' -NotePropertyValue $ExpectedPaneCount -Force
+            $Registry | Add-Member -NotePropertyName 'panes' -NotePropertyValue $registryPanes -Force
         }
         Save-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir -Registry $Registry | Out-Null
     }

--- a/winsmux-core/scripts/manifest.ps1
+++ b/winsmux-core/scripts/manifest.ps1
@@ -1918,3 +1918,198 @@ function New-WinsmuxDeclarativeWorkspaceProjection {
     }
     return $projection
 }
+
+
+function Get-OrchestraMinLiveWorkerPaneCount {
+    return 1
+}
+
+function Get-OrchestraMaxLiveWorkerPaneCount {
+    param([AllowEmptyString()][string]$Mode = 'team')
+
+    if ([string]::Equals($Mode, 'simple', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return 1
+    }
+
+    return 6
+}
+
+function Get-OrchestraModeDocument {
+    param([Parameter(Mandatory = $true)][string]$ProjectDir)
+
+    $modePath = Join-Path (Join-Path $ProjectDir '.winsmux') 'orchestra-mode.json'
+    if (-not (Test-Path -LiteralPath $modePath -PathType Leaf)) {
+        return [pscustomobject]@{
+            schema_version = 1
+            mode           = 'team'
+            valid          = $true
+            source         = 'default'
+        }
+    }
+
+    $raw = Get-Content -LiteralPath $modePath -Raw -Encoding UTF8
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        throw 'orchestra-mode.json is not valid JSON'
+    }
+
+    try {
+        $parsed = $raw | ConvertFrom-Json
+    } catch {
+        throw 'orchestra-mode.json is not valid JSON'
+    }
+
+    if ($null -eq $parsed) {
+        throw 'orchestra-mode.json must be an object'
+    }
+    if ($parsed -is [System.Collections.IEnumerable] -and $parsed -isnot [System.Collections.IDictionary] -and $parsed -isnot [string]) {
+        throw 'orchestra-mode.json must be an object'
+    }
+    if ($null -eq $parsed.PSObject) {
+        throw 'orchestra-mode.json must be an object'
+    }
+
+    $names = @($parsed.PSObject.Properties.Name)
+    if ($names.Count -ne 2 -or $names -notcontains 'schema_version' -or $names -notcontains 'mode') {
+        throw 'orchestra-mode.json must contain only schema_version and mode'
+    }
+
+    $versionValue = $parsed.schema_version
+    $versionOk = $false
+    if ($versionValue -is [int] -or $versionValue -is [long] -or $versionValue -is [decimal] -or $versionValue -is [double]) {
+        $versionOk = ([int]$versionValue -eq 1)
+    }
+    if (-not $versionOk) {
+        throw 'orchestra-mode.json schema_version must be 1'
+    }
+
+    $mode = [string]$parsed.mode
+    if ($mode -cne 'simple' -and $mode -cne 'team') {
+        throw 'orchestra-mode.json mode must be simple or team'
+    }
+
+    return [pscustomobject]@{
+        schema_version = 1
+        mode           = $mode
+        valid          = $true
+        source         = 'file'
+    }
+}
+
+function Get-OrchestraCanonicalPaneRole {
+    param(
+        [AllowNull()]$Pane = $null,
+        [AllowEmptyString()][string]$Label = ''
+    )
+
+    $role = [string](Get-WinsmuxRuntimeValue -InputObject $Pane -Name 'role' -Default '')
+    $candidate = if ([string]::IsNullOrWhiteSpace($role)) { $Label } else { $role }
+    if ([string]::IsNullOrWhiteSpace($candidate)) {
+        return ''
+    }
+
+    switch -Regex ($candidate.Trim()) {
+        '^(?i)worker(?:$|[-_:/\s])' { return 'Worker' }
+        '^(?i)builder(?:$|[-_:/\s])' { return 'Builder' }
+        '^(?i)researcher(?:$|[-_:/\s])' { return 'Researcher' }
+        '^(?i)reviewer(?:$|[-_:/\s])' { return 'Reviewer' }
+        '^(?i)operator(?:$|[-_:/\s])' { return 'Operator' }
+        default { return $candidate.Trim() }
+    }
+}
+
+function Get-OrchestraLiveWorkerRolePaneCount {
+    param([AllowNull()]$Manifest = $null)
+
+    if ($null -eq $Manifest) {
+        return 0
+    }
+
+    $panes = Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'panes' -Default $null
+    if ($null -eq $panes) {
+        $panes = Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'Panes' -Default $null
+    }
+    if ($null -eq $panes) {
+        return 0
+    }
+
+    $count = 0
+    $map = $null
+    if ($panes -is [System.Collections.IDictionary]) {
+        $map = $panes
+    } elseif ($null -ne $panes.PSObject) {
+        $map = [ordered]@{}
+        foreach ($property in $panes.PSObject.Properties) {
+            $map[$property.Name] = $property.Value
+        }
+    }
+
+    if ($null -eq $map) {
+        return 0
+    }
+
+    foreach ($label in @($map.Keys)) {
+        $pane = $map[$label]
+        $paneId = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'pane_id' -Default '')
+        if ([string]::IsNullOrWhiteSpace($paneId)) {
+            continue
+        }
+        if ((Get-OrchestraCanonicalPaneRole -Pane $pane -Label ([string]$label)) -eq 'Worker') {
+            $count++
+        }
+    }
+
+    return $count
+}
+
+function Test-OrchestraSimpleModeLiveWorkerLimit {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Mode,
+        [Parameter(Mandatory = $true)][int]$LiveWorkerPaneCount
+    )
+
+    $max = Get-OrchestraMaxLiveWorkerPaneCount -Mode $Mode
+    return ($LiveWorkerPaneCount -le $max)
+}
+
+function Set-OrchestraLiveExpectedPaneCount {
+    param(
+        [AllowNull()]$Manifest = $null,
+        [AllowNull()]$Registry = $null,
+        [Parameter(Mandatory = $true)][int]$ExpectedPaneCount,
+        [Parameter(Mandatory = $true)][string]$ProjectDir
+    )
+
+    if ($ExpectedPaneCount -lt 1) {
+        throw 'Live expected pane count must be 1 or greater.'
+    }
+
+    if ($null -ne $Manifest) {
+        $session = Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'session' -Default (Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'Session' -Default $null)
+        if ($null -ne $session) {
+            if ($session -is [System.Collections.IDictionary]) {
+                $session['expected_pane_count'] = $ExpectedPaneCount
+            } else {
+                $session | Add-Member -NotePropertyName 'expected_pane_count' -NotePropertyValue $ExpectedPaneCount -Force
+            }
+        }
+    }
+
+    if ($null -eq $Registry) {
+        try {
+            $Registry = Read-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir
+        } catch {
+            $Registry = $null
+        }
+    }
+
+    if ($null -ne $Registry) {
+        if ($Registry -is [System.Collections.IDictionary]) {
+            $Registry['expected_pane_count'] = $ExpectedPaneCount
+        } else {
+            $Registry | Add-Member -NotePropertyName 'expected_pane_count' -NotePropertyValue $ExpectedPaneCount -Force
+        }
+        Save-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir -Registry $Registry | Out-Null
+    }
+
+    return $ExpectedPaneCount
+}

--- a/winsmux-core/scripts/manifest.ps1
+++ b/winsmux-core/scripts/manifest.ps1
@@ -2103,7 +2103,7 @@ function ConvertTo-OrchestraLiveRegistryPanes {
         if ($existingByLabel.Keys -contains $label) {
             $prior = $existingByLabel[$label]
         }
-        $state = 'live'
+        $state = 'bootstrap_pending'
         $bootstrapPid = 0
         $bootstrapStartedAt = ''
         $markerPath = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'bootstrap_marker_path' -Default '')
@@ -2124,6 +2124,28 @@ function ConvertTo-OrchestraLiveRegistryPanes {
             if (-not [string]::IsNullOrWhiteSpace($priorMarker)) {
                 $markerPath = $priorMarker
             }
+        }
+        if (-not [string]::IsNullOrWhiteSpace($markerPath) -and (Test-Path -LiteralPath $markerPath -PathType Leaf)) {
+            try {
+                $marker = Get-Content -LiteralPath $markerPath -Raw -Encoding UTF8 | ConvertFrom-Json
+                $markerPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $marker -Name 'bootstrap_pid' -Default $null)
+                $markerStarted = [string](Get-WinsmuxRuntimeValue -InputObject $marker -Name 'bootstrap_process_started_at' -Default '')
+                if ($null -ne $markerPid -and $markerPid -gt 0) {
+                    $bootstrapPid = $markerPid
+                }
+                if (-not [string]::IsNullOrWhiteSpace($markerStarted)) {
+                    $bootstrapStartedAt = $markerStarted
+                }
+            } catch {
+            }
+        }
+        $manifestStatus = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'status' -Default '')
+        $statusClassification = Get-WinsmuxRuntimeStatusClassification -Status $manifestStatus
+        $runtimeReady = (Get-WinsmuxRuntimeValue -InputObject $pane -Name 'runtime_ready' -Default $false) -eq $true
+        if ([bool]$statusClassification.IsDeferred) {
+            $state = 'deferred'
+        } elseif ($runtimeReady -or $bootstrapPid -gt 0) {
+            $state = 'live'
         }
         $result += [PSCustomObject]@{
             label                        = $label
@@ -2186,8 +2208,76 @@ function Set-OrchestraLiveExpectedPaneCount {
             $Registry | Add-Member -NotePropertyName 'expected_pane_count' -NotePropertyValue $ExpectedPaneCount -Force
             $Registry | Add-Member -NotePropertyName 'panes' -NotePropertyValue $registryPanes -Force
         }
-        Save-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir -Registry $Registry | Out-Null
     }
 
     return $ExpectedPaneCount
+}
+
+function Save-OrchestraLivePaneSetTransition {
+    param(
+        [Parameter(Mandatory = $true)][string]$ManifestPath,
+        [Parameter(Mandatory = $true)]$Manifest,
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [AllowEmptyString()][string]$ExpectedGenerationId = '',
+        [AllowEmptyString()][string]$RuntimePaneId = ''
+    )
+
+    $registryPath = Get-WinsmuxRuntimeRegistryPath -ProjectDir $ProjectDir
+    $oldManifestBytes = $null
+    $oldRegistryBytes = $null
+    if (Test-Path -LiteralPath $ManifestPath -PathType Leaf) {
+        $oldManifestBytes = [System.IO.File]::ReadAllBytes($ManifestPath)
+    }
+    if (Test-Path -LiteralPath $registryPath -PathType Leaf) {
+        $oldRegistryBytes = [System.IO.File]::ReadAllBytes($registryPath)
+    }
+
+    $registry = $null
+    try {
+        $registry = Read-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir
+    } catch {
+        $registry = $null
+    }
+
+    $count = Set-OrchestraLiveExpectedPaneCount -Manifest $Manifest -Registry $registry -ProjectDir $ProjectDir
+    $manifestVersion = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'version' -Default (Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'Version' -Default $null))
+    $saveGenerationId = $ExpectedGenerationId
+    if ($manifestVersion -ne 2) {
+        $saveGenerationId = ''
+    }
+    $manifestPublished = $false
+    $registryPublished = $false
+    try {
+        if (Get-Command Save-PaneScalerManifest -ErrorAction SilentlyContinue) {
+            Save-PaneScalerManifest -ManifestPath $ManifestPath -Manifest $Manifest `
+                -ExpectedGenerationId $saveGenerationId -RuntimePaneId $RuntimePaneId `
+                -RuntimeOperation 'stop_transition'
+        } elseif (Get-Command Save-PaneControlManifestDocument -ErrorAction SilentlyContinue) {
+            Save-PaneControlManifestDocument -ManifestPath $ManifestPath -Manifest $Manifest `
+                -ExpectedGenerationId $saveGenerationId -RuntimePaneId $RuntimePaneId `
+                -RuntimeOperation 'stop_transition'
+        } else {
+            throw 'Pane-set transition requires a guarded manifest save.'
+        }
+        $manifestPublished = $true
+
+        if ($null -ne $registry) {
+            Save-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir -Registry $registry | Out-Null
+            $registryPublished = $true
+        }
+    } catch {
+        if ($manifestPublished -and $null -ne $oldManifestBytes) {
+            [System.IO.File]::WriteAllBytes($ManifestPath, $oldManifestBytes)
+        }
+        if ($registryPublished) {
+            if ($null -ne $oldRegistryBytes) {
+                [System.IO.File]::WriteAllBytes($registryPath, $oldRegistryBytes)
+            } elseif (Test-Path -LiteralPath $registryPath -PathType Leaf) {
+                Remove-Item -LiteralPath $registryPath -Force
+            }
+        }
+        throw
+    }
+
+    return $count
 }

--- a/winsmux-core/scripts/manifest.ps1
+++ b/winsmux-core/scripts/manifest.ps1
@@ -2129,7 +2129,7 @@ function ConvertTo-OrchestraLiveRegistryPanes {
             try {
                 $marker = Get-Content -LiteralPath $markerPath -Raw -Encoding UTF8 | ConvertFrom-Json
                 $markerPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $marker -Name 'bootstrap_pid' -Default $null)
-                $markerStarted = [string](Get-WinsmuxRuntimeValue -InputObject $marker -Name 'bootstrap_process_started_at' -Default '')
+                $markerStarted = ConvertTo-WinsmuxRuntimeUtcIdentity -Value (Get-WinsmuxRuntimeValue -InputObject $marker -Name 'bootstrap_process_started_at' -Default '')
                 if ($null -ne $markerPid -and $markerPid -gt 0) {
                     $bootstrapPid = $markerPid
                 }
@@ -2213,13 +2213,62 @@ function Set-OrchestraLiveExpectedPaneCount {
     return $ExpectedPaneCount
 }
 
+function New-OrchestraLiveTransitionManifestEntry {
+    param(
+        [Parameter(Mandatory = $true)]$Manifest,
+        [AllowEmptyString()][string]$RuntimePaneId = ''
+    )
+
+    $session = Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'session' -Default $null
+    $bootstrapPaneId = [string](Get-WinsmuxRuntimeValue -InputObject $session -Name 'bootstrap_pane_id' -Default '')
+    $paneMap = ConvertTo-ManifestPropertyMap -Value (Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'panes' -Default $null)
+    $chosenLabel = ''
+    $chosenPane = $null
+    foreach ($label in @($paneMap.Keys | Sort-Object)) {
+        $pane = $paneMap[$label]
+        $paneId = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'pane_id' -Default '')
+        if ($paneId -cnotmatch '^%[0-9]+$' -or
+            [string]::Equals($paneId, $bootstrapPaneId, [System.StringComparison]::Ordinal)) {
+            continue
+        }
+        if (-not [string]::IsNullOrWhiteSpace($RuntimePaneId)) {
+            if ($paneId -ceq $RuntimePaneId) {
+                $chosenLabel = [string]$label
+                $chosenPane = $pane
+                break
+            }
+            continue
+        }
+        if ($null -eq $chosenPane) {
+            $chosenLabel = [string]$label
+            $chosenPane = $pane
+        }
+    }
+    if ($null -eq $chosenPane) {
+        return $null
+    }
+
+    return [PSCustomObject]@{
+        Label               = $chosenLabel
+        SlotId              = [string](Get-WinsmuxRuntimeValue -InputObject $chosenPane -Name 'slot_id' -Default $chosenLabel)
+        PaneId              = [string](Get-WinsmuxRuntimeValue -InputObject $chosenPane -Name 'pane_id' -Default '')
+        WorkerBackend       = [string](Get-WinsmuxRuntimeValue -InputObject $chosenPane -Name 'worker_backend' -Default '')
+        WorkerRole          = [string](Get-WinsmuxRuntimeValue -InputObject $chosenPane -Name 'worker_role' -Default '')
+        Role                = [string](Get-WinsmuxRuntimeValue -InputObject $chosenPane -Name 'role' -Default '')
+        Title               = [string](Get-WinsmuxRuntimeValue -InputObject $chosenPane -Name 'title' -Default '')
+        Status              = [string](Get-WinsmuxRuntimeValue -InputObject $chosenPane -Name 'status' -Default '')
+        BootstrapMarkerPath = [string](Get-WinsmuxRuntimeValue -InputObject $chosenPane -Name 'bootstrap_marker_path' -Default '')
+    }
+}
+
 function Save-OrchestraLivePaneSetTransition {
     param(
         [Parameter(Mandatory = $true)][string]$ManifestPath,
         [Parameter(Mandatory = $true)]$Manifest,
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [AllowEmptyString()][string]$ExpectedGenerationId = '',
-        [AllowEmptyString()][string]$RuntimePaneId = ''
+        [AllowEmptyString()][string]$RuntimePaneId = '',
+        [bool]$RestoreOnFailure = $true
     )
 
     $registryPath = Get-WinsmuxRuntimeRegistryPath -ProjectDir $ProjectDir
@@ -2230,6 +2279,17 @@ function Save-OrchestraLivePaneSetTransition {
     }
     if (Test-Path -LiteralPath $registryPath -PathType Leaf) {
         $oldRegistryBytes = [System.IO.File]::ReadAllBytes($registryPath)
+    }
+
+    $restorePublishedFiles = {
+        if ($null -ne $oldManifestBytes) {
+            [System.IO.File]::WriteAllBytes($ManifestPath, $oldManifestBytes)
+        }
+        if ($null -ne $oldRegistryBytes) {
+            [System.IO.File]::WriteAllBytes($registryPath, $oldRegistryBytes)
+        } elseif (Test-Path -LiteralPath $registryPath -PathType Leaf) {
+            Remove-Item -LiteralPath $registryPath -Force
+        }
     }
 
     $registry = $null
@@ -2245,17 +2305,39 @@ function Save-OrchestraLivePaneSetTransition {
     if ($manifestVersion -ne 2) {
         $saveGenerationId = ''
     }
+
+    $transitionEntry = $null
+    if ($manifestVersion -eq 2) {
+        $transitionEntry = New-OrchestraLiveTransitionManifestEntry -Manifest $Manifest -RuntimePaneId $RuntimePaneId
+        if ($null -eq $transitionEntry) {
+            throw 'runtime dispatch refused (runtime_target_mismatch): Planned pane set has no managed runtime pane for the live transition.'
+        }
+        if ([string]::IsNullOrWhiteSpace($RuntimePaneId)) {
+            $RuntimePaneId = [string]$transitionEntry.PaneId
+        }
+        if (-not (Get-Command Test-PaneControlRuntimeContext -ErrorAction SilentlyContinue)) {
+            throw 'runtime dispatch refused (runtime_target_mismatch): Planned pane-set validation is unavailable.'
+        }
+        $plannedValidation = Test-PaneControlRuntimeContext -ProjectDir $ProjectDir -ManifestEntry $transitionEntry `
+            -Operation stop_transition -PlannedManifest $Manifest -PlannedRegistry $registry
+        if ($null -eq $plannedValidation -or -not [bool]$plannedValidation.valid) {
+            $reasonCode = [string](Get-WinsmuxRuntimeValue -InputObject $plannedValidation -Name 'reason_code' -Default 'runtime_target_mismatch')
+            $diagnostic = [string](Get-WinsmuxRuntimeValue -InputObject $plannedValidation -Name 'diagnostic' -Default 'Planned pane set does not match the observed live server.')
+            throw ("runtime dispatch refused ({0}): {1}" -f $reasonCode, $diagnostic)
+        }
+    }
+
     $manifestPublished = $false
     $registryPublished = $false
     try {
         if (Get-Command Save-PaneScalerManifest -ErrorAction SilentlyContinue) {
             Save-PaneScalerManifest -ManifestPath $ManifestPath -Manifest $Manifest `
                 -ExpectedGenerationId $saveGenerationId -RuntimePaneId $RuntimePaneId `
-                -RuntimeOperation 'stop_transition'
+                -RuntimeOperation 'stop_transition' -AcceptPlannedPaneSet:($manifestVersion -eq 2)
         } elseif (Get-Command Save-PaneControlManifestDocument -ErrorAction SilentlyContinue) {
             Save-PaneControlManifestDocument -ManifestPath $ManifestPath -Manifest $Manifest `
                 -ExpectedGenerationId $saveGenerationId -RuntimePaneId $RuntimePaneId `
-                -RuntimeOperation 'stop_transition'
+                -RuntimeOperation 'stop_transition' -AcceptPlannedPaneSet:($manifestVersion -eq 2)
         } else {
             throw 'Pane-set transition requires a guarded manifest save.'
         }
@@ -2266,17 +2348,44 @@ function Save-OrchestraLivePaneSetTransition {
             $registryPublished = $true
         }
     } catch {
-        if ($manifestPublished -and $null -ne $oldManifestBytes) {
-            [System.IO.File]::WriteAllBytes($ManifestPath, $oldManifestBytes)
+        $saveError = $_
+        if ($RestoreOnFailure) {
+            if ($manifestPublished -or $registryPublished) {
+                & $restorePublishedFiles
+            }
+            throw $saveError
         }
-        if ($registryPublished) {
-            if ($null -ne $oldRegistryBytes) {
-                [System.IO.File]::WriteAllBytes($registryPath, $oldRegistryBytes)
-            } elseif (Test-Path -LiteralPath $registryPath -PathType Leaf) {
-                Remove-Item -LiteralPath $registryPath -Force
+
+        # Server mutation is already irreversible. Do not restore bytes that would
+        # advertise a pane the live server no longer has.
+        for ($fallbackAttempt = 1; $fallbackAttempt -le 2; $fallbackAttempt++) {
+            try {
+                if (-not $manifestPublished) {
+                    Save-WinsmuxManifest -ProjectDir $ProjectDir -Manifest $Manifest -ExpectedGenerationId $saveGenerationId
+                    $manifestPublished = $true
+                }
+                if (-not $registryPublished -and $null -ne $registry) {
+                    Save-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir -Registry $registry | Out-Null
+                    $registryPublished = $true
+                }
+                break
+            } catch {
             }
         }
-        throw
+        throw $saveError
+    }
+
+    if ($manifestVersion -eq 2 -and (Get-Command Test-PaneControlRuntimeContext -ErrorAction SilentlyContinue)) {
+        $postValidation = Test-PaneControlRuntimeContext -ProjectDir $ProjectDir -ManifestEntry $transitionEntry `
+            -Operation stop_transition
+        if ($null -eq $postValidation -or -not [bool]$postValidation.valid) {
+            $reasonCode = [string](Get-WinsmuxRuntimeValue -InputObject $postValidation -Name 'reason_code' -Default 'runtime_target_mismatch')
+            $diagnostic = [string](Get-WinsmuxRuntimeValue -InputObject $postValidation -Name 'diagnostic' -Default 'Post-commit pane set does not match the observed live server.')
+            if ($RestoreOnFailure) {
+                & $restorePublishedFiles
+            }
+            throw ("runtime dispatch refused ({0}): {1}" -f $reasonCode, $diagnostic)
+        }
     }
 
     return $count

--- a/winsmux-core/scripts/orchestra-smoke.ps1
+++ b/winsmux-core/scripts/orchestra-smoke.ps1
@@ -40,9 +40,7 @@ function Get-OrchestraSmokeLayoutSettings {
         }
     }
 
-    if ($agentSlots.Count -gt 0) {
-        $workers = $agentSlots.Count
-    }
+    $workers = Get-OrchestraMinLiveWorkerPaneCount
 
     return [ordered]@{
         Operators = if ([bool]$settings.external_operator) { 0 } else { 1 }
@@ -837,6 +835,16 @@ $winsmuxCorePath = [System.IO.Path]::GetFullPath($winsmuxCorePath)
 $layoutSettings = Get-OrchestraSmokeLayoutSettings -Root $ProjectDir
 $externalOperatorMode = ([int]$layoutSettings.Operators -eq 0)
 $expectedPaneCount = Get-OrchestraSmokeExpectedPaneCount -LayoutSettings $layoutSettings
+$orchestraModeValid = $true
+$orchestraMode = 'team'
+$orchestraModeError = ''
+try {
+    $orchestraModeDocument = Get-OrchestraModeDocument -ProjectDir $ProjectDir
+    $orchestraMode = [string]$orchestraModeDocument.mode
+} catch {
+    $orchestraModeValid = $false
+    $orchestraModeError = [string]$_.Exception.Message
+}
 
 $winsmuxBin = ''
 try {
@@ -932,6 +940,12 @@ if ($manifestFound -and $manifestReadable) {
         $manifestObject = $null
     }
 }
+if ($null -ne $manifestObject -and $null -ne $manifestObject.session) {
+    $manifestExpected = ConvertTo-OrchestraSmokeInt (Get-OrchestraSmokeObjectPropertyValue -InputObject $manifestObject.session -Name 'expected_pane_count' -Default 0)
+    if ($manifestExpected -ge 1) {
+        $expectedPaneCount = $manifestExpected
+    }
+}
 
 $workerIsolation = Get-WinsmuxWorkerIsolationReport -ProjectDir $ProjectDir -Manifest $manifestObject -GitPath $gitPath
 
@@ -951,6 +965,14 @@ if ($paneProbeOk -and $paneCount -lt $expectedPaneCount) { $smokeErrors.Add("pan
 if (-not [bool]$workerIsolation.ok) {
     foreach ($finding in @($workerIsolation.findings)) {
         $smokeErrors.Add("worker isolation drift: $($finding.label): $($finding.message)") | Out-Null
+    }
+}
+if (-not $orchestraModeValid) {
+    $smokeErrors.Add(("orchestra-mode.json is invalid: {0}" -f $orchestraModeError)) | Out-Null
+} else {
+    $liveWorkerPaneCount = Get-OrchestraLiveWorkerRolePaneCount -Manifest $manifestObject
+    if (-not (Test-OrchestraSimpleModeLiveWorkerLimit -Mode $orchestraMode -LiveWorkerPaneCount $liveWorkerPaneCount)) {
+        $smokeErrors.Add('simple_mode_live_worker_limit: simple mode forbids more than one live worker-role pane.') | Out-Null
     }
 }
 

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -977,9 +977,7 @@ function Get-OrchestraLayoutSettings {
     }
 
     $managedOperators = if ($externalOperator) { 0 } else { 1 }
-    if ($agentSlots.Count -gt 0) {
-        $workers = $agentSlots.Count
-    }
+    $workers = Get-OrchestraMinLiveWorkerPaneCount
     if ($workers -lt 1) {
         throw "worker_count must be 1 or greater in external operator mode (got $workers)."
     }
@@ -3110,8 +3108,10 @@ if ($MyInvocation.InvocationName -ne '.') {
 
         try {
             try {
+                $null = Get-OrchestraModeDocument -ProjectDir $projectDir
                 Assert-TeamProfileStartGate -ProjectDir $projectDir
                 $layout = . $layoutScript -SessionName $sessionName -Operators $layoutSettings.Operators -Workers $layoutSettings.Workers -Builders $layoutSettings.Builders -Researchers $layoutSettings.Researchers -Reviewers $layoutSettings.Reviewers
+                $expectedPaneCount = [int]$layout.Panes.Count
                 foreach ($sessionPaneId in @(Get-OrchestraSessionPaneIds -SessionName $sessionName)) {
                     if ($createdPaneIds -notcontains $sessionPaneId) {
                         $createdPaneIds += $sessionPaneId

--- a/winsmux-core/scripts/orchestra-start.ps1
+++ b/winsmux-core/scripts/orchestra-start.ps1
@@ -1132,10 +1132,11 @@ function Invoke-TeamProfileLaunchProjection {
         [Parameter(Mandatory = $true)][string]$SessionId,
         [Parameter(Mandatory = $true)][string]$SlotId,
         [AllowEmptyString()][string]$Worktree = '',
-        [string]$ReadWriteScope = 'session'
+        [string]$ReadWriteScope = 'session',
+        [switch]$Force
     )
 
-    if ($script:teamProfileOptedIn -ne $true) {
+    if (-not $Force -and $script:teamProfileOptedIn -ne $true) {
         return $null
     }
 

--- a/winsmux-core/scripts/orchestra-supervisor.ps1
+++ b/winsmux-core/scripts/orchestra-supervisor.ps1
@@ -235,8 +235,11 @@ function Invoke-OrchestraSupervisorLoop {
         $runtimeSnapshot = Get-OrchestraSupervisorRuntimePaneSnapshot -Manifest $runtimeManifest `
             -GenerationId $GenerationId -ServerSessionId $ServerSessionId -ProcessResolver $processResolver
         if ([bool]$runtimeSnapshot.valid) {
+            # Lease refresh must not rewrite registry.panes. Spawn/archive owns the
+            # pane-set commit. Passing a snapshot taken before that commit races the
+            # supervisor into restoring the old pane set.
             Update-WinsmuxRuntimeRegistryLease -ProjectDir $runtimeProjectDir -GenerationId $GenerationId `
-                -SupervisorPid $PID -SupervisorProcessStartedAt $supervisorProcessStartedAt -Panes @($runtimeSnapshot.panes) `
+                -SupervisorPid $PID -SupervisorProcessStartedAt $supervisorProcessStartedAt `
                 -Now $now -LeaseSeconds 15 | Out-Null
         } else {
             Write-OrchestraSupervisorWarning -Component 'runtime-registry' -Message ([string]$runtimeSnapshot.diagnostic)

--- a/winsmux-core/scripts/pane-control.ps1
+++ b/winsmux-core/scripts/pane-control.ps1
@@ -459,12 +459,14 @@ function Test-PaneControlRuntimeContext {
         [Parameter(Mandatory = $true)]$ManifestEntry,
         [ValidateSet('dispatch', 'start_deferred', 'caller_ack', 'stop_transition')][string]$Operation = 'dispatch',
         [AllowNull()]$CallerIdentity = $null,
-        [AllowNull()][scriptblock]$ProcessResolver = $null
+        [AllowNull()][scriptblock]$ProcessResolver = $null,
+        [AllowNull()]$PlannedManifest = $null,
+        [AllowNull()]$PlannedRegistry = $null
     )
 
     try {
-        $manifest = Get-WinsmuxManifest -ProjectDir $ProjectDir
-        $registry = Read-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir
+        $manifest = if ($null -ne $PlannedManifest) { $PlannedManifest } else { Get-WinsmuxManifest -ProjectDir $ProjectDir }
+        $registry = if ($null -ne $PlannedRegistry) { $PlannedRegistry } else { Read-WinsmuxRuntimeRegistry -ProjectDir $ProjectDir }
     } catch {
         return New-WinsmuxRuntimeValidationResult -Valid $false -ReasonCode 'manifest_regeneration_required' `
             -Diagnostic 'Runtime manifest or registry is missing or malformed; regenerate the orchestra session.'
@@ -671,7 +673,8 @@ function Save-PaneControlManifestDocument {
         [Parameter(Mandatory = $true)]$Manifest,
         [AllowEmptyString()][string]$ExpectedGenerationId = '',
         [AllowEmptyString()][string]$RuntimePaneId = '',
-        [ValidateSet('auto', 'dispatch', 'start_deferred', 'caller_ack', 'stop_transition')][string]$RuntimeOperation = 'auto'
+        [ValidateSet('auto', 'dispatch', 'start_deferred', 'caller_ack', 'stop_transition')][string]$RuntimeOperation = 'auto',
+        [switch]$AcceptPlannedPaneSet
     )
 
     $projectDir = Split-Path (Split-Path $ManifestPath -Parent) -Parent
@@ -707,8 +710,12 @@ function Save-PaneControlManifestDocument {
         throw 'runtime dispatch refused (invalid_supervisor_identity): Runtime generation changed before the manifest mutation began.'
     }
 
-    $bootstrapPaneId = [string](Get-WinsmuxRuntimeValue -InputObject $currentSession -Name 'bootstrap_pane_id' -Default '')
-    $paneMap = ConvertTo-ManifestPropertyMap -Value (Get-WinsmuxRuntimeValue -InputObject $currentManifest -Name 'panes' -Default $null)
+    $paneSourceManifest = if ($AcceptPlannedPaneSet) { $Manifest } else { $currentManifest }
+    $paneSourceSession = Get-WinsmuxRuntimeValue -InputObject $paneSourceManifest -Name 'session' -Default $null
+    $bootstrapPaneId = [string](Get-WinsmuxRuntimeValue -InputObject $paneSourceSession -Name 'bootstrap_pane_id' -Default (
+        Get-WinsmuxRuntimeValue -InputObject $currentSession -Name 'bootstrap_pane_id' -Default ''
+    ))
+    $paneMap = ConvertTo-ManifestPropertyMap -Value (Get-WinsmuxRuntimeValue -InputObject $paneSourceManifest -Name 'panes' -Default $null)
     $managedPaneIds = [System.Collections.Generic.List[string]]::new()
     $seenPaneIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
     foreach ($label in @($paneMap.Keys | Sort-Object)) {
@@ -729,24 +736,29 @@ function Save-PaneControlManifestDocument {
         }
         $RuntimePaneId = $managedPaneIds[0]
     } elseif ($RuntimePaneId -cnotmatch '^%[0-9]+$' -or -not $seenPaneIds.Contains($RuntimePaneId)) {
-        throw 'runtime dispatch refused (runtime_target_mismatch): RuntimePaneId must identify a managed non-bootstrap pane in the current v2 manifest.'
+        $paneSetName = if ($AcceptPlannedPaneSet) { 'planned' } else { 'current' }
+        throw ("runtime dispatch refused (runtime_target_mismatch): RuntimePaneId must identify a managed non-bootstrap pane in the {0} v2 manifest." -f $paneSetName)
     }
 
-    $manifestEntry = Get-PaneControlManifestContext -ProjectDir $projectDir -PaneId $RuntimePaneId
-    $effectiveOperation = $RuntimeOperation
-    if ($effectiveOperation -ceq 'auto') {
-        $status = [string](Get-PaneControlValue -InputObject $manifestEntry -Name 'Status' -Default '')
-        $effectiveOperation = [string](Get-WinsmuxRuntimeStatusClassification -Status $status).RuntimeOperation
-    }
-    $runtimeValidation = Test-PaneControlRuntimeContext -ProjectDir $projectDir -ManifestEntry $manifestEntry -Operation $effectiveOperation
-    if ($null -eq $runtimeValidation -or -not [bool]$runtimeValidation.valid) {
-        $reasonCode = [string](Get-PaneControlValue -InputObject $runtimeValidation -Name 'reason_code' -Default 'invalid_supervisor_identity')
-        $diagnostic = [string](Get-PaneControlValue -InputObject $runtimeValidation -Name 'diagnostic' -Default 'Runtime identity validation failed immediately before manifest save.')
-        throw ("runtime dispatch refused ({0}): {1}" -f $reasonCode, $diagnostic)
-    }
-    $validatedGenerationId = [string](Get-PaneControlValue -InputObject $runtimeValidation.context -Name 'generation_id' -Default '')
-    if (-not [string]::Equals($validatedGenerationId, $ExpectedGenerationId, [System.StringComparison]::Ordinal)) {
-        throw 'runtime dispatch refused (invalid_supervisor_identity): Runtime generation changed immediately before manifest save.'
+    # After split-window / kill-pane the live server already has the next set.
+    # Comparing the still-old on-disk documents to that server is a stale check.
+    if (-not $AcceptPlannedPaneSet) {
+        $manifestEntry = Get-PaneControlManifestContext -ProjectDir $projectDir -PaneId $RuntimePaneId
+        $effectiveOperation = $RuntimeOperation
+        if ($effectiveOperation -ceq 'auto') {
+            $status = [string](Get-PaneControlValue -InputObject $manifestEntry -Name 'Status' -Default '')
+            $effectiveOperation = [string](Get-WinsmuxRuntimeStatusClassification -Status $status).RuntimeOperation
+        }
+        $runtimeValidation = Test-PaneControlRuntimeContext -ProjectDir $projectDir -ManifestEntry $manifestEntry -Operation $effectiveOperation
+        if ($null -eq $runtimeValidation -or -not [bool]$runtimeValidation.valid) {
+            $reasonCode = [string](Get-PaneControlValue -InputObject $runtimeValidation -Name 'reason_code' -Default 'invalid_supervisor_identity')
+            $diagnostic = [string](Get-PaneControlValue -InputObject $runtimeValidation -Name 'diagnostic' -Default 'Runtime identity validation failed immediately before manifest save.')
+            throw ("runtime dispatch refused ({0}): {1}" -f $reasonCode, $diagnostic)
+        }
+        $validatedGenerationId = [string](Get-PaneControlValue -InputObject $runtimeValidation.context -Name 'generation_id' -Default '')
+        if (-not [string]::Equals($validatedGenerationId, $ExpectedGenerationId, [System.StringComparison]::Ordinal)) {
+            throw 'runtime dispatch refused (invalid_supervisor_identity): Runtime generation changed immediately before manifest save.'
+        }
     }
 
     $freshManifest = Get-WinsmuxManifest -ProjectDir $projectDir

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -315,6 +315,37 @@ function Get-PaneScalerReadinessAgent {
     return $readinessAgent
 }
 
+function New-PaneScalerWorkerLaunchApproval {
+    param(
+        [Parameter(Mandatory = $true)][string]$SlotId,
+        [Parameter(Mandatory = $true)]$SlotAgentConfig,
+        [bool]$AutoLaunch = $false
+    )
+
+    if (Get-Command New-OrchestraWorkerLaunchApproval -ErrorAction SilentlyContinue) {
+        return New-OrchestraWorkerLaunchApproval -SlotId $SlotId -SlotAgentConfig $SlotAgentConfig -AutoLaunch:$AutoLaunch
+    }
+
+    return [ordered]@{
+        packet_type             = 'worker_launch_approval'
+        source                  = 'user_approved_worker_config'
+        slot_id                 = $SlotId
+        worker_backend          = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'WorkerBackend' -Default '')
+        worker_role             = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'WorkerRole' -Default '')
+        agent                   = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'Agent' -Default '')
+        model                   = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'Model' -Default '')
+        model_source            = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'ModelSource' -Default '')
+        reasoning_effort        = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'ReasoningEffort' -Default '')
+        prompt_transport        = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'PromptTransport' -Default '')
+        auth_mode               = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'AuthMode' -Default '')
+        credential_requirements = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'CredentialRequirements' -Default '')
+        execution_profile       = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'ExecutionProfile' -Default '')
+        execution_backend       = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'ExecutionBackend' -Default '')
+        analysis_posture        = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'AnalysisPosture' -Default '')
+        auto_launch             = [bool]$AutoLaunch
+    }
+}
+
 function New-PaneScalerBuilderWorktree {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -759,6 +790,11 @@ function Add-OrchestraWorkerPane {
         if (Get-Command Resolve-WinsmuxRuntimeRole -ErrorAction SilentlyContinue) {
             $runtimeWorkerRole = Resolve-WinsmuxRuntimeRole -WorkerRole 'worker' -CanonicalRole 'Worker'
         }
+        $capabilityAdapter = Get-PaneScalerReadinessAgent -SlotAgentConfig $SlotAgentConfig -FallbackAgent $agent
+        $approvedLaunch = $null
+        if ($null -ne $SlotAgentConfig) {
+            $approvedLaunch = New-PaneScalerWorkerLaunchApproval -SlotId $SlotId -SlotAgentConfig $SlotAgentConfig -AutoLaunch $true
+        }
         $cleanPtyEnv = [pscustomobject]@{ Environment = [ordered]@{} }
         if (Get-Command Get-CleanPtyEnv -ErrorAction SilentlyContinue) {
             try {
@@ -790,7 +826,8 @@ function Add-OrchestraWorkerPane {
             -StartupToken $startupToken `
             -LaunchDir $worktree.WorktreePath `
             -CleanPtyEnv $cleanPtyEnv `
-            -LaunchCommand $launchCommand
+            -LaunchCommand $launchCommand `
+            -ApprovedLaunch $approvedLaunch
         Start-OrchestraPaneBootstrap -PaneId $newPaneId -PlanPath $bootstrapPlanPath -SessionName $sessionName
         $bootstrapMarkerPath = Get-OrchestraPaneBootstrapMarkerPath -PlanPath $bootstrapPlanPath -GenerationId $expectedGenerationId
         $runtimeReady = $false
@@ -842,6 +879,12 @@ function Add-OrchestraWorkerPane {
             runtime_ready          = $runtimeReady
             bootstrap_plan_path    = $bootstrapPlanPath
             bootstrap_marker_path  = $bootstrapMarkerPath
+        }
+        if ($null -ne $approvedLaunch) {
+            $newPane['approved_launch'] = $approvedLaunch
+        }
+        if (-not [string]::IsNullOrWhiteSpace($capabilityAdapter)) {
+            $newPane['capability_adapter'] = $capabilityAdapter
         }
         if ($null -ne $Projection) {
             $projRoot = $Projection

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -576,6 +576,7 @@ function Add-OrchestraWorkerPane {
         $Settings = $null,
         $SlotAgentConfig = $null,
         $Assignment = $null,
+        $Projection = $null,
         [int]$AgentReadyTimeoutSeconds = 60,
         [int]$AgentReadyPollMilliseconds = 2000
     )
@@ -691,6 +692,17 @@ function Add-OrchestraWorkerPane {
         $launchCommand = Get-PaneScalerLaunchCommand -Agent $agent -Model $model -ModelSource $modelSource -ReasoningEffort $effort -McpMode $mcpMode -SlotId $SlotId -ProjectDir $worktree.WorktreePath -GitWorktreeDir $worktree.GitWorktreeDir -RootPath $projectDir
         if ([string]::IsNullOrWhiteSpace($launchCommand)) {
             throw 'Worker spawn requires a non-empty orchestra bootstrap launch command.'
+        }
+        if ($null -ne $Projection) {
+            if (-not (Get-Command Add-TeamProfileBundleToLaunchCommand -ErrorAction SilentlyContinue)) {
+                if (Get-Command Import-Task789OrchestraHelpers -ErrorAction SilentlyContinue) {
+                    Import-Task789OrchestraHelpers -IncludePaneScaler
+                }
+            }
+            if (-not (Get-Command Add-TeamProfileBundleToLaunchCommand -ErrorAction SilentlyContinue)) {
+                throw 'Worker spawn requires Add-TeamProfileBundleToLaunchCommand to attach the Team Profile bundle.'
+            }
+            $launchCommand = Add-TeamProfileBundleToLaunchCommand -LaunchCommand $launchCommand -Projection $Projection -ProjectDir $projectDir
         }
 
         $paneTitle = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'PaneTitle' -Default $SlotId)
@@ -1020,11 +1032,12 @@ function Add-OrchestraPane {
         [ValidateSet('Builder', 'Worker')][string]$Role = 'Builder',
         [AllowEmptyString()][string]$SlotId = '',
         $SlotAgentConfig = $null,
-        $Assignment = $null
+        $Assignment = $null,
+        $Projection = $null
     )
 
     if ($Role -eq 'Worker') {
-        return Add-OrchestraWorkerPane -ManifestPath $ManifestPath -SlotId $SlotId -Settings $Settings -SlotAgentConfig $SlotAgentConfig -Assignment $Assignment
+        return Add-OrchestraWorkerPane -ManifestPath $ManifestPath -SlotId $SlotId -Settings $Settings -SlotAgentConfig $SlotAgentConfig -Assignment $Assignment -Projection $Projection
     }
 
     $manifest = Read-PaneScalerManifest -ManifestPath $ManifestPath

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -105,7 +105,9 @@ function Save-PaneScalerManifest {
     param(
         [Parameter(Mandatory = $true)][string]$ManifestPath,
         [Parameter(Mandatory = $true)]$Manifest,
-        [AllowEmptyString()][string]$ExpectedGenerationId = ''
+        [AllowEmptyString()][string]$ExpectedGenerationId = '',
+        [AllowEmptyString()][string]$RuntimePaneId = '',
+        [ValidateSet('auto', 'dispatch', 'start_deferred', 'caller_ack', 'stop_transition')][string]$RuntimeOperation = 'auto'
     )
 
     $projectDir = Split-Path (Split-Path $ManifestPath -Parent) -Parent
@@ -125,7 +127,8 @@ function Save-PaneScalerManifest {
     }
 
     Save-PaneControlManifestDocument -ManifestPath $ManifestPath -Manifest $canonicalManifest `
-        -ExpectedGenerationId $ExpectedGenerationId
+        -ExpectedGenerationId $ExpectedGenerationId -RuntimePaneId $RuntimePaneId `
+        -RuntimeOperation $RuntimeOperation
 }
 
 function Assert-PaneScalerPaneCountMutationSupported {
@@ -468,10 +471,16 @@ function New-PaneScalerWorkerWorktree {
 function Update-PaneScalerLiveExpectedPaneCount {
     param(
         [Parameter(Mandatory = $true)]$Manifest,
-        [Parameter(Mandatory = $true)][string]$ProjectDir
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [AllowEmptyString()][string]$ManifestPath = '',
+        [AllowEmptyString()][string]$ExpectedGenerationId = ''
     )
 
     $liveCount = @($Manifest.Panes.Keys).Count
+    if (-not [string]::IsNullOrWhiteSpace($ManifestPath) -and (Get-Command Save-OrchestraLivePaneSetTransition -ErrorAction SilentlyContinue)) {
+        return Save-OrchestraLivePaneSetTransition -ManifestPath $ManifestPath -Manifest $Manifest `
+            -ProjectDir $ProjectDir -ExpectedGenerationId $ExpectedGenerationId
+    }
     if (Get-Command Set-OrchestraLiveExpectedPaneCount -ErrorAction SilentlyContinue) {
         return Set-OrchestraLiveExpectedPaneCount -Manifest $Manifest -ExpectedPaneCount $liveCount -ProjectDir $ProjectDir
     }
@@ -537,9 +546,30 @@ function Add-OrchestraWorkerPane {
 
     $manifest = Read-PaneScalerManifest -ManifestPath $ManifestPath
     $expectedGenerationId = [string](Get-MonitorPropertyValue -InputObject $manifest.Session -Name 'generation_id' -Default '')
+    $serverSessionId = [string](Get-MonitorPropertyValue -InputObject $manifest.Session -Name 'server_session_id' -Default '')
+    $startupToken = [string](Get-MonitorPropertyValue -InputObject $manifest.Session -Name 'startup_token' -Default '')
+    $sessionName = [string](Get-MonitorPropertyValue -InputObject $manifest.Session -Name 'name' -Default 'winsmux-orchestra')
+    if ([string]::IsNullOrWhiteSpace($sessionName)) {
+        $sessionName = 'winsmux-orchestra'
+    }
     $projectDir = Get-PaneScalerProjectDir -Manifest $manifest -ManifestPath $ManifestPath
     if ($null -eq $Settings) {
         $Settings = Get-BridgeSettings -RootPath $projectDir
+    }
+    if ([string]::IsNullOrWhiteSpace($expectedGenerationId) -or [string]::IsNullOrWhiteSpace($serverSessionId)) {
+        throw 'Worker spawn requires a verified session generation and server session identity.'
+    }
+    if ((-not (Get-Command New-OrchestraPaneBootstrapPlan -ErrorAction SilentlyContinue)) -or
+        (-not (Get-Command Get-OrchestraPaneBootstrapMarkerPath -ErrorAction SilentlyContinue)) -or
+        (-not (Get-Command Start-OrchestraPaneBootstrap -ErrorAction SilentlyContinue))) {
+        if (Get-Command Import-Task789OrchestraHelpers -ErrorAction SilentlyContinue) {
+            Import-Task789OrchestraHelpers -IncludePaneScaler
+        }
+    }
+    if ((-not (Get-Command New-OrchestraPaneBootstrapPlan -ErrorAction SilentlyContinue)) -or
+        (-not (Get-Command Get-OrchestraPaneBootstrapMarkerPath -ErrorAction SilentlyContinue)) -or
+        (-not (Get-Command Start-OrchestraPaneBootstrap -ErrorAction SilentlyContinue))) {
+        throw 'Worker spawn requires the orchestra bootstrap plan helpers.'
     }
 
     if ([string]::IsNullOrWhiteSpace($SlotId)) {
@@ -597,17 +627,86 @@ function Add-OrchestraWorkerPane {
         }
 
         Wait-MonitorPaneShellReady -PaneId $newPaneId
-        if (-not [string]::IsNullOrWhiteSpace($agent)) {
-            Send-MonitorBridgeCommand -PaneId $newPaneId -Text (Get-PaneScalerLaunchCommand -Agent $agent -Model $model -ModelSource $modelSource -ReasoningEffort $effort -McpMode $mcpMode -SlotId $SlotId -ProjectDir $worktree.WorktreePath -GitWorktreeDir $worktree.GitWorktreeDir -RootPath $projectDir) -DeliveryClass 'launch'
+        if ([string]::IsNullOrWhiteSpace($agent)) {
+            throw 'Worker spawn requires a Team Profile agent for the orchestra bootstrap launch command.'
+        }
+        $launchCommand = Get-PaneScalerLaunchCommand -Agent $agent -Model $model -ModelSource $modelSource -ReasoningEffort $effort -McpMode $mcpMode -SlotId $SlotId -ProjectDir $worktree.WorktreePath -GitWorktreeDir $worktree.GitWorktreeDir -RootPath $projectDir
+        if ([string]::IsNullOrWhiteSpace($launchCommand)) {
+            throw 'Worker spawn requires a non-empty orchestra bootstrap launch command.'
         }
 
         $paneTitle = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'PaneTitle' -Default $SlotId)
+        $runtimeWorkerRole = 'worker'
+        if (Get-Command Resolve-WinsmuxRuntimeRole -ErrorAction SilentlyContinue) {
+            $runtimeWorkerRole = Resolve-WinsmuxRuntimeRole -WorkerRole 'worker' -CanonicalRole 'Worker'
+        }
+        $cleanPtyEnv = [pscustomobject]@{ Environment = [ordered]@{} }
+        if (Get-Command Get-CleanPtyEnv -ErrorAction SilentlyContinue) {
+            try {
+                $allowedEnvironment = $null
+                if (Get-Command Get-WinsmuxPaneEnvironment -ErrorAction SilentlyContinue) {
+                    $allowedEnvironment = Get-WinsmuxPaneEnvironment -Role 'Worker' -PaneId $newPaneId -SessionName $sessionName -ProjectDir $projectDir -SlotId $SlotId -BuilderWorktreePath $worktree.WorktreePath -AssignedBranch $worktree.BranchName -GitWorktreeDir $worktree.GitWorktreeDir
+                }
+                if ($null -ne $allowedEnvironment) {
+                    $cleanPtyEnv = Get-CleanPtyEnv -AllowedEnvironment $allowedEnvironment
+                }
+            } catch {
+                $cleanPtyEnv = [pscustomobject]@{ Environment = [ordered]@{} }
+            }
+        }
+
+        $bootstrapPlanPath = New-OrchestraPaneBootstrapPlan `
+            -ProjectDir $projectDir `
+            -PaneId $newPaneId `
+            -Label $SlotId `
+            -SlotId $SlotId `
+            -Role 'Worker' `
+            -WorkerBackend $workerBackend `
+            -WorkerRole $runtimeWorkerRole `
+            -PaneTitle $paneTitle `
+            -GenerationId $expectedGenerationId `
+            -ServerSessionId $serverSessionId `
+            -Agent $agent `
+            -Model $model `
+            -StartupToken $startupToken `
+            -LaunchDir $worktree.WorktreePath `
+            -CleanPtyEnv $cleanPtyEnv `
+            -LaunchCommand $launchCommand
+        Start-OrchestraPaneBootstrap -PaneId $newPaneId -PlanPath $bootstrapPlanPath -SessionName $sessionName
+        $bootstrapMarkerPath = Get-OrchestraPaneBootstrapMarkerPath -PlanPath $bootstrapPlanPath -GenerationId $expectedGenerationId
+        $runtimeReady = $false
+        $paneStatus = 'deferred_starting'
+        if (-not [string]::IsNullOrWhiteSpace($bootstrapMarkerPath)) {
+            for ($waitAttempt = 1; $waitAttempt -le 20; $waitAttempt++) {
+                if (Test-Path -LiteralPath $bootstrapMarkerPath -PathType Leaf) {
+                    break
+                }
+                Start-Sleep -Milliseconds 100
+            }
+            if (Test-Path -LiteralPath $bootstrapMarkerPath -PathType Leaf) {
+                try {
+                    $marker = Get-Content -LiteralPath $bootstrapMarkerPath -Raw -Encoding UTF8 | ConvertFrom-Json
+                    $markerPid = $null
+                    if (Get-Command ConvertTo-WinsmuxRuntimeInteger -ErrorAction SilentlyContinue) {
+                        $markerPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $marker -Name 'bootstrap_pid' -Default $null)
+                    } else {
+                        $markerPid = [int](Get-MonitorPropertyValue -InputObject $marker -Name 'bootstrap_pid' -Default 0)
+                    }
+                    if ($null -ne $markerPid -and $markerPid -gt 0) {
+                        $runtimeReady = $true
+                        $paneStatus = 'ready'
+                    }
+                } catch {
+                }
+            }
+        }
+
         $newPane = [ordered]@{
             label                  = $SlotId
             slot_id                = $SlotId
             pane_id                = $newPaneId
             role                   = 'Worker'
-            worker_role            = 'worker'
+            worker_role            = $runtimeWorkerRole
             worker_backend         = $workerBackend
             title                  = $paneTitle
             exec_mode              = 'false'
@@ -615,16 +714,19 @@ function Add-OrchestraWorkerPane {
             builder_branch         = $worktree.BranchName
             builder_worktree_path  = $worktree.WorktreePath
             task                   = $null
-            status                 = 'ready'
+            status                 = $paneStatus
+            runtime_ready          = $runtimeReady
+            bootstrap_plan_path    = $bootstrapPlanPath
+            bootstrap_marker_path  = $bootstrapMarkerPath
         }
         $paneObject = [PSCustomObject]@{}
         foreach ($entry in $newPane.GetEnumerator()) {
             Add-Member -InputObject $paneObject -MemberType NoteProperty -Name $entry.Key -Value $entry.Value
         }
         $manifest.Panes[$SlotId] = $paneObject
-        Update-PaneScalerLiveExpectedPaneCount -Manifest $manifest -ProjectDir $projectDir | Out-Null
         $manifest.SavedAt = Get-Date -Format o
-        Save-PaneScalerManifest -ManifestPath $ManifestPath -Manifest $manifest -ExpectedGenerationId $expectedGenerationId
+        Update-PaneScalerLiveExpectedPaneCount -Manifest $manifest -ProjectDir $projectDir `
+            -ManifestPath $ManifestPath -ExpectedGenerationId $expectedGenerationId | Out-Null
 
         return [PSCustomObject]@{
             Changed      = $true
@@ -698,9 +800,9 @@ function Remove-OrchestraWorkerPane {
     $worktreePath = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'builder_worktree_path' -Default '')
     $branchName = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'builder_branch' -Default '')
     [void]$manifest.Panes.Remove($Label)
-    Update-PaneScalerLiveExpectedPaneCount -Manifest $manifest -ProjectDir $projectDir | Out-Null
     $manifest.SavedAt = Get-Date -Format o
-    Save-PaneScalerManifest -ManifestPath $ManifestPath -Manifest $manifest -ExpectedGenerationId $expectedGenerationId
+    Update-PaneScalerLiveExpectedPaneCount -Manifest $manifest -ProjectDir $projectDir `
+        -ManifestPath $ManifestPath -ExpectedGenerationId $expectedGenerationId | Out-Null
 
     if (-not [string]::IsNullOrWhiteSpace($paneId)) {
         Invoke-MonitorWinsmux -Arguments @('kill-pane', '-t', $paneId) | Out-Null

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -295,6 +295,26 @@ function Test-PaneScalerParallelRunsAvailable {
     return [bool](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'SupportsParallelRuns' -Default $false)
 }
 
+function Get-PaneScalerReadinessAgent {
+    param(
+        [AllowNull()]$SlotAgentConfig,
+        [string]$FallbackAgent = ''
+    )
+
+    $readinessAgent = ''
+    if ($null -ne $SlotAgentConfig) {
+        $readinessAgent = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'CapabilityAdapter' -Default '')
+        if ([string]::IsNullOrWhiteSpace($readinessAgent)) {
+            $readinessAgent = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'Agent' -Default '')
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($readinessAgent)) {
+        $readinessAgent = [string]$FallbackAgent
+    }
+
+    return $readinessAgent
+}
+
 function New-PaneScalerBuilderWorktree {
     param(
         [Parameter(Mandatory = $true)][string]$ProjectDir,
@@ -397,11 +417,7 @@ function Get-PaneWorkload {
             }
         }
 
-        $statusAgent = [string](Get-MonitorPropertyValue -InputObject $roleAgentConfig -Name 'CapabilityAdapter' -Default '')
-        if ([string]::IsNullOrWhiteSpace($statusAgent)) {
-            $statusAgent = [string]$roleAgentConfig.Agent
-        }
-
+        $statusAgent = Get-PaneScalerReadinessAgent -SlotAgentConfig $roleAgentConfig
         $status = Get-PaneAgentStatus -PaneId $paneId -Agent $statusAgent -Role 'Builder' -HungThreshold $HungThreshold
         $statusName = [string](Get-MonitorPropertyValue -InputObject $status -Name 'Status' -Default '')
         if ($statusName -in @('busy', 'approval_waiting')) {
@@ -799,7 +815,8 @@ function Add-OrchestraWorkerPane {
                     $markerPid = $null
                 }
                 if ($null -ne $markerPid -and $markerPid -gt 0) {
-                    Wait-OrchestraSpawnAgentReady -PaneId $newPaneId -Agent $agent `
+                    $readinessAgent = Get-PaneScalerReadinessAgent -SlotAgentConfig $SlotAgentConfig -FallbackAgent $agent
+                    Wait-OrchestraSpawnAgentReady -PaneId $newPaneId -Agent $readinessAgent `
                         -TimeoutSeconds $AgentReadyTimeoutSeconds `
                         -PollMilliseconds $AgentReadyPollMilliseconds
                     $runtimeReady = $true

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -3,7 +3,26 @@ Set-StrictMode -Version Latest
 
 $scriptDir = $PSScriptRoot
 . (Join-Path $scriptDir 'settings.ps1')
+# agent-monitor.ps1 is dual-mode: param() binds when dotted and would clobber
+# a caller $ProjectDir (DW15 rollback probe, other send helpers).
+$monitorCallerVars = [ordered]@{}
+foreach ($name in @('ProjectDir', 'SessionName', 'HungThresholdSeconds', 'ContextResetThresholdPercent')) {
+    $existing = Get-Variable -Name $name -ErrorAction SilentlyContinue
+    if ($null -ne $existing) {
+        $monitorCallerVars[$name] = [pscustomobject]@{ Present = $true; Value = $existing.Value }
+    } else {
+        $monitorCallerVars[$name] = [pscustomobject]@{ Present = $false; Value = $null }
+    }
+}
 . (Join-Path $scriptDir 'agent-monitor.ps1')
+foreach ($name in @($monitorCallerVars.Keys)) {
+    $saved = $monitorCallerVars[$name]
+    if ([bool]$saved.Present) {
+        Set-Variable -Name $name -Value $saved.Value
+    } else {
+        Remove-Variable -Name $name -ErrorAction SilentlyContinue
+    }
+}
 . (Join-Path $scriptDir 'builder-worktree.ps1')
 . (Join-Path $scriptDir 'clm-safe-io.ps1')
 . (Join-Path $scriptDir 'manifest.ps1')
@@ -796,6 +815,30 @@ function Add-OrchestraWorkerPane {
             runtime_ready          = $runtimeReady
             bootstrap_plan_path    = $bootstrapPlanPath
             bootstrap_marker_path  = $bootstrapMarkerPath
+        }
+        if ($null -ne $Projection) {
+            $projRoot = $Projection
+            $nestedProjection = Get-WinsmuxRuntimeValue -InputObject $Projection -Name 'projection'
+            if ($null -ne $nestedProjection) {
+                $projRoot = $nestedProjection
+            }
+            $projectedPane = Get-WinsmuxRuntimeValue -InputObject $projRoot -Name 'pane'
+            $projectedAssignment = Get-WinsmuxRuntimeValue -InputObject $projectedPane -Name 'assignment'
+            $projectedBundle = Get-WinsmuxRuntimeValue -InputObject $projectedPane -Name 'prompt_bundle'
+            if ($null -ne $projectedAssignment) {
+                $newPane['assignment'] = $projectedAssignment
+            }
+            if ($null -ne $projectedBundle) {
+                $newPane['prompt_bundle'] = $projectedBundle
+            }
+            $projectedSession = Get-WinsmuxRuntimeValue -InputObject $projRoot -Name 'session'
+            $projectedTeamProfile = Get-WinsmuxRuntimeValue -InputObject $projectedSession -Name 'team_profile'
+            if ($null -ne $projectedTeamProfile) {
+                if ($null -eq $manifest.Session) {
+                    $manifest | Add-Member -NotePropertyName 'Session' -NotePropertyValue ([pscustomobject]@{}) -Force
+                }
+                $manifest.Session | Add-Member -NotePropertyName 'team_profile' -NotePropertyValue $projectedTeamProfile -Force
+            }
         }
         $paneObject = [PSCustomObject]@{}
         foreach ($entry in $newPane.GetEnumerator()) {

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -107,7 +107,8 @@ function Save-PaneScalerManifest {
         [Parameter(Mandatory = $true)]$Manifest,
         [AllowEmptyString()][string]$ExpectedGenerationId = '',
         [AllowEmptyString()][string]$RuntimePaneId = '',
-        [ValidateSet('auto', 'dispatch', 'start_deferred', 'caller_ack', 'stop_transition')][string]$RuntimeOperation = 'auto'
+        [ValidateSet('auto', 'dispatch', 'start_deferred', 'caller_ack', 'stop_transition')][string]$RuntimeOperation = 'auto',
+        [switch]$AcceptPlannedPaneSet
     )
 
     $projectDir = Split-Path (Split-Path $ManifestPath -Parent) -Parent
@@ -128,7 +129,7 @@ function Save-PaneScalerManifest {
 
     Save-PaneControlManifestDocument -ManifestPath $ManifestPath -Manifest $canonicalManifest `
         -ExpectedGenerationId $ExpectedGenerationId -RuntimePaneId $RuntimePaneId `
-        -RuntimeOperation $RuntimeOperation
+        -RuntimeOperation $RuntimeOperation -AcceptPlannedPaneSet:$AcceptPlannedPaneSet
 }
 
 function Assert-PaneScalerPaneCountMutationSupported {
@@ -473,13 +474,16 @@ function Update-PaneScalerLiveExpectedPaneCount {
         [Parameter(Mandatory = $true)]$Manifest,
         [Parameter(Mandatory = $true)][string]$ProjectDir,
         [AllowEmptyString()][string]$ManifestPath = '',
-        [AllowEmptyString()][string]$ExpectedGenerationId = ''
+        [AllowEmptyString()][string]$ExpectedGenerationId = '',
+        [AllowEmptyString()][string]$RuntimePaneId = '',
+        [bool]$RestoreOnFailure = $true
     )
 
     $liveCount = @($Manifest.Panes.Keys).Count
     if (-not [string]::IsNullOrWhiteSpace($ManifestPath) -and (Get-Command Save-OrchestraLivePaneSetTransition -ErrorAction SilentlyContinue)) {
         return Save-OrchestraLivePaneSetTransition -ManifestPath $ManifestPath -Manifest $Manifest `
-            -ProjectDir $ProjectDir -ExpectedGenerationId $ExpectedGenerationId
+            -ProjectDir $ProjectDir -ExpectedGenerationId $ExpectedGenerationId `
+            -RuntimePaneId $RuntimePaneId -RestoreOnFailure $RestoreOnFailure
     }
     if (Get-Command Set-OrchestraLiveExpectedPaneCount -ErrorAction SilentlyContinue) {
         return Set-OrchestraLiveExpectedPaneCount -Manifest $Manifest -ExpectedPaneCount $liveCount -ProjectDir $ProjectDir
@@ -598,6 +602,30 @@ function Add-OrchestraWorkerPane {
         $workerIndex = @($manifest.Panes.Keys).Count + 1
     }
 
+    $manifestVersion = ConvertTo-WinsmuxRuntimeInteger -Value (
+        Get-MonitorPropertyValue -InputObject $manifest -Name 'version' -Default (
+            Get-MonitorPropertyValue -InputObject $manifest -Name 'Version' -Default $null
+        )
+    )
+    if ($manifestVersion -eq 2) {
+        if (-not (Get-Command Test-PaneControlRuntimeContext -ErrorAction SilentlyContinue)) {
+            throw 'Worker spawn requires live runtime validation before the server pane set is mutated.'
+        }
+        $seedEntry = $null
+        if (Get-Command New-OrchestraLiveTransitionManifestEntry -ErrorAction SilentlyContinue) {
+            $seedEntry = New-OrchestraLiveTransitionManifestEntry -Manifest $manifest -RuntimePaneId $seed.PaneId
+        }
+        if ($null -eq $seedEntry) {
+            throw 'Worker spawn requires a tracked seed pane in the current v2 pane set.'
+        }
+        $preflight = Test-PaneControlRuntimeContext -ProjectDir $projectDir -ManifestEntry $seedEntry -Operation stop_transition
+        if ($null -eq $preflight -or -not [bool]$preflight.valid) {
+            $reasonCode = [string](Get-MonitorPropertyValue -InputObject $preflight -Name 'reason_code' -Default 'runtime_target_mismatch')
+            $diagnostic = [string](Get-MonitorPropertyValue -InputObject $preflight -Name 'diagnostic' -Default 'Current live pane set is not consistent.')
+            throw ("Worker spawn refused ({0}): {1}" -f $reasonCode, $diagnostic)
+        }
+    }
+
     $worktree = $null
     $newPaneId = ''
     try {
@@ -607,8 +635,6 @@ function Add-OrchestraWorkerPane {
         if ([string]::IsNullOrWhiteSpace($newPaneId)) {
             throw 'winsmux split-window did not return a pane id.'
         }
-
-        Invoke-MonitorWinsmux -Arguments @('select-pane', '-t', $newPaneId, '-T', $SlotId) | Out-Null
 
         $agent = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'Agent' -Default ([string]$Settings.agent))
         $model = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'Model' -Default ([string]$Settings.model))
@@ -636,6 +662,10 @@ function Add-OrchestraWorkerPane {
         }
 
         $paneTitle = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'PaneTitle' -Default $SlotId)
+        if ([string]::IsNullOrWhiteSpace($paneTitle)) {
+            $paneTitle = $SlotId
+        }
+        Invoke-MonitorWinsmux -Arguments @('select-pane', '-t', $newPaneId, '-T', $paneTitle) | Out-Null
         $runtimeWorkerRole = 'worker'
         if (Get-Command Resolve-WinsmuxRuntimeRole -ErrorAction SilentlyContinue) {
             $runtimeWorkerRole = Resolve-WinsmuxRuntimeRole -WorkerRole 'worker' -CanonicalRole 'Worker'
@@ -726,7 +756,8 @@ function Add-OrchestraWorkerPane {
         $manifest.Panes[$SlotId] = $paneObject
         $manifest.SavedAt = Get-Date -Format o
         Update-PaneScalerLiveExpectedPaneCount -Manifest $manifest -ProjectDir $projectDir `
-            -ManifestPath $ManifestPath -ExpectedGenerationId $expectedGenerationId | Out-Null
+            -ManifestPath $ManifestPath -ExpectedGenerationId $expectedGenerationId `
+            -RuntimePaneId $seed.PaneId -RestoreOnFailure $true | Out-Null
 
         return [PSCustomObject]@{
             Changed      = $true
@@ -753,6 +784,43 @@ function Add-OrchestraWorkerPane {
     }
 }
 
+function Test-OrchestraLiveServerPanePresent {
+    param(
+        [Parameter(Mandatory = $true)][string]$PaneId,
+        [Parameter(Mandatory = $true)][string]$SessionName
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PaneId) -or [string]::IsNullOrWhiteSpace($SessionName)) {
+        return $null
+    }
+
+    try {
+        $format = "#{session_id}`t#{session_name}`t#{pane_id}`t#{pane_title}"
+        $output = $null
+        if (Get-Command Invoke-PaneControlWinsmux -ErrorAction SilentlyContinue) {
+            $output = Invoke-PaneControlWinsmux -Arguments @('list-panes', '-a', '-t', $SessionName, '-F', $format)
+        } elseif (Get-Command Invoke-MonitorWinsmux -ErrorAction SilentlyContinue) {
+            $output = Invoke-MonitorWinsmux -Arguments @('list-panes', '-a', '-t', $SessionName, '-F', $format) -CaptureOutput
+        } else {
+            return $null
+        }
+
+        foreach ($line in @((($output | Out-String).Trim()) -split "\r?\n")) {
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+            $parts = $line -split "`t", 4
+            if ($parts.Count -ge 3 -and $parts[2] -ceq $PaneId) {
+                return $true
+            }
+            if ($line.Trim() -ceq $PaneId) {
+                return $true
+            }
+        }
+        return $false
+    } catch {
+        return $null
+    }
+}
+
 function Remove-OrchestraWorkerPane {
     param(
         [Parameter(Mandatory = $true)][string]$ManifestPath,
@@ -762,6 +830,10 @@ function Remove-OrchestraWorkerPane {
 
     $manifest = Read-PaneScalerManifest -ManifestPath $ManifestPath
     $expectedGenerationId = [string](Get-MonitorPropertyValue -InputObject $manifest.Session -Name 'generation_id' -Default '')
+    $sessionName = [string](Get-MonitorPropertyValue -InputObject $manifest.Session -Name 'name' -Default 'winsmux-orchestra')
+    if ([string]::IsNullOrWhiteSpace($sessionName)) {
+        $sessionName = 'winsmux-orchestra'
+    }
     $projectDir = Get-PaneScalerProjectDir -Manifest $manifest -ManifestPath $ManifestPath
     if (-not $manifest.Panes.Contains($Label)) {
         return [PSCustomObject]@{
@@ -799,19 +871,100 @@ function Remove-OrchestraWorkerPane {
     $paneId = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'pane_id' -Default '')
     $worktreePath = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'builder_worktree_path' -Default '')
     $branchName = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'builder_branch' -Default '')
+    $manifestVersion = ConvertTo-WinsmuxRuntimeInteger -Value (
+        Get-MonitorPropertyValue -InputObject $manifest -Name 'version' -Default (
+            Get-MonitorPropertyValue -InputObject $manifest -Name 'Version' -Default $null
+        )
+    )
+    if ($manifestVersion -eq 2 -and -not [string]::IsNullOrWhiteSpace($paneId) -and
+        (Get-Command Test-PaneControlRuntimeContext -ErrorAction SilentlyContinue)) {
+        $ownedEntry = $null
+        if (Get-Command New-OrchestraLiveTransitionManifestEntry -ErrorAction SilentlyContinue) {
+            $ownedEntry = New-OrchestraLiveTransitionManifestEntry -Manifest $manifest -RuntimePaneId $paneId
+        }
+        if ($null -eq $ownedEntry) {
+            return [PSCustomObject]@{
+                Changed = $false
+                Action  = 'no_change'
+                Reason  = 'runtime_target_mismatch'
+                Label   = $Label
+            }
+        }
+        $preflight = Test-PaneControlRuntimeContext -ProjectDir $projectDir -ManifestEntry $ownedEntry -Operation stop_transition
+        if ($null -eq $preflight -or -not [bool]$preflight.valid) {
+            $reasonCode = [string](Get-MonitorPropertyValue -InputObject $preflight -Name 'reason_code' -Default 'runtime_target_mismatch')
+            return [PSCustomObject]@{
+                Changed = $false
+                Action  = 'no_change'
+                Reason  = $reasonCode
+                Label   = $Label
+            }
+        }
+    }
+
     [void]$manifest.Panes.Remove($Label)
     $manifest.SavedAt = Get-Date -Format o
-    Update-PaneScalerLiveExpectedPaneCount -Manifest $manifest -ProjectDir $projectDir `
-        -ManifestPath $ManifestPath -ExpectedGenerationId $expectedGenerationId | Out-Null
-
-    if (-not [string]::IsNullOrWhiteSpace($paneId)) {
-        Invoke-MonitorWinsmux -Arguments @('kill-pane', '-t', $paneId) | Out-Null
+    $remainingPaneId = ''
+    foreach ($remainingLabel in @($manifest.Panes.Keys | Sort-Object)) {
+        $remainingId = [string](Get-MonitorPropertyValue -InputObject $manifest.Panes[$remainingLabel] -Name 'pane_id' -Default '')
+        if ($remainingId -cmatch '^%[0-9]+$') {
+            $remainingPaneId = $remainingId
+            break
+        }
     }
-    if (-not [string]::IsNullOrWhiteSpace($worktreePath)) {
+
+    $serverRemoved = $false
+    if ([string]::IsNullOrWhiteSpace($paneId)) {
+        $serverRemoved = $true
+    } else {
+        $killThrew = $false
+        try {
+            Invoke-MonitorWinsmux -Arguments @('kill-pane', '-t', $paneId) | Out-Null
+        } catch {
+            $killThrew = $true
+        }
+        $stillPresent = Test-OrchestraLiveServerPanePresent -PaneId $paneId -SessionName $sessionName
+        if ($stillPresent -eq $true) {
+            throw ("archive-pane kill-pane failed; pane {0} is still live." -f $paneId)
+        }
+        if ($killThrew -and $stillPresent -ne $false) {
+            throw ("archive-pane kill-pane failed; live presence of pane {0} is unconfirmed." -f $paneId)
+        }
+        $serverRemoved = $true
+    }
+
+    $restoreOnFailure = -not $serverRemoved
+    $persistError = $null
+    try {
+        Update-PaneScalerLiveExpectedPaneCount -Manifest $manifest -ProjectDir $projectDir `
+            -ManifestPath $ManifestPath -ExpectedGenerationId $expectedGenerationId `
+            -RuntimePaneId $remainingPaneId -RestoreOnFailure $restoreOnFailure | Out-Null
+    } catch {
+        $persistError = $_
+        if ($serverRemoved) {
+            try {
+                Update-PaneScalerLiveExpectedPaneCount -Manifest $manifest -ProjectDir $projectDir `
+                    -ManifestPath $ManifestPath -ExpectedGenerationId $expectedGenerationId `
+                    -RuntimePaneId $remainingPaneId -RestoreOnFailure $false | Out-Null
+                $persistError = $null
+            } catch {
+                $persistError = $_
+            }
+        }
+    }
+
+    if ($serverRemoved -and -not [string]::IsNullOrWhiteSpace($worktreePath)) {
         try {
             Remove-PaneScalerBuilderWorktree -ProjectDir $projectDir -WorktreePath $worktreePath -BranchName $branchName
         } catch {
         }
+    }
+
+    if ($null -ne $persistError) {
+        if ($serverRemoved) {
+            throw ("archive-pane removed pane {0} but failed to persist the new pane set: {1}" -f $paneId, $persistError.Exception.Message)
+        }
+        throw $persistError
     }
 
     return [PSCustomObject]@{

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -412,11 +412,269 @@ function Get-PaneWorkload {
     }
 }
 
+
+function Get-PaneScalerSeedPane {
+    param([Parameter(Mandatory = $true)]$Manifest)
+
+    $candidates = [System.Collections.Generic.List[object]]::new()
+    foreach ($label in @($Manifest.Panes.Keys)) {
+        $pane = $Manifest.Panes[$label]
+        $paneId = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'pane_id' -Default '')
+        if ([string]::IsNullOrWhiteSpace($paneId)) {
+            continue
+        }
+        $role = Get-PaneScalerCanonicalRole -Role ([string](Get-MonitorPropertyValue -InputObject $pane -Name 'role' -Default '')) -Label $label
+        $candidates.Add([PSCustomObject]@{
+            Label  = [string]$label
+            PaneId = $paneId
+            Role   = $role
+            Pane   = $pane
+        }) | Out-Null
+    }
+
+    $workerSeed = @($candidates | Where-Object { $_.Role -eq 'Worker' } | Select-Object -Last 1)
+    if ($workerSeed.Count -gt 0) {
+        return $workerSeed[0]
+    }
+    $any = @($candidates | Select-Object -Last 1)
+    if ($any.Count -eq 0) {
+        throw 'Cannot spawn a Worker pane because no live seed pane was found.'
+    }
+    return $any[0]
+}
+
+function Get-PaneScalerWorkerIndex {
+    param([Parameter(Mandatory = $true)][string]$Label)
+
+    if ($Label -match '(?i)^worker-(\d+)$') {
+        return [int]$Matches[1]
+    }
+    return 0
+}
+
+function New-PaneScalerWorkerWorktree {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProjectDir,
+        [Parameter(Mandatory = $true)][int]$WorkerIndex
+    )
+
+    if (Get-Command New-BuilderWorktree -ErrorAction SilentlyContinue) {
+        return New-BuilderWorktree -ProjectDir $ProjectDir -BuilderIndex $WorkerIndex
+    }
+
+    return New-PaneScalerBuilderWorktree -ProjectDir $ProjectDir -BuilderIndex $WorkerIndex
+}
+
+function Update-PaneScalerLiveExpectedPaneCount {
+    param(
+        [Parameter(Mandatory = $true)]$Manifest,
+        [Parameter(Mandatory = $true)][string]$ProjectDir
+    )
+
+    $liveCount = @($Manifest.Panes.Keys).Count
+    if ($liveCount -lt 1) {
+        $liveCount = 1
+    }
+    $session = $Manifest.Session
+    if ($null -ne $session) {
+        if ($session -is [System.Collections.IDictionary]) {
+            $session['expected_pane_count'] = $liveCount
+        } else {
+            $session | Add-Member -NotePropertyName 'expected_pane_count' -NotePropertyValue $liveCount -Force
+        }
+    }
+    if (Get-Command Set-OrchestraLiveExpectedPaneCount -ErrorAction SilentlyContinue) {
+        Set-OrchestraLiveExpectedPaneCount -Manifest $Manifest -ExpectedPaneCount $liveCount -ProjectDir $ProjectDir | Out-Null
+    }
+    return $liveCount
+}
+
+function Add-OrchestraWorkerPane {
+    param(
+        [Parameter(Mandatory = $true)][string]$ManifestPath,
+        [Parameter(Mandatory = $true)][string]$SlotId,
+        $Settings = $null,
+        $SlotAgentConfig = $null,
+        $Assignment = $null
+    )
+
+    $manifest = Read-PaneScalerManifest -ManifestPath $ManifestPath
+    $expectedGenerationId = [string](Get-MonitorPropertyValue -InputObject $manifest.Session -Name 'generation_id' -Default '')
+    $projectDir = Get-PaneScalerProjectDir -Manifest $manifest -ManifestPath $ManifestPath
+    if ($null -eq $Settings) {
+        $Settings = Get-BridgeSettings -RootPath $projectDir
+    }
+
+    if ([string]::IsNullOrWhiteSpace($SlotId)) {
+        throw 'Worker spawn requires a Team Profile slot id.'
+    }
+    if ($manifest.Panes.Contains($SlotId)) {
+        $existing = $manifest.Panes[$SlotId]
+        $existingPaneId = [string](Get-MonitorPropertyValue -InputObject $existing -Name 'pane_id' -Default '')
+        if (-not [string]::IsNullOrWhiteSpace($existingPaneId)) {
+            return [PSCustomObject]@{
+                Changed = $false
+                Action  = 'already_live'
+                Label   = $SlotId
+                PaneId  = $existingPaneId
+            }
+        }
+    }
+
+    if ($null -eq $SlotAgentConfig -and $null -ne $Assignment -and (Get-Command New-TeamProfileSlotAgentConfig -ErrorAction SilentlyContinue)) {
+        $SlotAgentConfig = New-TeamProfileSlotAgentConfig -Role 'Worker' -SlotId $SlotId -Assignment $Assignment -Settings $Settings -RootPath $projectDir
+    }
+
+    $seed = Get-PaneScalerSeedPane -Manifest $manifest
+    $workerIndex = Get-PaneScalerWorkerIndex -Label $SlotId
+    if ($workerIndex -lt 1) {
+        $workerIndex = @($manifest.Panes.Keys).Count + 1
+    }
+
+    $worktree = $null
+    $newPaneId = ''
+    try {
+        $worktree = New-PaneScalerWorkerWorktree -ProjectDir $projectDir -WorkerIndex $workerIndex
+        $splitOutput = Invoke-MonitorWinsmux -Arguments @('split-window', '-t', $seed.PaneId, '-h', '-c', $worktree.WorktreePath, '-P', '-F', '#{pane_id}') -CaptureOutput
+        $newPaneId = (($splitOutput | Out-String).Trim() -split "\r?\n" | Where-Object { $_ -match '^%\d+$' } | Select-Object -Last 1)
+        if ([string]::IsNullOrWhiteSpace($newPaneId)) {
+            throw 'winsmux split-window did not return a pane id.'
+        }
+
+        Invoke-MonitorWinsmux -Arguments @('select-pane', '-t', $newPaneId, '-T', $SlotId) | Out-Null
+
+        $agent = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'Agent' -Default ([string]$Settings.agent))
+        $model = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'Model' -Default ([string]$Settings.model))
+        $modelSource = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'ModelSource' -Default '')
+        $effort = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'ReasoningEffort' -Default '')
+        $mcpMode = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'McpMode' -Default '')
+        $workerBackend = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'WorkerBackend' -Default 'local')
+        if ($null -ne $Assignment) {
+            $assignmentBackend = [string](Get-MonitorPropertyValue -InputObject $Assignment -Name 'worker_backend' -Default '')
+            if ([string]::IsNullOrWhiteSpace($assignmentBackend)) {
+                $assignmentBackend = [string](Get-MonitorPropertyValue -InputObject $Assignment -Name 'worker-backend' -Default '')
+            }
+            if (-not [string]::IsNullOrWhiteSpace($assignmentBackend)) {
+                $workerBackend = $assignmentBackend
+            }
+        }
+
+        Wait-MonitorPaneShellReady -PaneId $newPaneId
+        if (-not [string]::IsNullOrWhiteSpace($agent)) {
+            Send-MonitorBridgeCommand -PaneId $newPaneId -Text (Get-PaneScalerLaunchCommand -Agent $agent -Model $model -ModelSource $modelSource -ReasoningEffort $effort -McpMode $mcpMode -SlotId $SlotId -ProjectDir $worktree.WorktreePath -GitWorktreeDir $worktree.GitWorktreeDir -RootPath $projectDir) -DeliveryClass 'launch'
+        }
+
+        $paneTitle = [string](Get-MonitorPropertyValue -InputObject $SlotAgentConfig -Name 'PaneTitle' -Default $SlotId)
+        $newPane = [ordered]@{
+            label                  = $SlotId
+            slot_id                = $SlotId
+            pane_id                = $newPaneId
+            role                   = 'Worker'
+            worker_role            = 'worker'
+            worker_backend         = $workerBackend
+            title                  = $paneTitle
+            exec_mode              = 'false'
+            launch_dir             = $worktree.WorktreePath
+            builder_branch         = $worktree.BranchName
+            builder_worktree_path  = $worktree.WorktreePath
+            task                   = $null
+            status                 = 'ready'
+        }
+        $paneObject = [PSCustomObject]@{}
+        foreach ($entry in $newPane.GetEnumerator()) {
+            Add-Member -InputObject $paneObject -MemberType NoteProperty -Name $entry.Key -Value $entry.Value
+        }
+        $manifest.Panes[$SlotId] = $paneObject
+        Update-PaneScalerLiveExpectedPaneCount -Manifest $manifest -ProjectDir $projectDir | Out-Null
+        $manifest.SavedAt = Get-Date -Format o
+        Save-PaneScalerManifest -ManifestPath $ManifestPath -Manifest $manifest -ExpectedGenerationId $expectedGenerationId
+
+        return [PSCustomObject]@{
+            Changed      = $true
+            Action       = 'spawn_worker'
+            Label        = $SlotId
+            PaneId       = $newPaneId
+            WorktreePath = $worktree.WorktreePath
+            BranchName   = $worktree.BranchName
+        }
+    } catch {
+        if (-not [string]::IsNullOrWhiteSpace($newPaneId)) {
+            try {
+                Invoke-MonitorWinsmux -Arguments @('kill-pane', '-t', $newPaneId) | Out-Null
+            } catch {
+            }
+        }
+        if ($null -ne $worktree) {
+            try {
+                Remove-PaneScalerBuilderWorktree -ProjectDir $projectDir -WorktreePath $worktree.WorktreePath -BranchName $worktree.BranchName
+            } catch {
+            }
+        }
+        throw
+    }
+}
+
+function Remove-OrchestraWorkerPane {
+    param(
+        [Parameter(Mandatory = $true)][string]$ManifestPath,
+        [Parameter(Mandatory = $true)][string]$Label,
+        $Settings = $null
+    )
+
+    $manifest = Read-PaneScalerManifest -ManifestPath $ManifestPath
+    $expectedGenerationId = [string](Get-MonitorPropertyValue -InputObject $manifest.Session -Name 'generation_id' -Default '')
+    $projectDir = Get-PaneScalerProjectDir -Manifest $manifest -ManifestPath $ManifestPath
+    if (-not $manifest.Panes.Contains($Label)) {
+        return [PSCustomObject]@{
+            Changed = $false
+            Action  = 'no_change'
+            Reason  = 'pane_not_live'
+            Label   = $Label
+        }
+    }
+
+    $pane = $manifest.Panes[$Label]
+    $paneId = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'pane_id' -Default '')
+    $worktreePath = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'builder_worktree_path' -Default '')
+    $branchName = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'builder_branch' -Default '')
+    [void]$manifest.Panes.Remove($Label)
+    Update-PaneScalerLiveExpectedPaneCount -Manifest $manifest -ProjectDir $projectDir | Out-Null
+    $manifest.SavedAt = Get-Date -Format o
+    Save-PaneScalerManifest -ManifestPath $ManifestPath -Manifest $manifest -ExpectedGenerationId $expectedGenerationId
+
+    if (-not [string]::IsNullOrWhiteSpace($paneId)) {
+        Invoke-MonitorWinsmux -Arguments @('kill-pane', '-t', $paneId) | Out-Null
+    }
+    if (-not [string]::IsNullOrWhiteSpace($worktreePath)) {
+        try {
+            Remove-PaneScalerBuilderWorktree -ProjectDir $projectDir -WorktreePath $worktreePath -BranchName $branchName
+        } catch {
+        }
+    }
+
+    return [PSCustomObject]@{
+        Changed      = $true
+        Action       = 'archive'
+        Label        = $Label
+        PaneId       = $paneId
+        WorktreePath = $worktreePath
+        BranchName   = $branchName
+    }
+}
+
 function Add-OrchestraPane {
     param(
         [Parameter(Mandatory = $true)][string]$ManifestPath,
-        $Settings = $null
+        $Settings = $null,
+        [ValidateSet('Builder', 'Worker')][string]$Role = 'Builder',
+        [AllowEmptyString()][string]$SlotId = '',
+        $SlotAgentConfig = $null,
+        $Assignment = $null
     )
+
+    if ($Role -eq 'Worker') {
+        return Add-OrchestraWorkerPane -ManifestPath $ManifestPath -SlotId $SlotId -Settings $Settings -SlotAgentConfig $SlotAgentConfig -Assignment $Assignment
+    }
 
     $manifest = Read-PaneScalerManifest -ManifestPath $ManifestPath
     Assert-PaneScalerPaneCountMutationSupported -Manifest $manifest
@@ -511,8 +769,14 @@ function Remove-OrchestraPane {
     param(
         [Parameter(Mandatory = $true)][string]$ManifestPath,
         $Settings = $null,
-        [int]$MinimumBuilders = 2
+        [int]$MinimumBuilders = 2,
+        [ValidateSet('Builder', 'Worker')][string]$Role = 'Builder',
+        [AllowEmptyString()][string]$Label = ''
     )
+
+    if ($Role -eq 'Worker') {
+        return Remove-OrchestraWorkerPane -ManifestPath $ManifestPath -Label $Label -Settings $Settings
+    }
 
     $currentManifest = Read-PaneScalerManifest -ManifestPath $ManifestPath
     Assert-PaneScalerPaneCountMutationSupported -Manifest $currentManifest

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -472,8 +472,12 @@ function Update-PaneScalerLiveExpectedPaneCount {
     )
 
     $liveCount = @($Manifest.Panes.Keys).Count
+    if (Get-Command Set-OrchestraLiveExpectedPaneCount -ErrorAction SilentlyContinue) {
+        return Set-OrchestraLiveExpectedPaneCount -Manifest $Manifest -ExpectedPaneCount $liveCount -ProjectDir $ProjectDir
+    }
+
     if ($liveCount -lt 1) {
-        $liveCount = 1
+        throw 'Live expected pane count must be 1 or greater.'
     }
     $session = $Manifest.Session
     if ($null -ne $session) {
@@ -483,10 +487,43 @@ function Update-PaneScalerLiveExpectedPaneCount {
             $session | Add-Member -NotePropertyName 'expected_pane_count' -NotePropertyValue $liveCount -Force
         }
     }
-    if (Get-Command Set-OrchestraLiveExpectedPaneCount -ErrorAction SilentlyContinue) {
-        Set-OrchestraLiveExpectedPaneCount -Manifest $Manifest -ExpectedPaneCount $liveCount -ProjectDir $ProjectDir | Out-Null
-    }
     return $liveCount
+}
+
+function Test-OrchestraArchiveRemovesLastRequiredWorker {
+    param(
+        [AllowNull()]$Manifest = $null,
+        [AllowEmptyString()][string]$Label = ''
+    )
+
+    $min = 1
+    if (Get-Command Get-OrchestraMinLiveWorkerPaneCount -ErrorAction SilentlyContinue) {
+        $min = [int](Get-OrchestraMinLiveWorkerPaneCount)
+    }
+    $liveWorkers = 0
+    if (Get-Command Get-OrchestraLiveWorkerRolePaneCount -ErrorAction SilentlyContinue) {
+        $liveWorkers = [int](Get-OrchestraLiveWorkerRolePaneCount -Manifest $Manifest)
+    }
+    if ($liveWorkers -gt $min) {
+        return $false
+    }
+
+    if ($null -eq $Manifest -or [string]::IsNullOrWhiteSpace($Label)) {
+        return ($liveWorkers -le $min)
+    }
+
+    $map = ConvertTo-ManifestPropertyMap -Value (
+        Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'panes' -Default (
+            Get-WinsmuxRuntimeValue -InputObject $Manifest -Name 'Panes' -Default $null
+        )
+    )
+    if (-not $map.Contains($Label)) {
+        return $false
+    }
+    $pane = $map[$Label]
+    $paneId = [string](Get-WinsmuxRuntimeValue -InputObject $pane -Name 'pane_id' -Default '')
+    $role = [string](Get-OrchestraCanonicalPaneRole -Pane $pane -Label $Label)
+    return ($role -eq 'Worker' -and -not [string]::IsNullOrWhiteSpace($paneId))
 }
 
 function Add-OrchestraWorkerPane {
@@ -634,6 +671,29 @@ function Remove-OrchestraWorkerPane {
     }
 
     $pane = $manifest.Panes[$Label]
+    $canonicalRole = ''
+    if (Get-Command Get-OrchestraCanonicalPaneRole -ErrorAction SilentlyContinue) {
+        $canonicalRole = [string](Get-OrchestraCanonicalPaneRole -Pane $pane -Label $Label)
+    } else {
+        $canonicalRole = [string](Get-PaneScalerCanonicalRole -Role ([string](Get-MonitorPropertyValue -InputObject $pane -Name 'role' -Default '')) -Label $Label)
+    }
+    if ($canonicalRole -cne 'Worker') {
+        return [PSCustomObject]@{
+            Changed = $false
+            Action  = 'no_change'
+            Reason  = 'archive_role_not_worker'
+            Label   = $Label
+        }
+    }
+    if (Test-OrchestraArchiveRemovesLastRequiredWorker -Manifest $manifest -Label $Label) {
+        return [PSCustomObject]@{
+            Changed = $false
+            Action  = 'no_change'
+            Reason  = 'last_required_worker'
+            Label   = $Label
+        }
+    }
+
     $paneId = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'pane_id' -Default '')
     $worktreePath = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'builder_worktree_path' -Default '')
     $branchName = [string](Get-MonitorPropertyValue -InputObject $pane -Name 'builder_branch' -Default '')

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -539,13 +539,45 @@ function Test-OrchestraArchiveRemovesLastRequiredWorker {
     return ($role -eq 'Worker' -and -not [string]::IsNullOrWhiteSpace($paneId))
 }
 
+function Wait-OrchestraSpawnAgentReady {
+    param(
+        [Parameter(Mandatory = $true)][string]$PaneId,
+        [Parameter(Mandatory = $true)][string]$Agent,
+        [int]$TimeoutSeconds = 60,
+        [int]$PollMilliseconds = 2000
+    )
+
+    if (-not (Get-Command Get-PaneAgentStatus -ErrorAction SilentlyContinue)) {
+        throw 'Worker spawn requires Get-PaneAgentStatus after the bootstrap marker is present.'
+    }
+
+    $timeoutSeconds = [Math]::Max(0, $TimeoutSeconds)
+    $pollMilliseconds = [Math]::Max(1, $PollMilliseconds)
+    $deadline = (Get-Date).AddSeconds($timeoutSeconds)
+    while ($true) {
+        $status = Get-PaneAgentStatus -PaneId $PaneId -Agent $Agent -Role 'Worker'
+        $statusName = [string](Get-MonitorPropertyValue -InputObject $status -Name 'Status' -Default '')
+        if ($statusName -ceq 'ready') {
+            return
+        }
+
+        if ((Get-Date) -ge $deadline) {
+            throw ("Worker spawn timed out waiting for agent ready in pane {0}." -f $PaneId)
+        }
+
+        Start-Sleep -Milliseconds $pollMilliseconds
+    }
+}
+
 function Add-OrchestraWorkerPane {
     param(
         [Parameter(Mandatory = $true)][string]$ManifestPath,
         [Parameter(Mandatory = $true)][string]$SlotId,
         $Settings = $null,
         $SlotAgentConfig = $null,
-        $Assignment = $null
+        $Assignment = $null,
+        [int]$AgentReadyTimeoutSeconds = 60,
+        [int]$AgentReadyPollMilliseconds = 2000
     )
 
     $manifest = Read-PaneScalerManifest -ManifestPath $ManifestPath
@@ -714,19 +746,23 @@ function Add-OrchestraWorkerPane {
                 Start-Sleep -Milliseconds 100
             }
             if (Test-Path -LiteralPath $bootstrapMarkerPath -PathType Leaf) {
+                $markerPid = $null
                 try {
                     $marker = Get-Content -LiteralPath $bootstrapMarkerPath -Raw -Encoding UTF8 | ConvertFrom-Json
-                    $markerPid = $null
                     if (Get-Command ConvertTo-WinsmuxRuntimeInteger -ErrorAction SilentlyContinue) {
                         $markerPid = ConvertTo-WinsmuxRuntimeInteger -Value (Get-WinsmuxRuntimeValue -InputObject $marker -Name 'bootstrap_pid' -Default $null)
                     } else {
                         $markerPid = [int](Get-MonitorPropertyValue -InputObject $marker -Name 'bootstrap_pid' -Default 0)
                     }
-                    if ($null -ne $markerPid -and $markerPid -gt 0) {
-                        $runtimeReady = $true
-                        $paneStatus = 'ready'
-                    }
                 } catch {
+                    $markerPid = $null
+                }
+                if ($null -ne $markerPid -and $markerPid -gt 0) {
+                    Wait-OrchestraSpawnAgentReady -PaneId $newPaneId -Agent $agent `
+                        -TimeoutSeconds $AgentReadyTimeoutSeconds `
+                        -PollMilliseconds $AgentReadyPollMilliseconds
+                    $runtimeReady = $true
+                    $paneStatus = 'ready'
                 }
             }
         }

--- a/winsmux-core/scripts/pane-scaler.ps1
+++ b/winsmux-core/scripts/pane-scaler.ps1
@@ -682,6 +682,16 @@ function Add-OrchestraWorkerPane {
     $newPaneId = ''
     try {
         $worktree = New-PaneScalerWorkerWorktree -ProjectDir $projectDir -WorkerIndex $workerIndex
+        if (Get-Command Invoke-TeamProfileLaunchProjection -ErrorAction SilentlyContinue) {
+            try {
+                $worktreeProjection = Invoke-TeamProfileLaunchProjection -ProjectDir $projectDir -SessionId $sessionName -SlotId $SlotId -Worktree $worktree.WorktreePath -ReadWriteScope 'session' -Force
+                if ($null -ne $worktreeProjection) {
+                    $Projection = $worktreeProjection
+                }
+            } catch {
+                # Keep the caller projection when regeneration after worktree is unavailable.
+            }
+        }
         $splitOutput = Invoke-MonitorWinsmux -Arguments @('split-window', '-t', $seed.PaneId, '-h', '-c', $worktree.WorktreePath, '-P', '-F', '#{pane_id}') -CaptureOutput
         $newPaneId = (($splitOutput | Out-String).Trim() -split "\r?\n" | Where-Object { $_ -match '^%\d+$' } | Select-Object -Last 1)
         if ([string]::IsNullOrWhiteSpace($newPaneId)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

TASK-789 only: change always-on 6 worker panes into spawn on dispatch / archive on collect. Official Team Profile slots stay 6. Live cockpit starts with the operator pane (if managed) plus a minimum pool of 1 worker pane. Idle catalog rows are not live panes.

This draft now includes both commits: RED tests, then GREEN product wiring. Do not merge. Do not mark ready. Do not tag. Do not npm publish. VERSION remains 0.36.32.

## Surface Classification

- [x] Public product surface
- [ ] Runtime contract surface
- [x] Contributor/test surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Responsibility And Cutover

- Replaced behavior, workflow, config path, or responsibility: `Get-OrchestraLayoutSettings` no longer copies `agent_slots.Count` onto live `Workers`. Smoke `ready` no longer requires a constant Operators+Workers count of 7. Collect is a new public `archive-pane` command; `workers stop` still respawns and is not collect.
- Expected outcome: start layout live workers = 1; `expected_pane_count` is the live pane count after layout; team-mode `dispatch-task` spawns a missing pane (live workers < 6) via `Add-OrchestraPane` and `New-TeamProfileSlotAgentConfig` from Team Profile assignment JSON (not catalog `requiredBackend`); `archive-pane` interrupts if needed, requires idle, then `Remove-OrchestraPane` / `kill-pane`; simple mode with live worker-role panes > 1 is not `ready` and does not spawn a second live worker.
- Source of truth: Team Profile start-gate (`selectable` | `runnable`) remains TASK-718 and still runs before layout; `partial_start` stays false; orchestra mode is `.winsmux/orchestra-mode.json` (`simple`|`team`, missing file = team, invalid JSON / extra keys / bad mode = fail closed). Event authority stays `events.jsonl` / `winsmux events --json`.
- Old paths preserved, redirected, deprecated, or removed: `Assert-TeamProfileStartGate` stays before layout. `Add-OrchestraPane` / `Remove-OrchestraPane` are reused for worker spawn/archive. `workers stop` remains respawn and is not collect.

## Verification

- Ubuntu parser check (`[System.Management.Automation.Language.Parser]::ParseFile`): exit 0 on all edited `.ps1` files.
- Pester 5.7.1 filter `*TASK-789*` after GREEN: Passed=17 Failed=0 (exit 0).
- Ubuntu is not orchestra-smoke / Pester-on-real-session / Tauri E2E proof. GitHub Actions Windows Tests is the authority after push.
- Do not bump VERSION, tag, npm publish, or merge.

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77ff7210-4ba9-4a29-8c73-445f7e2e1b97?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77ff7210-4ba9-4a29-8c73-445f7e2e1b97&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

