### PR TITLE
feat(control-plane): bootstrap control-pipe token file and document external connect (TASK-835)

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -90,6 +90,7 @@ $whitelistPatterns = @(
     'docs/project/v03622-context-continuity.ja.md',
     'docs/project/pre-ga-v10-planning-sync.md',
     'docs/project/v03629-team-profile-architecture.md',
+    'docs/project/v03629-declarative-workspace-architecture.md',
     '.agents/README.md',
     'scripts/bootstrap-git-guard.ps1',
     'scripts/bump-version.ps1',

--- a/docs/external-control-plane.ja.md
+++ b/docs/external-control-plane.ja.md
@@ -2,13 +2,42 @@
 
 winsmux は、デスクトップアプリと同じ Windows マシンで動く外部自動化クライアント向けに、ローカルの named pipe JSON-RPC エンドポイントを公開します。
 
+すでに起動しているデスクトップ（起動前に `WINSMUX_CONTROL_PIPE_TOKEN` をセットしていない通常起動）から、ソースを読まずに `desktop.operator.snapshot` まで到達できます。
+
 ## 伝送方式
 
 - パイプ: `\\.\pipe\winsmux-control`
 - プロトコル: JSON-RPC 2.0
 - ネットワーク伝送: なし。localhost HTTP や WebSocket エンドポイントはありません。
 - リモートクライアントは、ユーザーが承認したローカルブリッジを経由する必要があります。デスクトップアプリは、この pipe をネットワークへ公開しません。
-- 認可: `desktop.control_plane.contract` だけはトークンなしで取得できます。それ以外のメソッドは、winsmux CLI ヘルパーがローカル環境変数 `WINSMUX_CONTROL_PIPE_TOKEN` から注入する `auth.token` を要求します。
+
+## 起動モード
+
+通常のデスクトップ起動では、プロセス環境に `WINSMUX_CONTROL_PIPE_TOKEN` は不要です。起動時、デスクトップアプリは `%LOCALAPPDATA%\winsmux\control-pipe\token` をユーザー専用 DACL（Windows における `0600` 相当）で作り、新しい現行トークンを書き、直前のトークンはプロセスメモリにだけ残します。直前値は、新しいトークンでの初回成功認証まで、またはプロセス時間 60 秒まで受け付け、その後破棄します。ログに出してよい印は `control-pipe token: rotated` だけです。トークン値も、展開済みファイルパスも書いてはいけません。
+
+一部のランチャーは、いまもデスクトッププロセスに `WINSMUX_CONTROL_PIPE_TOKEN` をセットします。その明示 env は引き続き有効で、デスクトップ pipe と CLI の両方でトークンファイルより優先します。
+
+## トークンの用意
+
+保護対象は control-pipe トークンのバイト列です。信頼境界はローカルユーザープロファイルであり、git リポジトリでもプロジェクトの `.winsmux` でもありません。
+
+発見経路はこの正確なパスだけです。
+
+`%LOCALAPPDATA%\winsmux\control-pipe\token`
+
+リポジトリ、プロジェクト `.winsmux`、`TEMP`、別ファイル名へ置いたファイルは勝ってはいけません。
+
+デスクトップ pipe と `winsmux control-rpc` のトークン取得順:
+
+1. 空でないプロセス環境変数 `WINSMUX_CONTROL_PIPE_TOKEN`（既存テストと明示ランチャーを維持）
+2. それ以外は上記の正確なトークンファイル
+3. どちらも無ければ安全側で失敗
+
+トークン値を印刷しないでください。例の秘密スロットは `<token-file>` です。
+
+## 認可
+
+`desktop.control_plane.contract` だけはトークンなしで取得できます。それ以外のメソッドは `auth.token` を要求します。通常は `winsmux control-rpc` を使います。env 上書きがあればそれを、無ければ正確なトークンファイルを読んで `auth.token` を注入します。
 
 外部契約は次の呼び出しで取得します。
 
@@ -16,15 +45,40 @@ winsmux は、デスクトップアプリと同じ Windows マシンで動く外
 {"jsonrpc":"2.0","id":"contract","method":"desktop.control_plane.contract"}
 ```
 
-この要求を named pipe 経由で送ると、`methods` には pipe の許可リストが受け付けるメソッドだけが入ります。
+この要求を named pipe 経由で送ると、`methods` には pipe の許可リストが受け付けるメソッドだけが入ります。契約の `auth.token_env` は `WINSMUX_CONTROL_PIPE_TOKEN`、`auth.token_file` は `%LOCALAPPDATA%\winsmux\control-pipe\token` です。
 
 `desktop.control_plane.contract` 以外のメソッドでは、`params` の外側にローカル制御トークンを含めます。
 
 ```json
-{"jsonrpc":"2.0","id":"capture","method":"pty.capture","params":{"paneId":"pane-1"},"auth":{"token":"<WINSMUX_CONTROL_PIPE_TOKEN>"}}
+{"jsonrpc":"2.0","id":"capture","method":"pty.capture","params":{"paneId":"pane-1"},"auth":{"token":"<token-file>"}}
 ```
 
-トークン値をシェル履歴に直接書かないでください。通常は `winsmux control-rpc` を使います。このコマンドは現在のプロセス環境の `WINSMUX_CONTROL_PIPE_TOKEN` を読み、非契約メソッドへ `auth.token` を注入します。
+トークン値をシェル履歴に直接書かないでください。
+
+## ゼロから operator-snapshot まで
+
+1. デスクトップアプリを通常起動するか、まだ env をセットするランチャーを使います。
+2. 契約をトークンなしで確認します。
+
+```powershell
+winsmux control-rpc '{"jsonrpc":"2.0","id":"contract","method":"desktop.control_plane.contract"}'
+```
+
+3. operator 出力を取得します。CLI は env 上書きがあればそれを、無ければ正確なトークンファイルを使います。
+
+```powershell
+winsmux operator-snapshot --lines 80
+```
+
+同等の生 JSON-RPC:
+
+```json
+{"jsonrpc":"2.0","id":"operator-snapshot","method":"desktop.operator.snapshot","params":{"lines":80},"auth":{"token":"<token-file>"}}
+```
+
+## エラー意味論
+
+非契約呼び出しは、使えるトークンが無い（env が空で正確なファイルも無い／空）、`auth.token` が無い、またはトークンが一致しないときに安全側で失敗します。pipe は既存の JSON-RPC 失敗閉のままです。エラーコードは `-32600`（Invalid Request）で、メッセージは `WINSMUX_CONTROL_PIPE_TOKEN` を名前で示します。CLI ヘルパーは `control-rpc requires WINSMUX_CONTROL_PIPE_TOKEN for non-contract methods` で失敗します。新しい公開エラーコードは追加しません。
 
 ## 公開メソッド
 
@@ -52,16 +106,16 @@ winsmux operator-snapshot --lines 80
 winsmux operator-submit --text "Restore the six-pane orchestra and report can_dispatch."
 ```
 
-このヘルパーは `WINSMUX_CONTROL_PIPE_TOKEN` を読み取り、
+このヘルパーは同じトークン優先順（env 上書き、無ければ正確なトークンファイル）を使い、
 `desktop.operator.snapshot` / `desktop.operator.submit` だけを呼びます。
 worker ペインの指定は受け付けません。独自の named pipe クライアントを実装する場合は、次の JSON-RPC を直接送れます。
 
 ```json
-{"jsonrpc":"2.0","id":"operator-snapshot","method":"desktop.operator.snapshot","params":{"lines":80},"auth":{"token":"<WINSMUX_CONTROL_PIPE_TOKEN>"}}
+{"jsonrpc":"2.0","id":"operator-snapshot","method":"desktop.operator.snapshot","params":{"lines":80},"auth":{"token":"<token-file>"}}
 ```
 
 ```json
-{"jsonrpc":"2.0","id":"operator-submit","method":"desktop.operator.submit","params":{"message":"Restore the six-pane orchestra and report can_dispatch."},"auth":{"token":"<WINSMUX_CONTROL_PIPE_TOKEN>"}}
+{"jsonrpc":"2.0","id":"operator-submit","method":"desktop.operator.submit","params":{"message":"Restore the six-pane orchestra and report can_dispatch."},"auth":{"token":"<token-file>"}}
 ```
 
 同じ pipe は、ローカルペイン制御用に次の PTY メソッドも公開します。
@@ -106,7 +160,7 @@ Tauri アプリは、より広い内部 `desktop_json_rpc` 面を使います。
 
 ローカル自動化クライアントは、同じ Windows ホスト上で動き、named pipe 上の JSON-RPC を実装していれば接続できます。最初に `desktop.control_plane.contract` を呼び、返された `methods` からクライアント機能を構成してください。
 
-デスクトップアプリが `WINSMUX_CONTROL_PIPE_TOKEN` 付きで起動されていない場合、または要求に `auth.token` がない場合、契約取得以外の呼び出しは安全側で失敗します。
+空でない `WINSMUX_CONTROL_PIPE_TOKEN` も正確なトークンファイルも認証に使えない場合、または要求に `auth.token` がない場合、契約取得以外の呼び出しは安全側で失敗します。
 
 エージェント CLI も、ユーザーがローカルコマンド実行を許可した場合は、ローカルシェルやツール呼び出しから pipe を操作できます。専用の特権 API 面はありません。他のローカルクライアントと同じ外部契約だけを見ます。
 

--- a/docs/external-control-plane.md
+++ b/docs/external-control-plane.md
@@ -3,6 +3,10 @@
 winsmux exposes a local Windows named-pipe JSON-RPC endpoint for external
 automation clients that run on the same machine as the desktop app.
 
+A new external agent can follow this page from a already-running desktop (no
+`WINSMUX_CONTROL_PIPE_TOKEN` set before launch) to a successful
+`desktop.operator.snapshot` without reading source.
+
 ## Transport
 
 - Pipe: `\\.\pipe\winsmux-control`
@@ -10,9 +14,50 @@ automation clients that run on the same machine as the desktop app.
 - Network transport: none. There is no localhost HTTP or WebSocket endpoint.
 - Remote clients must connect through a user-approved local bridge; the desktop
   app does not expose this pipe to the network.
-- Authorization: `desktop.control_plane.contract` is discoverable without a
-  token. Every other method requires `auth.token`, supplied from the local
-  `WINSMUX_CONTROL_PIPE_TOKEN` environment variable by the winsmux CLI helper.
+
+## Launch modes
+
+Normal desktop start does not require `WINSMUX_CONTROL_PIPE_TOKEN` in the
+process environment. On start, the desktop app creates
+`%LOCALAPPDATA%\winsmux\control-pipe\token` with a user-only DACL (Windows
+equivalent of `0600`), writes a new current token, and keeps any previous token
+in process memory only. The previous value is accepted until the first
+successful auth with the new token, or until 60 seconds of process time, then
+the old bytes are dropped. Logs may contain the marker
+`control-pipe token: rotated`. They must not contain the token value or the
+expanded filesystem path.
+
+Some launchers still set `WINSMUX_CONTROL_PIPE_TOKEN` on the desktop process
+(for example bakeoff helpers). That explicit env remains supported and wins
+over the token file for both the desktop pipe and the CLI.
+
+## Token provisioning
+
+The protected asset is the control-pipe token bytes. The trust boundary is the
+local user profile, not the git repo and not project `.winsmux`.
+
+Discovery is this exact path only:
+
+`%LOCALAPPDATA%\winsmux\control-pipe\token`
+
+A planted file under the repo, project `.winsmux`, `TEMP`, or any other name
+must not win.
+
+Token source precedence for the desktop pipe and for `winsmux control-rpc`:
+
+1. Non-empty process env `WINSMUX_CONTROL_PIPE_TOKEN` (keeps existing tests and
+   explicit launchers)
+2. Else the exact token file above
+3. Else fail closed
+
+Do not print the token. Secret slots in examples use `<token-file>`.
+
+## Authorization
+
+`desktop.control_plane.contract` is discoverable without a token. Every other
+method requires `auth.token`. Prefer `winsmux control-rpc`, which injects
+`auth.token` from the env override or, when the env is unset, from the exact
+token file.
 
 Clients can discover the external contract by calling:
 
@@ -21,18 +66,51 @@ Clients can discover the external contract by calling:
 ```
 
 When that request is sent through the named pipe, `methods` contains only the
-methods that the pipe allowlist accepts.
+methods that the pipe allowlist accepts. The contract advertises
+`auth.token_env` as `WINSMUX_CONTROL_PIPE_TOKEN` and `auth.token_file` as
+`%LOCALAPPDATA%\winsmux\control-pipe\token`.
 
 For any method other than `desktop.control_plane.contract`, clients must include
 the local control token outside `params`:
 
 ```json
-{"jsonrpc":"2.0","id":"capture","method":"pty.capture","params":{"paneId":"pane-1"},"auth":{"token":"<WINSMUX_CONTROL_PIPE_TOKEN>"}}
+{"jsonrpc":"2.0","id":"capture","method":"pty.capture","params":{"paneId":"pane-1"},"auth":{"token":"<token-file>"}}
 ```
 
-Do not write the token directly in shell history. Prefer `winsmux control-rpc`,
-which reads `WINSMUX_CONTROL_PIPE_TOKEN` from the current process environment
-and injects `auth.token` into non-contract requests.
+Do not write the token directly in shell history.
+
+## Connect from zero to operator-snapshot
+
+1. Start the desktop app normally, or use a launcher that may still set
+   `WINSMUX_CONTROL_PIPE_TOKEN`.
+2. Confirm the contract (no token):
+
+```powershell
+winsmux control-rpc '{"jsonrpc":"2.0","id":"contract","method":"desktop.control_plane.contract"}'
+```
+
+3. Capture operator output. The CLI reads the env override if set, otherwise
+   the exact token file:
+
+```powershell
+winsmux operator-snapshot --lines 80
+```
+
+Equivalent raw JSON-RPC:
+
+```json
+{"jsonrpc":"2.0","id":"operator-snapshot","method":"desktop.operator.snapshot","params":{"lines":80},"auth":{"token":"<token-file>"}}
+```
+
+## Error semantics
+
+Non-contract calls fail closed when no usable token exists (env unset and the
+exact file missing or empty), when `auth.token` is omitted, or when the token
+does not match. The pipe keeps the existing JSON-RPC fail-closed behavior:
+error code `-32600` (Invalid Request) with a message that names
+`WINSMUX_CONTROL_PIPE_TOKEN`. The CLI helper fails with
+`control-rpc requires WINSMUX_CONTROL_PIPE_TOKEN for non-contract methods`.
+This page does not introduce a new public error code.
 
 ## Exposed Methods
 
@@ -64,17 +142,17 @@ winsmux operator-snapshot --lines 80
 winsmux operator-submit --text "Restore the six-pane orchestra and report can_dispatch."
 ```
 
-Those helpers read `WINSMUX_CONTROL_PIPE_TOKEN`, call only
-`desktop.operator.snapshot` / `desktop.operator.submit`, and never accept a
-worker pane target. Raw JSON-RPC remains available for clients that implement
-their own named-pipe transport:
+Those helpers follow the same token precedence (env override, else the exact
+token file), call only `desktop.operator.snapshot` /
+`desktop.operator.submit`, and never accept a worker pane target. Raw JSON-RPC
+remains available for clients that implement their own named-pipe transport:
 
 ```json
-{"jsonrpc":"2.0","id":"operator-snapshot","method":"desktop.operator.snapshot","params":{"lines":80},"auth":{"token":"<WINSMUX_CONTROL_PIPE_TOKEN>"}}
+{"jsonrpc":"2.0","id":"operator-snapshot","method":"desktop.operator.snapshot","params":{"lines":80},"auth":{"token":"<token-file>"}}
 ```
 
 ```json
-{"jsonrpc":"2.0","id":"operator-submit","method":"desktop.operator.submit","params":{"message":"Restore the six-pane orchestra and report can_dispatch."},"auth":{"token":"<WINSMUX_CONTROL_PIPE_TOKEN>"}}
+{"jsonrpc":"2.0","id":"operator-submit","method":"desktop.operator.submit","params":{"message":"Restore the six-pane orchestra and report can_dispatch."},"auth":{"token":"<token-file>"}}
 ```
 
 The same pipe also exposes these PTY methods for local pane control:
@@ -142,8 +220,9 @@ implement JSON-RPC over the named pipe. They should call
 `desktop.control_plane.contract` first and generate client capabilities from
 the returned `methods` list.
 
-Non-contract calls fail closed when the desktop app was not launched with
-`WINSMUX_CONTROL_PIPE_TOKEN`, or when the request omits `auth.token`.
+Non-contract calls fail closed when neither a non-empty
+`WINSMUX_CONTROL_PIPE_TOKEN` nor the exact token file can authenticate the
+request, or when the request omits `auth.token`. See [Error semantics](#error-semantics).
 
 Agent CLIs can also drive the pipe from a local shell or tool call when the user
 has granted permission to run a local command. They do not get a special

--- a/docs/project/v03629-declarative-workspace-architecture.md
+++ b/docs/project/v03629-declarative-workspace-architecture.md
@@ -111,9 +111,10 @@ Resolution order is fixed:
    catalog.
 2. Lane A validates recipe bindings against slot IDs and capabilities from
    that catalog.
-3. A recipe may require a provider capability or refer to `slot_id`; it may not
-   override a slot's provider, model, reasoning effort, role profile,
-   lifecycle, or task classes.
+3. A recipe may require a provider capability or refer to a YAML `slot-ref`;
+   it may not override a slot's provider, model, reasoning effort, role
+   profile, lifecycle, or task classes. Runtime objects may expose the resolved
+   identity as `slot_id`.
 4. The dry-run output shows the resolved slot for every logical recipe role.
    A missing, ambiguous, unavailable, or capability-incompatible binding fails
    closed before pane creation.
@@ -125,6 +126,22 @@ parsing Lane A configuration. TASK-662 cannot declare the v0.36.29 release
 gate complete until TASK-718 has verified the combined desktop/CLI behavior.
 
 ### 3.2 Schema sketch
+
+Canonical `.winsmux.yaml` keys are kebab-case, matching the live product
+contract: `team-profile`, `agent-slots`, `workspace-recipes`, `slot-ref`, and
+the other hyphenated fields in the fragment below. Snake_case spellings such as
+`team_profile` / `agent_slots` are load-only aliases where the live loader
+already accepts them (`mapping_lookup` in `core/src/team_profile.rs`, and the
+legacy settings loader's hyphen-to-underscore fold). They are not the
+canonical on-disk form. Do not reverse live product keys to snake_case.
+
+A scalar `team-profile: default` is not a valid Lane B opt-in. The live parser
+requires a mapping and fails closed with "team-profile must be a mapping."
+This document does not introduce a scalar migration alias.
+
+Normalized runtime objects, including `.winsmux/manifest.yaml` projections,
+may still use snake_case field names. That runtime spelling is not the YAML
+settings contract.
 
 Public YAML uses the repository's existing hyphenated spelling; normalized
 runtime objects use snake_case. The marker-delimited fragment below is the
@@ -572,6 +589,12 @@ The current `.winsmux.yaml` keys, default external-operator layout,
 `agent-slots` behavior, `orchestra-start.ps1` entrypoint, one-shot
 `team-pipeline.ps1` path, and operator-owned decisions are intentionally
 preserved.
+
+Slot and session launch is task-agnostic. Orchestra startup may create or
+respawn worker panes and record launch approval before any task assignment
+exists. Launch bundles and `orchestra-start.ps1` must not require a task ID;
+dispatch carries task metadata later. This document does not change
+`orchestra-start.ps1`.
 
 Lane A keys are opt-in. Absence of `workspace-recipes`, `workflows`, and
 `context-packs` selects current behavior. The gallery may generate a proposal,

--- a/docs/project/v03629-team-profile-architecture.md
+++ b/docs/project/v03629-team-profile-architecture.md
@@ -101,10 +101,20 @@ read-modify-write path that preserves unknown top-level keys. A save operation
 that parses only its own subtree and serializes a replacement root document is
 not acceptable.
 
-The canonical on-disk spelling is kebab-case. Existing snake_case spellings
-remain load-only compatibility aliases where the current settings loader
-already accepts them. New saves emit the canonical spelling without changing
-unrelated legacy keys merely to normalize formatting.
+The canonical on-disk spelling is kebab-case (`team-profile`, `agent-slots`,
+and their nested fields such as `slot-id`). The live opted-in parser in
+`core/src/team_profile.rs` looks up kebab-case first and accepts the matching
+snake_case spelling as a load-only alias (`mapping_lookup`). If both spellings
+are present for the same field, the parser fails closed with `ambiguous_alias`.
+Do not reverse live product keys to snake_case. New saves emit the canonical
+kebab-case spelling without rewriting unrelated legacy keys merely to
+normalize formatting.
+
+A scalar `team-profile: default` is not valid opt-in. The live parser requires
+`team-profile` to be a mapping with `schema-version`, `preset`,
+`preset-revision`, and `update-policy`; a scalar fails with
+`invalid_team_profile` / "team-profile must be a mapping." This document does
+not add a scalar migration alias.
 
 ### Composed example
 
@@ -347,7 +357,8 @@ authorization. When the operator dispatches real work, the existing typed
 dispatch packet carries the concrete task ID, task-scoped read/write bounds,
 and expected evidence contract. That packet may reference the immutable launch
 bundle digest, but it does not rewrite the launch bundle or infer task state
-from its text.
+from its text. `orchestra-start.ps1` remains the startup entrypoint and is not
+required to carry a task ID at slot or session launch.
 
 The bundle is written atomically beneath
 `.winsmux/runtime/prompt-bundles/<session-id>/<slot-id>.md`. It is ephemeral

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -309,6 +309,44 @@ function Get-ControlRpcTokenEnvName {
     return 'WINSMUX_CONTROL_PIPE_TOKEN'
 }
 
+function Get-ControlRpcTokenFileTemplate {
+    return '%LOCALAPPDATA%\winsmux\control-pipe\token'
+}
+
+function Get-ControlRpcTokenFilePath {
+    $localAppData = [Environment]::GetEnvironmentVariable('LOCALAPPDATA', 'Process')
+    if ([string]::IsNullOrWhiteSpace($localAppData)) {
+        return $null
+    }
+    return [System.IO.Path]::Combine($localAppData, 'winsmux', 'control-pipe', 'token')
+}
+
+function Get-ControlRpcToken {
+    $tokenEnvName = Get-ControlRpcTokenEnvName
+    $token = [string][Environment]::GetEnvironmentVariable($tokenEnvName, 'Process')
+    if (-not [string]::IsNullOrWhiteSpace($token)) {
+        return $token
+    }
+
+    $tokenPath = Get-ControlRpcTokenFilePath
+    if ([string]::IsNullOrWhiteSpace($tokenPath)) {
+        return $null
+    }
+    if (-not (Test-Path -LiteralPath $tokenPath -PathType Leaf)) {
+        return $null
+    }
+
+    try {
+        $fileToken = [System.IO.File]::ReadAllText($tokenPath)
+    } catch {
+        return $null
+    }
+    if ([string]::IsNullOrWhiteSpace($fileToken)) {
+        return $null
+    }
+    return $fileToken.Trim()
+}
+
 function Add-ControlRpcAuthToPayload {
     param([Parameter(Mandatory = $true)]$Payload)
 
@@ -318,7 +356,7 @@ function Add-ControlRpcAuthToPayload {
     }
 
     $tokenEnvName = Get-ControlRpcTokenEnvName
-    $token = [string][Environment]::GetEnvironmentVariable($tokenEnvName, 'Process')
+    $token = Get-ControlRpcToken
     if ([string]::IsNullOrWhiteSpace($token)) {
         Stop-WithError "control-rpc requires $tokenEnvName for non-contract methods"
     }

--- a/tests/bridge/ArtifactsRuntime.Tests.ps1
+++ b/tests/bridge/ArtifactsRuntime.Tests.ps1
@@ -1828,10 +1828,28 @@ Describe 'winsmux control-rpc command' {
 
     BeforeEach {
         $script:previousControlPipeToken = $env:WINSMUX_CONTROL_PIPE_TOKEN
+        $script:previousControlPipeLocalAppData = $env:LOCALAPPDATA
         Remove-Item Env:\WINSMUX_CONTROL_PIPE_TOKEN -ErrorAction SilentlyContinue
+        $script:controlPipeLocalAppDataRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("winsmux-control-pipe-pester-" + [guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $script:controlPipeLocalAppDataRoot -Force | Out-Null
+        $env:LOCALAPPDATA = $script:controlPipeLocalAppDataRoot
+        $script:controlPipePlantedPaths = @()
     }
 
     AfterEach {
+        foreach ($plantedPath in @($script:controlPipePlantedPaths)) {
+            if (-not [string]::IsNullOrWhiteSpace($plantedPath) -and (Test-Path -LiteralPath $plantedPath)) {
+                Remove-Item -LiteralPath $plantedPath -Force -ErrorAction SilentlyContinue
+            }
+        }
+        if (-not [string]::IsNullOrWhiteSpace($script:controlPipeLocalAppDataRoot) -and (Test-Path -LiteralPath $script:controlPipeLocalAppDataRoot)) {
+            Remove-Item -LiteralPath $script:controlPipeLocalAppDataRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        if ($null -eq $script:previousControlPipeLocalAppData) {
+            Remove-Item Env:\LOCALAPPDATA -ErrorAction SilentlyContinue
+        } else {
+            $env:LOCALAPPDATA = $script:previousControlPipeLocalAppData
+        }
         if ($null -eq $script:previousControlPipeToken) {
             Remove-Item Env:\WINSMUX_CONTROL_PIPE_TOKEN -ErrorAction SilentlyContinue
         } else {
@@ -1849,6 +1867,8 @@ Describe 'winsmux control-rpc command' {
         $script:controlRpcBridgeContent | Should -Match '\$client\.ReadAsync\(\$buffer, 0, \$buffer\.Length\)'
         $script:controlRpcBridgeContent | Should -Match 'timed out waiting for response'
         $script:controlRpcBridgeContent | Should -Match 'WINSMUX_CONTROL_PIPE_TOKEN'
+        $script:controlRpcBridgeContent | Should -Match 'Get-ControlRpcTokenFileTemplate'
+        Get-ControlRpcTokenFileTemplate | Should -Be '%LOCALAPPDATA%\winsmux\control-pipe\token'
         Get-ControlRpcPipeName | Should -Be 'winsmux-control'
         Get-ControlRpcPipeDisplayName | Should -Be '\\.\pipe\winsmux-control'
     }
@@ -1883,6 +1903,61 @@ Describe 'winsmux control-rpc command' {
     It 'fails closed when a non-contract method has no control pipe token' {
         { ConvertTo-ControlRpcPayload -JsonText '{"jsonrpc":"2.0","id":1,"method":"pty.capture","params":{"paneId":"pane-1"}}' } |
             Should -Throw '*WINSMUX_CONTROL_PIPE_TOKEN*'
+    }
+
+    It 'uses the LOCALAPPDATA control-pipe token file when the env is unset' {
+        $tokenDir = Join-Path $env:LOCALAPPDATA 'winsmux\control-pipe'
+        New-Item -ItemType Directory -Path $tokenDir -Force | Out-Null
+        $tokenPath = Join-Path $tokenDir 'token'
+        $generated = [guid]::NewGuid().ToString('N')
+        [System.IO.File]::WriteAllText($tokenPath, $generated)
+
+        try {
+            $payload = ConvertTo-ControlRpcPayload -JsonText '{"jsonrpc":"2.0","id":1,"method":"pty.capture","params":{"paneId":"pane-1"}}'
+            $request = $payload | ConvertFrom-Json
+            $request.method | Should -Be 'pty.capture'
+            $request.auth.token | Should -Be $generated
+        } finally {
+            if (Test-Path -LiteralPath $tokenPath) {
+                Remove-Item -LiteralPath $tokenPath -Force
+            }
+        }
+    }
+
+    It 'ignores a planted repo .winsmux token file' {
+        $repoRoot = Split-Path -Parent $script:BridgeTestsRoot
+        $plantedDir = Join-Path $repoRoot '.winsmux'
+        $createdPlantedDir = -not (Test-Path -LiteralPath $plantedDir)
+        $plantedPath = Join-Path $plantedDir 'token'
+        $script:controlPipePlantedPaths += $plantedPath
+        $plantedToken = 'planted-' + [guid]::NewGuid().ToString('N')
+        New-Item -ItemType Directory -Path $plantedDir -Force | Out-Null
+        [System.IO.File]::WriteAllText($plantedPath, $plantedToken)
+
+        try {
+            { ConvertTo-ControlRpcPayload -JsonText '{"jsonrpc":"2.0","id":1,"method":"pty.capture","params":{"paneId":"pane-1"}}' } |
+                Should -Throw '*WINSMUX_CONTROL_PIPE_TOKEN*'
+
+            $tokenDir = Join-Path $env:LOCALAPPDATA 'winsmux\control-pipe'
+            New-Item -ItemType Directory -Path $tokenDir -Force | Out-Null
+            $tokenPath = Join-Path $tokenDir 'token'
+            $generated = [guid]::NewGuid().ToString('N')
+            [System.IO.File]::WriteAllText($tokenPath, $generated)
+            $payload = ConvertTo-ControlRpcPayload -JsonText '{"jsonrpc":"2.0","id":1,"method":"pty.capture","params":{"paneId":"pane-1"}}'
+            $request = $payload | ConvertFrom-Json
+            $request.auth.token | Should -Be $generated
+            $request.auth.token | Should -Not -Be $plantedToken
+        } finally {
+            if (Test-Path -LiteralPath $plantedPath) {
+                Remove-Item -LiteralPath $plantedPath -Force
+            }
+            if ($createdPlantedDir -and (Test-Path -LiteralPath $plantedDir)) {
+                $remaining = @(Get-ChildItem -LiteralPath $plantedDir -Force -ErrorAction SilentlyContinue)
+                if ($remaining.Count -eq 0) {
+                    Remove-Item -LiteralPath $plantedDir -Force -ErrorAction SilentlyContinue
+                }
+            }
+        }
     }
 
     It 'rejects missing JSON-RPC payloads' {

--- a/winsmux-app/src-tauri/Cargo.toml
+++ b/winsmux-app/src-tauri/Cargo.toml
@@ -27,4 +27,4 @@ sha2 = "0.10"
 ureq = { version = "2", features = ["json"] }
 portable-pty = "0.9.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Media", "Win32_Media_Audio", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Pipes"] }
+windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Media", "Win32_Media_Audio", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Threading"] }

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -75,8 +75,7 @@ pub fn control_pipe_auth_is_available() -> bool {
 }
 
 pub fn control_pipe_ui_is_enabled() -> bool {
-    control_pipe_auth_is_available()
-        || CONTROL_PIPE_SERVER_INTENDED.load(Ordering::SeqCst)
+    control_pipe_auth_is_available() || CONTROL_PIPE_SERVER_INTENDED.load(Ordering::SeqCst)
 }
 
 #[cfg(any(windows, test))]
@@ -135,25 +134,21 @@ fn write_control_pipe_token_file(path: &Path, token: &str) -> Result<(), String>
         .parent()
         .ok_or_else(|| "control-pipe token rotate failed".to_string())?;
     fs::create_dir_all(parent).map_err(|_| "control-pipe token rotate failed".to_string())?;
-    fs::write(path, token.as_bytes())
-        .map_err(|_| "control-pipe token rotate failed".to_string())?;
     #[cfg(windows)]
     {
-        if let Err(err) = apply_user_only_dacl(path) {
-            let _ = fs::remove_file(path);
-            return Err(err);
-        }
-        if let Err(err) = apply_user_only_dacl(parent) {
-            let _ = fs::remove_file(path);
-            return Err(err);
-        }
+        write_control_pipe_token_file_windows(path, parent, token)
     }
-    #[cfg(unix)]
+    #[cfg(not(windows))]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+        fs::write(path, token.as_bytes())
+            .map_err(|_| "control-pipe token rotate failed".to_string())?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+        }
+        Ok(())
     }
-    Ok(())
 }
 
 fn existing_token_file_is_trusted(path: &Path) -> bool {
@@ -361,6 +356,140 @@ fn apply_user_only_dacl(path: &Path) -> Result<(), String> {
         } else {
             Ok(())
         }
+    }
+}
+
+#[cfg(windows)]
+fn write_control_pipe_token_file_windows(
+    path: &Path,
+    parent: &Path,
+    token: &str,
+) -> Result<(), String> {
+    apply_user_only_dacl(parent)?;
+    let mut last_err = "control-pipe token rotate failed".to_string();
+    for _ in 0..8 {
+        let mut name_bytes = [0u8; 16];
+        fill_random_bytes(&mut name_bytes)?;
+        let temp_hex: String = name_bytes
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect();
+        let temp_name = format!("token.{temp_hex}.tmp");
+        let temp_path = parent.join(temp_name);
+        match create_user_only_file_with_bytes(&temp_path, token.as_bytes()) {
+            Ok(()) => {
+                if let Err(err) = replace_file_atomic(&temp_path, path) {
+                    let _ = fs::remove_file(&temp_path);
+                    return Err(err);
+                }
+                return Ok(());
+            }
+            Err(err) if err == "control-pipe token rotate failed (exists)" => {
+                last_err = err;
+            }
+            Err(err) => {
+                let _ = fs::remove_file(&temp_path);
+                return Err(err);
+            }
+        }
+    }
+    Err(last_err)
+}
+
+#[cfg(windows)]
+fn create_user_only_file_with_bytes(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, GetLastError, ERROR_ALREADY_EXISTS, ERROR_FILE_EXISTS, HANDLE,
+        INVALID_HANDLE_VALUE,
+    };
+    use windows_sys::Win32::Security::Authorization::{
+        ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+    };
+    use windows_sys::Win32::Security::{PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES};
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FlushFileBuffers, WriteFile, CREATE_NEW, FILE_ATTRIBUTE_NORMAL,
+        FILE_FLAG_WRITE_THROUGH,
+    };
+
+    const GENERIC_WRITE: u32 = 0x4000_0000;
+
+    let sid = current_user_sid_string()?;
+    let sddl = format!("D:P(A;;GA;;;{sid})");
+    let sddl_wide: Vec<u16> = sddl.encode_utf16().chain(Some(0)).collect();
+    let path_wide = path_to_wide(path);
+    unsafe {
+        let mut sd: PSECURITY_DESCRIPTOR = core::ptr::null_mut();
+        if ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl_wide.as_ptr(),
+            SDDL_REVISION_1,
+            &mut sd,
+            core::ptr::null_mut(),
+        ) == 0
+        {
+            return Err("control-pipe token rotate failed".to_string());
+        }
+        let sa = SECURITY_ATTRIBUTES {
+            nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: sd,
+            bInheritHandle: 0,
+        };
+        let handle: HANDLE = CreateFileW(
+            path_wide.as_ptr(),
+            GENERIC_WRITE,
+            0,
+            &sa,
+            CREATE_NEW,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_WRITE_THROUGH,
+            core::ptr::null_mut(),
+        );
+        let create_error = GetLastError();
+        local_free_ptr(sd);
+        if handle == INVALID_HANDLE_VALUE {
+            if create_error == ERROR_FILE_EXISTS || create_error == ERROR_ALREADY_EXISTS {
+                return Err("control-pipe token rotate failed (exists)".to_string());
+            }
+            return Err(format!("control-pipe token rotate failed ({create_error})"));
+        }
+        let mut bytes_written = 0u32;
+        let write_ok = WriteFile(
+            handle,
+            bytes.as_ptr(),
+            bytes.len() as u32,
+            &mut bytes_written,
+            core::ptr::null_mut(),
+        );
+        if write_ok == 0 || bytes_written as usize != bytes.len() {
+            CloseHandle(handle);
+            return Err("control-pipe token rotate failed".to_string());
+        }
+        FlushFileBuffers(handle);
+        CloseHandle(handle);
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn replace_file_atomic(from: &Path, to: &Path) -> Result<(), String> {
+    use windows_sys::Win32::Foundation::GetLastError;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let from_wide = path_to_wide(from);
+    let to_wide = path_to_wide(to);
+    let moved = unsafe {
+        MoveFileExW(
+            from_wide.as_ptr(),
+            to_wide.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if moved == 0 {
+        Err(format!("control-pipe token rotate failed ({})", unsafe {
+            GetLastError()
+        }))
+    } else {
+        Ok(())
     }
 }
 
@@ -920,6 +1049,25 @@ mod tests {
         guard
     }
 
+    fn leftover_control_pipe_token_temps(parent: &Path) -> Vec<PathBuf> {
+        let Ok(entries) = fs::read_dir(parent) else {
+            return Vec::new();
+        };
+        entries
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| {
+                        name.starts_with("token.")
+                            && name.ends_with(".tmp")
+                            && name.len() == "token.".len() + 32 + ".tmp".len()
+                    })
+            })
+            .collect()
+    }
+
     fn harden_existing_token_file_for_test(path: &Path) {
         #[cfg(windows)]
         apply_user_only_dacl(path).expect("harden previous token file");
@@ -1432,6 +1580,15 @@ mod tests {
         bootstrap_control_pipe_token().expect("bootstrap");
         let current = fs::read_to_string(&path).expect("current token");
         assert_ne!(current, "planted-previous-token");
+        #[cfg(windows)]
+        assert!(
+            existing_token_file_is_trusted(&path),
+            "replaced dest must keep the user-only create DACL"
+        );
+        assert!(
+            leftover_control_pipe_token_temps(path.parent().expect("parent")).is_empty(),
+            "atomic replace must not leave token.*.tmp"
+        );
 
         let pty_transport = StubPtyTransport::new();
         let rejected = handle_control_pipe_payload(
@@ -1539,6 +1696,23 @@ mod tests {
     }
 
     #[test]
+    fn control_pipe_token_file_is_user_only_after_first_write() {
+        let _guard = isolate_control_pipe_paths_for_test();
+        let path = control_pipe_token_file_path().expect("token path");
+        bootstrap_control_pipe_token().expect("bootstrap");
+        assert!(path.is_file());
+        #[cfg(windows)]
+        assert!(
+            existing_token_file_is_trusted(&path),
+            "first write must create the dest with a user-only DACL"
+        );
+        assert!(
+            leftover_control_pipe_token_temps(path.parent().expect("parent")).is_empty(),
+            "first write must not leave token.*.tmp"
+        );
+    }
+
+    #[test]
     #[cfg(windows)]
     fn control_pipe_bootstrap_fail_closed_when_dacl_hardening_fails() {
         struct ResetDaclFailure;
@@ -1556,6 +1730,12 @@ mod tests {
             .expect_err("hardening failure must fail closed");
         assert!(!bootstrapped);
         assert!(!path.exists(), "unhardened token file must be removed");
+        if let Some(parent) = path.parent() {
+            assert!(
+                leftover_control_pipe_token_temps(parent).is_empty(),
+                "fail-closed DACL must not leave a temp token file"
+            );
+        }
         assert!(control_pipe_auth_state_lock().is_none());
         assert!(!control_pipe_auth_is_available());
         assert!(is_control_pipe_startup_error(&err));

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -8,6 +8,7 @@ use crate::pty_backend::{
 use serde_json::{json, Value};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -26,6 +27,7 @@ struct ControlPipeAuthState {
 }
 
 static CONTROL_PIPE_AUTH_STATE: Mutex<Option<ControlPipeAuthState>> = Mutex::new(None);
+static CONTROL_PIPE_SERVER_INTENDED: AtomicBool = AtomicBool::new(false);
 
 fn control_pipe_auth_state_lock() -> std::sync::MutexGuard<'static, Option<ControlPipeAuthState>> {
     CONTROL_PIPE_AUTH_STATE
@@ -70,6 +72,21 @@ fn read_control_pipe_token_file() -> Option<String> {
 
 pub fn control_pipe_auth_is_available() -> bool {
     process_env_control_pipe_token().is_some() || read_control_pipe_token_file().is_some()
+}
+
+pub fn control_pipe_ui_is_enabled() -> bool {
+    control_pipe_auth_is_available()
+        || CONTROL_PIPE_SERVER_INTENDED.load(Ordering::SeqCst)
+}
+
+#[cfg(any(windows, test))]
+fn mark_control_pipe_server_intended() {
+    CONTROL_PIPE_SERVER_INTENDED.store(true, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+fn reset_control_pipe_server_intended() {
+    CONTROL_PIPE_SERVER_INTENDED.store(false, Ordering::SeqCst);
 }
 
 fn generate_control_pipe_token() -> Result<String, String> {
@@ -158,6 +175,10 @@ fn bootstrap_control_pipe_token_after_exclusive_pipe(
     already_bootstrapped: &mut bool,
 ) -> Result<(), String> {
     if *already_bootstrapped {
+        return Ok(());
+    }
+    if process_env_control_pipe_token().is_some() {
+        *already_bootstrapped = true;
         return Ok(());
     }
     bootstrap_control_pipe_token()?;
@@ -661,6 +682,7 @@ fn serialize_control_pipe_result(id: Value, result: Value) -> Vec<u8> {
 
 #[cfg(windows)]
 pub fn start_control_pipe_server(pty_transport: Arc<dyn PtyCommandTransport + Send + Sync>) {
+    mark_control_pipe_server_intended();
     std::thread::spawn(move || {
         let mut token_bootstrapped = false;
         loop {
@@ -822,6 +844,7 @@ mod tests {
     impl Drop for ControlPipeTokenEnvGuard {
         fn drop(&mut self) {
             reset_control_pipe_auth_state();
+            reset_control_pipe_server_intended();
             if let Some(previous) = self.previous_token.take() {
                 std::env::set_var(WINSMUX_CONTROL_PIPE_TOKEN_ENV, previous);
             } else {
@@ -841,6 +864,7 @@ mod tests {
             .lock()
             .unwrap_or_else(|err| err.into_inner());
         reset_control_pipe_auth_state();
+        reset_control_pipe_server_intended();
         let previous_token = std::env::var_os(WINSMUX_CONTROL_PIPE_TOKEN_ENV);
         let previous_localappdata = std::env::var_os("LOCALAPPDATA");
         std::env::remove_var(WINSMUX_CONTROL_PIPE_TOKEN_ENV);
@@ -1463,6 +1487,62 @@ mod tests {
         assert!(control_pipe_auth_state_lock().is_none());
         assert!(!control_pipe_auth_is_available());
         assert!(is_control_pipe_startup_error(&err));
+    }
+
+    #[test]
+    fn control_pipe_ui_enabled_before_token_file_exists() {
+        let _guard = isolate_control_pipe_paths_for_test();
+        let path = control_pipe_token_file_path().expect("token path");
+        assert!(!path.exists());
+        assert!(!control_pipe_auth_is_available());
+        assert!(!control_pipe_ui_is_enabled());
+        mark_control_pipe_server_intended();
+        assert!(!control_pipe_auth_is_available());
+        assert!(control_pipe_ui_is_enabled());
+    }
+
+    #[test]
+    fn control_pipe_env_token_skips_file_rotate_after_exclusive_pipe() {
+        let _guard = set_control_pipe_token_for_test(Some("env-token-value"));
+        let path = control_pipe_token_file_path().expect("token path");
+        fs::create_dir_all(path.parent().expect("parent")).expect("token dir");
+        fs::write(&path, "keep-file-token").expect("file token");
+        let mut bootstrapped = false;
+        bootstrap_control_pipe_token_after_exclusive_pipe(&mut bootstrapped)
+            .expect("env token must not require file rotate");
+        assert!(bootstrapped);
+        assert_eq!(
+            fs::read_to_string(&path).expect("unchanged file token"),
+            "keep-file-token"
+        );
+        assert!(control_pipe_auth_state_lock().is_none());
+        assert!(control_pipe_auth_is_available());
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn control_pipe_env_token_survives_file_dacl_hardening_failure() {
+        struct ResetDaclFailure;
+        impl Drop for ResetDaclFailure {
+            fn drop(&mut self) {
+                FORCE_CONTROL_PIPE_DACL_FAILURE.store(false, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+        let _reset = ResetDaclFailure;
+        let _guard = set_control_pipe_token_for_test(Some("env-token-value"));
+        FORCE_CONTROL_PIPE_DACL_FAILURE.store(true, std::sync::atomic::Ordering::SeqCst);
+        let path = control_pipe_token_file_path().expect("token path");
+        fs::create_dir_all(path.parent().expect("parent")).expect("token dir");
+        fs::write(&path, "keep-file-token").expect("file token");
+        let mut bootstrapped = false;
+        bootstrap_control_pipe_token_after_exclusive_pipe(&mut bootstrapped)
+            .expect("env token launch must not fail closed on file DACL");
+        assert!(bootstrapped);
+        assert_eq!(
+            fs::read_to_string(&path).expect("unchanged file token"),
+            "keep-file-token"
+        );
+        assert!(control_pipe_auth_is_available());
     }
 
     #[test]

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -501,29 +501,40 @@ fn replace_file_atomic(from: &Path, to: &Path) -> Result<(), String> {
 fn owner_sid_matches_current_principal(
     owner: windows_sys::Win32::Security::PSID,
     user_sid: windows_sys::Win32::Security::PSID,
-    token: windows_sys::Win32::Foundation::HANDLE,
+    token_owner_sid: windows_sys::Win32::Security::PSID,
 ) -> bool {
-    use windows_sys::Win32::Security::Authorization::ConvertStringSidToSidW;
-    use windows_sys::Win32::Security::{CheckTokenMembership, EqualSid, PSID};
+    use windows_sys::Win32::Security::EqualSid;
 
     unsafe {
-        if EqualSid(owner, user_sid) != 0 {
+        // TokenOwner is the SID Windows stamps on files this process creates.
+        // Elevated tokens often use BUILTIN\Administrators there; that SID can
+        // be deny-only, so CheckTokenMembership is not a reliable owner check.
+        if !user_sid.is_null() && EqualSid(owner, user_sid) != 0 {
             return true;
         }
-        // Elevated Windows (including GitHub-hosted runners) often stores
-        // BUILTIN\Administrators as the owner of files the process just created.
-        let ba: Vec<u16> = "S-1-5-32-544".encode_utf16().chain(Some(0)).collect();
-        let mut ba_sid: PSID = core::ptr::null_mut();
-        if ConvertStringSidToSidW(ba.as_ptr(), &mut ba_sid) == 0 || ba_sid.is_null() {
-            return false;
+        !token_owner_sid.is_null() && EqualSid(owner, token_owner_sid) != 0
+    }
+}
+
+#[cfg(all(windows, test))]
+fn sid_to_string_for_test(sid: windows_sys::Win32::Security::PSID) -> String {
+    use windows_sys::Win32::Security::Authorization::ConvertSidToStringSidW;
+
+    if sid.is_null() {
+        return "null".to_string();
+    }
+    unsafe {
+        let mut text: windows_sys::core::PWSTR = core::ptr::null_mut();
+        if ConvertSidToStringSidW(sid, &mut text) == 0 || text.is_null() {
+            return "unprintable".to_string();
         }
-        let is_builtin_admin = EqualSid(owner, ba_sid) != 0;
-        let mut is_member: windows_sys::core::BOOL = 0;
-        let trusted_admin = is_builtin_admin
-            && CheckTokenMembership(token, ba_sid, &mut is_member) != 0
-            && is_member != 0;
-        local_free_ptr(ba_sid);
-        trusted_admin
+        let mut len = 0usize;
+        while *text.add(len) != 0 {
+            len += 1;
+        }
+        let value = String::from_utf16_lossy(std::slice::from_raw_parts(text, len));
+        local_free_ptr(text.cast());
+        value
     }
 }
 
@@ -534,9 +545,10 @@ fn control_pipe_token_file_dacl_is_user_only(path: &Path) -> Result<bool, String
     use windows_sys::Win32::Security::Authorization::ConvertStringSidToSidW;
     use windows_sys::Win32::Security::Authorization::{GetNamedSecurityInfoW, SE_FILE_OBJECT};
     use windows_sys::Win32::Security::{
-        AclSizeInformation, EqualSid, GetAce, GetAclInformation, GetTokenInformation, TokenUser,
-        ACE_HEADER, ACL, ACL_SIZE_INFORMATION, DACL_SECURITY_INFORMATION,
-        OWNER_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID, TOKEN_QUERY, TOKEN_USER,
+        AclSizeInformation, EqualSid, GetAce, GetAclInformation, GetTokenInformation, TokenOwner,
+        TokenUser, ACE_HEADER, ACL, ACL_SIZE_INFORMATION, DACL_SECURITY_INFORMATION,
+        OWNER_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID, TOKEN_OWNER, TOKEN_QUERY,
+        TOKEN_USER,
     };
     use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
@@ -592,8 +604,30 @@ fn control_pipe_token_file_dacl_is_user_only(path: &Path) -> Result<bool, String
             return Err("control-pipe token rotate failed".to_string());
         }
         let token_user = &*(buffer.as_ptr() as *const TOKEN_USER);
+        let mut token_owner_required = 0u32;
+        GetTokenInformation(
+            token,
+            TokenOwner,
+            core::ptr::null_mut(),
+            0,
+            &mut token_owner_required,
+        );
+        let mut token_owner_buffer = vec![0u8; token_owner_required as usize];
+        let token_owner_sid = if token_owner_required > 0
+            && GetTokenInformation(
+                token,
+                TokenOwner,
+                token_owner_buffer.as_mut_ptr().cast(),
+                token_owner_required,
+                &mut token_owner_required,
+            ) != 0
+        {
+            (*(token_owner_buffer.as_ptr() as *const TOKEN_OWNER)).Owner
+        } else {
+            core::ptr::null_mut()
+        };
         let mut owner_matches =
-            owner_sid_matches_current_principal(owner, token_user.User.Sid, token);
+            owner_sid_matches_current_principal(owner, token_user.User.Sid, token_owner_sid);
         #[cfg(test)]
         {
             if FORCE_CONTROL_PIPE_OWNER_MISMATCH.load(std::sync::atomic::Ordering::SeqCst) {
@@ -612,6 +646,13 @@ fn control_pipe_token_file_dacl_is_user_only(path: &Path) -> Result<bool, String
         }
         CloseHandle(token);
         if !owner_matches {
+            #[cfg(test)]
+            eprintln!(
+                "control-pipe owner rejected file={} user={} token_owner={}",
+                sid_to_string_for_test(owner),
+                sid_to_string_for_test(token_user.User.Sid),
+                sid_to_string_for_test(token_owner_sid)
+            );
             local_free_ptr(sd);
             return Ok(false);
         }
@@ -632,6 +673,8 @@ fn control_pipe_token_file_dacl_is_user_only(path: &Path) -> Result<bool, String
             return Err("control-pipe token rotate failed".to_string());
         }
         if size_info.AceCount != 1 {
+            #[cfg(test)]
+            eprintln!("control-pipe DACL AceCount={}", size_info.AceCount);
             local_free_ptr(sd);
             return Ok(false);
         }

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -27,7 +27,6 @@ struct ControlPipeAuthState {
 
 static CONTROL_PIPE_AUTH_STATE: Mutex<Option<ControlPipeAuthState>> = Mutex::new(None);
 
-
 fn control_pipe_auth_state_lock() -> std::sync::MutexGuard<'static, Option<ControlPipeAuthState>> {
     CONTROL_PIPE_AUTH_STATE
         .lock()
@@ -119,11 +118,19 @@ fn write_control_pipe_token_file(path: &Path, token: &str) -> Result<(), String>
         .parent()
         .ok_or_else(|| "control-pipe token rotate failed".to_string())?;
     fs::create_dir_all(parent).map_err(|_| "control-pipe token rotate failed".to_string())?;
-    fs::write(path, token.as_bytes()).map_err(|_| "control-pipe token rotate failed".to_string())?;
+    fs::write(path, token.as_bytes())
+        .map_err(|_| "control-pipe token rotate failed".to_string())?;
     #[cfg(windows)]
-    apply_user_only_dacl(path)?;
-    #[cfg(windows)]
-    apply_user_only_dacl(parent)?;
+    {
+        if let Err(err) = apply_user_only_dacl(path) {
+            let _ = fs::remove_file(path);
+            return Err(err);
+        }
+        if let Err(err) = apply_user_only_dacl(parent) {
+            let _ = fs::remove_file(path);
+            return Err(err);
+        }
+    }
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -147,11 +154,15 @@ fn bootstrap_control_pipe_token() -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(windows)]
-fn bootstrap_control_pipe_token_on_start() {
-    if bootstrap_control_pipe_token().is_err() {
-        eprintln!("winsmux control pipe token rotate failed");
+fn bootstrap_control_pipe_token_after_exclusive_pipe(
+    already_bootstrapped: &mut bool,
+) -> Result<(), String> {
+    if *already_bootstrapped {
+        return Ok(());
     }
+    bootstrap_control_pipe_token()?;
+    *already_bootstrapped = true;
+    Ok(())
 }
 
 fn authorize_rotated_or_file_token(provided: &str) -> bool {
@@ -196,8 +207,8 @@ fn local_free_ptr(ptr: *mut core::ffi::c_void) {
 #[cfg(windows)]
 fn current_user_sid_string() -> Result<String, String> {
     use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
-    use windows_sys::Win32::Security::{GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER};
     use windows_sys::Win32::Security::Authorization::ConvertSidToStringSidW;
+    use windows_sys::Win32::Security::{GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER};
     use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
     unsafe {
@@ -239,16 +250,24 @@ fn current_user_sid_string() -> Result<String, String> {
     }
 }
 
+#[cfg(all(windows, test))]
+static FORCE_CONTROL_PIPE_DACL_FAILURE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 #[cfg(windows)]
 fn apply_user_only_dacl(path: &Path) -> Result<(), String> {
+    #[cfg(test)]
+    if FORCE_CONTROL_PIPE_DACL_FAILURE.load(std::sync::atomic::Ordering::SeqCst) {
+        return Err("control-pipe token rotate failed".to_string());
+    }
     use windows_sys::Win32::Foundation::ERROR_SUCCESS;
-    use windows_sys::Win32::Security::{
-        GetSecurityDescriptorDacl, ACL, DACL_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION,
-        PSECURITY_DESCRIPTOR,
-    };
     use windows_sys::Win32::Security::Authorization::{
-        ConvertStringSecurityDescriptorToSecurityDescriptorW, SetNamedSecurityInfoW, SDDL_REVISION_1,
-        SE_FILE_OBJECT,
+        ConvertStringSecurityDescriptorToSecurityDescriptorW, SetNamedSecurityInfoW,
+        SDDL_REVISION_1, SE_FILE_OBJECT,
+    };
+    use windows_sys::Win32::Security::{
+        GetSecurityDescriptorDacl, ACL, DACL_SECURITY_INFORMATION,
+        PROTECTED_DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR,
     };
 
     let sid = current_user_sid_string()?;
@@ -271,7 +290,9 @@ fn apply_user_only_dacl(path: &Path) -> Result<(), String> {
         let mut present: windows_sys::core::BOOL = 0;
         let mut defaulted: windows_sys::core::BOOL = 0;
         let mut dacl: *mut ACL = core::ptr::null_mut();
-        if GetSecurityDescriptorDacl(sd, &mut present, &mut dacl, &mut defaulted) == 0 || present == 0 {
+        if GetSecurityDescriptorDacl(sd, &mut present, &mut dacl, &mut defaulted) == 0
+            || present == 0
+        {
             local_free_ptr(sd);
             return Err("control-pipe token rotate failed".to_string());
         }
@@ -296,12 +317,12 @@ fn apply_user_only_dacl(path: &Path) -> Result<(), String> {
 #[cfg(windows)]
 fn control_pipe_token_file_dacl_is_user_only(path: &Path) -> Result<bool, String> {
     use windows_sys::Win32::Foundation::{CloseHandle, ERROR_SUCCESS, HANDLE};
+    use windows_sys::Win32::Security::Authorization::{GetNamedSecurityInfoW, SE_FILE_OBJECT};
     use windows_sys::Win32::Security::{
-        EqualSid, GetAce, GetAclInformation, GetTokenInformation, TokenUser, ACE_HEADER, ACL,
-        ACL_SIZE_INFORMATION, AclSizeInformation, DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR,
+        AclSizeInformation, EqualSid, GetAce, GetAclInformation, GetTokenInformation, TokenUser,
+        ACE_HEADER, ACL, ACL_SIZE_INFORMATION, DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR,
         PSID, TOKEN_QUERY, TOKEN_USER,
     };
-    use windows_sys::Win32::Security::Authorization::{GetNamedSecurityInfoW, SE_FILE_OBJECT};
     use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
     let path_wide = path_to_wide(path);
@@ -391,7 +412,6 @@ fn control_pipe_token_file_dacl_is_user_only(path: &Path) -> Result<bool, String
         Ok(equal)
     }
 }
-
 
 const JSON_RPC_PARSE_ERROR: i32 = -32700;
 const JSON_RPC_METHOD_NOT_FOUND: i32 = -32601;
@@ -641,15 +661,19 @@ fn serialize_control_pipe_result(id: Value, result: Value) -> Vec<u8> {
 
 #[cfg(windows)]
 pub fn start_control_pipe_server(pty_transport: Arc<dyn PtyCommandTransport + Send + Sync>) {
-    bootstrap_control_pipe_token_on_start();
-    std::thread::spawn(move || loop {
-        if let Err(err) = serve_one_control_pipe_client(pty_transport.as_ref()) {
-            if is_control_pipe_startup_error(&err) {
-                eprintln!("winsmux control pipe disabled: {err}");
-                break;
+    std::thread::spawn(move || {
+        let mut token_bootstrapped = false;
+        loop {
+            if let Err(err) =
+                serve_one_control_pipe_client(pty_transport.as_ref(), &mut token_bootstrapped)
+            {
+                if is_control_pipe_startup_error(&err) {
+                    eprintln!("winsmux control pipe disabled: {err}");
+                    break;
+                }
+                eprintln!("winsmux control pipe error: {err}");
+                std::thread::sleep(Duration::from_millis(250));
             }
-            eprintln!("winsmux control pipe error: {err}");
-            std::thread::sleep(Duration::from_millis(250));
         }
     });
 }
@@ -658,7 +682,10 @@ pub fn start_control_pipe_server(pty_transport: Arc<dyn PtyCommandTransport + Se
 pub fn start_control_pipe_server(_pty_transport: Arc<dyn PtyCommandTransport + Send + Sync>) {}
 
 #[cfg(windows)]
-fn serve_one_control_pipe_client(pty_transport: &dyn PtyCommandTransport) -> Result<(), String> {
+fn serve_one_control_pipe_client(
+    pty_transport: &dyn PtyCommandTransport,
+    token_bootstrapped: &mut bool,
+) -> Result<(), String> {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
     use std::ptr::null_mut;
@@ -707,6 +734,7 @@ fn serve_one_control_pipe_client(pty_transport: &dyn PtyCommandTransport) -> Res
         }));
     }
     let pipe = PipeHandle(handle);
+    bootstrap_control_pipe_token_after_exclusive_pipe(token_bootstrapped)?;
 
     let connected = unsafe { ConnectNamedPipe(pipe.0, null_mut()) };
     if connected == 0 {
@@ -768,6 +796,7 @@ fn serve_one_control_pipe_client(pty_transport: &dyn PtyCommandTransport) -> Res
 #[cfg(windows)]
 fn is_control_pipe_startup_error(message: &str) -> bool {
     message.starts_with("CreateNamedPipeW failed")
+        || message.starts_with("control-pipe token rotate failed")
 }
 
 #[cfg(test)]
@@ -1257,7 +1286,11 @@ mod tests {
         fs::write(&exact, "exact-file-token").expect("exact token");
 
         let pty_transport = StubPtyTransport::new();
-        for planted in ["planted-repo-token", "planted-wrong-name-token", "planted-temp-token"] {
+        for planted in [
+            "planted-repo-token",
+            "planted-wrong-name-token",
+            "planted-temp-token",
+        ] {
             let response = handle_control_pipe_payload(
                 &StubDesktopTransport,
                 &pty_transport,
@@ -1276,7 +1309,13 @@ mod tests {
         );
         let value: Value = serde_json::from_slice(&response).expect("json");
         assert_eq!(value["result"]["paneId"], "pane-1");
-        let _ = fs::remove_dir_all(planted_temp.parent().and_then(|p| p.parent()).and_then(|p| p.parent()).unwrap_or(planted_temp.as_path()));
+        let _ = fs::remove_dir_all(
+            planted_temp
+                .parent()
+                .and_then(|p| p.parent())
+                .and_then(|p| p.parent())
+                .unwrap_or(planted_temp.as_path()),
+        );
     }
 
     #[test]
@@ -1378,6 +1417,55 @@ mod tests {
     }
 
     #[test]
+    fn control_pipe_does_not_rotate_until_exclusive_pipe_is_acquired() {
+        let _guard = isolate_control_pipe_paths_for_test();
+        let path = control_pipe_token_file_path().expect("token path");
+        fs::create_dir_all(path.parent().expect("parent")).expect("token dir");
+        fs::write(&path, "keep-existing-token").expect("existing token");
+
+        let mut bootstrapped = false;
+        assert_eq!(
+            fs::read_to_string(&path).expect("unread token"),
+            "keep-existing-token"
+        );
+        assert!(control_pipe_auth_state_lock().is_none());
+
+        bootstrap_control_pipe_token_after_exclusive_pipe(&mut bootstrapped)
+            .expect("first exclusive bootstrap");
+        assert!(bootstrapped);
+        let current = fs::read_to_string(&path).expect("rotated token");
+        assert_ne!(current, "keep-existing-token");
+        assert_eq!(current.len(), CONTROL_PIPE_TOKEN_RANDOM_BYTES * 2);
+
+        bootstrap_control_pipe_token_after_exclusive_pipe(&mut bootstrapped)
+            .expect("second exclusive bootstrap is a no-op");
+        assert_eq!(fs::read_to_string(&path).expect("stable token"), current);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn control_pipe_bootstrap_fail_closed_when_dacl_hardening_fails() {
+        struct ResetDaclFailure;
+        impl Drop for ResetDaclFailure {
+            fn drop(&mut self) {
+                FORCE_CONTROL_PIPE_DACL_FAILURE.store(false, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+        let _reset = ResetDaclFailure;
+        let _guard = isolate_control_pipe_paths_for_test();
+        FORCE_CONTROL_PIPE_DACL_FAILURE.store(true, std::sync::atomic::Ordering::SeqCst);
+        let path = control_pipe_token_file_path().expect("token path");
+        let mut bootstrapped = false;
+        let err = bootstrap_control_pipe_token_after_exclusive_pipe(&mut bootstrapped)
+            .expect_err("hardening failure must fail closed");
+        assert!(!bootstrapped);
+        assert!(!path.exists(), "unhardened token file must be removed");
+        assert!(control_pipe_auth_state_lock().is_none());
+        assert!(!control_pipe_auth_is_available());
+        assert!(is_control_pipe_startup_error(&err));
+    }
+
+    #[test]
     fn control_pipe_operator_snapshot_accepts_file_token() {
         let _guard = isolate_control_pipe_paths_for_test();
         let path = control_pipe_token_file_path().expect("token path");
@@ -1391,5 +1479,4 @@ mod tests {
         assert_eq!(value["id"], 1);
         assert!(value.get("error").is_none() || value["error"].is_null());
     }
-
 }

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -119,11 +119,11 @@ fn write_control_pipe_token_file(path: &Path, token: &str) -> Result<(), String>
         .parent()
         .ok_or_else(|| "control-pipe token rotate failed".to_string())?;
     fs::create_dir_all(parent).map_err(|_| "control-pipe token rotate failed".to_string())?;
-    #[cfg(windows)]
-    apply_user_only_dacl(parent)?;
     fs::write(path, token.as_bytes()).map_err(|_| "control-pipe token rotate failed".to_string())?;
     #[cfg(windows)]
     apply_user_only_dacl(path)?;
+    #[cfg(windows)]
+    apply_user_only_dacl(parent)?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -252,7 +252,9 @@ fn apply_user_only_dacl(path: &Path) -> Result<(), String> {
     };
 
     let sid = current_user_sid_string()?;
-    let sddl = format!("D:P(A;;FA;;;{sid})");
+    // GENERIC_ALL maps for both files and directories. FILE_ALL_ACCESS (FA) on a
+    // directory can fail SetNamedSecurityInfoW on GitHub-hosted Windows images.
+    let sddl = format!("D:P(A;;GA;;;{sid})");
     let sddl_wide: Vec<u16> = sddl.encode_utf16().chain(Some(0)).collect();
     let mut path_wide = path_to_wide(path);
     unsafe {
@@ -284,7 +286,7 @@ fn apply_user_only_dacl(path: &Path) -> Result<(), String> {
         );
         local_free_ptr(sd);
         if status != ERROR_SUCCESS {
-            Err("control-pipe token rotate failed".to_string())
+            Err(format!("control-pipe token rotate failed ({status})"))
         } else {
             Ok(())
         }
@@ -808,7 +810,7 @@ mod tests {
     fn isolate_control_pipe_paths_for_test() -> ControlPipeTokenEnvGuard {
         let lock = CONTROL_PIPE_TOKEN_ENV_LOCK
             .lock()
-            .expect("control pipe token env lock");
+            .unwrap_or_else(|err| err.into_inner());
         reset_control_pipe_auth_state();
         let previous_token = std::env::var_os(WINSMUX_CONTROL_PIPE_TOKEN_ENV);
         let previous_localappdata = std::env::var_os("LOCALAPPDATA");

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -299,6 +299,10 @@ fn current_user_sid_string() -> Result<String, String> {
 static FORCE_CONTROL_PIPE_DACL_FAILURE: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
+#[cfg(all(windows, test))]
+static FORCE_CONTROL_PIPE_OWNER_MISMATCH: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 #[cfg(windows)]
 fn apply_user_only_dacl(path: &Path) -> Result<(), String> {
     #[cfg(test)]
@@ -496,11 +500,13 @@ fn replace_file_atomic(from: &Path, to: &Path) -> Result<(), String> {
 #[cfg(windows)]
 fn control_pipe_token_file_dacl_is_user_only(path: &Path) -> Result<bool, String> {
     use windows_sys::Win32::Foundation::{CloseHandle, ERROR_SUCCESS, HANDLE};
+    #[cfg(test)]
+    use windows_sys::Win32::Security::Authorization::ConvertStringSidToSidW;
     use windows_sys::Win32::Security::Authorization::{GetNamedSecurityInfoW, SE_FILE_OBJECT};
     use windows_sys::Win32::Security::{
         AclSizeInformation, EqualSid, GetAce, GetAclInformation, GetTokenInformation, TokenUser,
-        ACE_HEADER, ACL, ACL_SIZE_INFORMATION, DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR,
-        PSID, TOKEN_QUERY, TOKEN_USER,
+        ACE_HEADER, ACL, ACL_SIZE_INFORMATION, DACL_SECURITY_INFORMATION,
+        OWNER_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID, TOKEN_QUERY, TOKEN_USER,
     };
     use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
@@ -514,7 +520,7 @@ fn control_pipe_token_file_dacl_is_user_only(path: &Path) -> Result<bool, String
         let status = GetNamedSecurityInfoW(
             path_wide.as_ptr(),
             SE_FILE_OBJECT,
-            DACL_SECURITY_INFORMATION,
+            OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
             &mut owner,
             &mut group,
             &mut dacl,
@@ -524,6 +530,61 @@ fn control_pipe_token_file_dacl_is_user_only(path: &Path) -> Result<bool, String
         if status != ERROR_SUCCESS || dacl.is_null() {
             local_free_ptr(sd);
             return Err("control-pipe token rotate failed".to_string());
+        }
+        if owner.is_null() {
+            local_free_ptr(sd);
+            return Ok(false);
+        }
+
+        let mut token: HANDLE = core::ptr::null_mut();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
+            local_free_ptr(sd);
+            return Err("control-pipe token rotate failed".to_string());
+        }
+        let mut required = 0u32;
+        GetTokenInformation(token, TokenUser, core::ptr::null_mut(), 0, &mut required);
+        if required == 0 {
+            CloseHandle(token);
+            local_free_ptr(sd);
+            return Err("control-pipe token rotate failed".to_string());
+        }
+        let mut buffer = vec![0u8; required as usize];
+        if GetTokenInformation(
+            token,
+            TokenUser,
+            buffer.as_mut_ptr().cast(),
+            required,
+            &mut required,
+        ) == 0
+        {
+            CloseHandle(token);
+            local_free_ptr(sd);
+            return Err("control-pipe token rotate failed".to_string());
+        }
+        CloseHandle(token);
+        let token_user = &*(buffer.as_ptr() as *const TOKEN_USER);
+        let mut expected_owner = token_user.User.Sid;
+        #[cfg(test)]
+        let mut everyone_sid: PSID = core::ptr::null_mut();
+        #[cfg(test)]
+        {
+            if FORCE_CONTROL_PIPE_OWNER_MISMATCH.load(std::sync::atomic::Ordering::SeqCst) {
+                let everyone: Vec<u16> = "S-1-1-0".encode_utf16().chain(Some(0)).collect();
+                if ConvertStringSidToSidW(everyone.as_ptr(), &mut everyone_sid) == 0
+                    || everyone_sid.is_null()
+                {
+                    local_free_ptr(sd);
+                    return Err("control-pipe token rotate failed".to_string());
+                }
+                expected_owner = everyone_sid;
+            }
+        }
+        let owner_matches = EqualSid(owner, expected_owner) != 0;
+        #[cfg(test)]
+        local_free_ptr(everyone_sid);
+        if !owner_matches {
+            local_free_ptr(sd);
+            return Ok(false);
         }
 
         let mut size_info = ACL_SIZE_INFORMATION {
@@ -558,34 +619,6 @@ fn control_pipe_token_file_dacl_is_user_only(path: &Path) -> Result<bool, String
             return Ok(false);
         }
         let sid: PSID = ace_ptr.cast::<u8>().add(8).cast();
-
-        let mut token: HANDLE = core::ptr::null_mut();
-        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
-            local_free_ptr(sd);
-            return Err("control-pipe token rotate failed".to_string());
-        }
-        let mut required = 0u32;
-        GetTokenInformation(token, TokenUser, core::ptr::null_mut(), 0, &mut required);
-        if required == 0 {
-            CloseHandle(token);
-            local_free_ptr(sd);
-            return Err("control-pipe token rotate failed".to_string());
-        }
-        let mut buffer = vec![0u8; required as usize];
-        if GetTokenInformation(
-            token,
-            TokenUser,
-            buffer.as_mut_ptr().cast(),
-            required,
-            &mut required,
-        ) == 0
-        {
-            CloseHandle(token);
-            local_free_ptr(sd);
-            return Err("control-pipe token rotate failed".to_string());
-        }
-        CloseHandle(token);
-        let token_user = &*(buffer.as_ptr() as *const TOKEN_USER);
         let equal = EqualSid(sid, token_user.User.Sid) != 0;
         local_free_ptr(sd);
         Ok(equal)
@@ -1595,6 +1628,55 @@ mod tests {
             &StubDesktopTransport,
             &pty_transport,
             &capture_payload_with_token("planted-previous-token"),
+            None,
+        );
+        let rejected_value: Value = serde_json::from_slice(&rejected).expect("rejected json");
+        assert_eq!(rejected_value["error"]["code"], JSON_RPC_INVALID_REQUEST);
+
+        let accepted = handle_control_pipe_payload(
+            &StubDesktopTransport,
+            &pty_transport,
+            &capture_payload_with_token(&current),
+            None,
+        );
+        let accepted_value: Value = serde_json::from_slice(&accepted).expect("accepted json");
+        assert_eq!(accepted_value["result"]["paneId"], "pane-1");
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn control_pipe_foreign_owner_previous_token_is_not_accepted() {
+        struct ResetOwnerMismatch;
+        impl Drop for ResetOwnerMismatch {
+            fn drop(&mut self) {
+                FORCE_CONTROL_PIPE_OWNER_MISMATCH.store(false, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+        let _reset = ResetOwnerMismatch;
+        let _guard = isolate_control_pipe_paths_for_test();
+        let path = control_pipe_token_file_path().expect("token path");
+        fs::create_dir_all(path.parent().expect("parent")).expect("token dir");
+        fs::write(&path, "planted-foreign-owner-token").expect("planted token");
+        apply_user_only_dacl(&path).expect("user-only DACL");
+        assert!(
+            existing_token_file_is_trusted(&path),
+            "same-owner user-only DACL is the positive control"
+        );
+        FORCE_CONTROL_PIPE_OWNER_MISMATCH.store(true, std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            !existing_token_file_is_trusted(&path),
+            "user-only DACL with a foreign owner must not be trusted"
+        );
+
+        bootstrap_control_pipe_token().expect("bootstrap");
+        let current = fs::read_to_string(&path).expect("current token");
+        assert_ne!(current, "planted-foreign-owner-token");
+
+        let pty_transport = StubPtyTransport::new();
+        let rejected = handle_control_pipe_payload(
+            &StubDesktopTransport,
+            &pty_transport,
+            &capture_payload_with_token("planted-foreign-owner-token"),
             None,
         );
         let rejected_value: Value = serde_json::from_slice(&rejected).expect("rejected json");

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -498,6 +498,36 @@ fn replace_file_atomic(from: &Path, to: &Path) -> Result<(), String> {
 }
 
 #[cfg(windows)]
+fn owner_sid_matches_current_principal(
+    owner: windows_sys::Win32::Security::PSID,
+    user_sid: windows_sys::Win32::Security::PSID,
+    token: windows_sys::Win32::Foundation::HANDLE,
+) -> bool {
+    use windows_sys::Win32::Security::Authorization::ConvertStringSidToSidW;
+    use windows_sys::Win32::Security::{CheckTokenMembership, EqualSid, PSID};
+
+    unsafe {
+        if EqualSid(owner, user_sid) != 0 {
+            return true;
+        }
+        // Elevated Windows (including GitHub-hosted runners) often stores
+        // BUILTIN\Administrators as the owner of files the process just created.
+        let ba: Vec<u16> = "S-1-5-32-544".encode_utf16().chain(Some(0)).collect();
+        let mut ba_sid: PSID = core::ptr::null_mut();
+        if ConvertStringSidToSidW(ba.as_ptr(), &mut ba_sid) == 0 || ba_sid.is_null() {
+            return false;
+        }
+        let is_builtin_admin = EqualSid(owner, ba_sid) != 0;
+        let mut is_member: windows_sys::core::BOOL = 0;
+        let trusted_admin = is_builtin_admin
+            && CheckTokenMembership(token, ba_sid, &mut is_member) != 0
+            && is_member != 0;
+        local_free_ptr(ba_sid);
+        trusted_admin
+    }
+}
+
+#[cfg(windows)]
 fn control_pipe_token_file_dacl_is_user_only(path: &Path) -> Result<bool, String> {
     use windows_sys::Win32::Foundation::{CloseHandle, ERROR_SUCCESS, HANDLE};
     #[cfg(test)]
@@ -561,27 +591,26 @@ fn control_pipe_token_file_dacl_is_user_only(path: &Path) -> Result<bool, String
             local_free_ptr(sd);
             return Err("control-pipe token rotate failed".to_string());
         }
-        CloseHandle(token);
         let token_user = &*(buffer.as_ptr() as *const TOKEN_USER);
-        let mut expected_owner = token_user.User.Sid;
-        #[cfg(test)]
-        let mut everyone_sid: PSID = core::ptr::null_mut();
+        let mut owner_matches =
+            owner_sid_matches_current_principal(owner, token_user.User.Sid, token);
         #[cfg(test)]
         {
             if FORCE_CONTROL_PIPE_OWNER_MISMATCH.load(std::sync::atomic::Ordering::SeqCst) {
                 let everyone: Vec<u16> = "S-1-1-0".encode_utf16().chain(Some(0)).collect();
+                let mut everyone_sid: PSID = core::ptr::null_mut();
                 if ConvertStringSidToSidW(everyone.as_ptr(), &mut everyone_sid) == 0
                     || everyone_sid.is_null()
                 {
+                    CloseHandle(token);
                     local_free_ptr(sd);
                     return Err("control-pipe token rotate failed".to_string());
                 }
-                expected_owner = everyone_sid;
+                owner_matches = EqualSid(owner, everyone_sid) != 0;
+                local_free_ptr(everyone_sid);
             }
         }
-        let owner_matches = EqualSid(owner, expected_owner) != 0;
-        #[cfg(test)]
-        local_free_ptr(everyone_sid);
+        CloseHandle(token);
         if !owner_matches {
             local_free_ptr(sd);
             return Ok(false);

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -6,11 +6,390 @@ use crate::pty_backend::{
     PTY_CONTROL_PIPE_METHODS,
 };
 use serde_json::{json, Value};
-use std::sync::Arc;
-use std::time::Duration;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 pub const WINSMUX_CONTROL_PIPE_NAME: &str = r"\\.\pipe\winsmux-control";
 pub const WINSMUX_CONTROL_PIPE_TOKEN_ENV: &str = "WINSMUX_CONTROL_PIPE_TOKEN";
+pub const WINSMUX_CONTROL_PIPE_TOKEN_FILE_TEMPLATE: &str =
+    r"%LOCALAPPDATA%\winsmux\control-pipe\token";
+const CONTROL_PIPE_TOKEN_ROTATED_MARKER: &str = "control-pipe token: rotated";
+const PREVIOUS_TOKEN_TTL: Duration = Duration::from_secs(60);
+const CONTROL_PIPE_TOKEN_RANDOM_BYTES: usize = 32;
+
+struct ControlPipeAuthState {
+    current: String,
+    previous: Option<String>,
+    previous_deadline: Instant,
+}
+
+static CONTROL_PIPE_AUTH_STATE: Mutex<Option<ControlPipeAuthState>> = Mutex::new(None);
+
+
+fn control_pipe_auth_state_lock() -> std::sync::MutexGuard<'static, Option<ControlPipeAuthState>> {
+    CONTROL_PIPE_AUTH_STATE
+        .lock()
+        .unwrap_or_else(|err| err.into_inner())
+}
+
+fn reset_control_pipe_auth_state() {
+    *control_pipe_auth_state_lock() = None;
+}
+
+fn control_pipe_token_file_path() -> Option<PathBuf> {
+    let local_app_data = std::env::var_os("LOCALAPPDATA")?;
+    if local_app_data.is_empty() {
+        return None;
+    }
+    Some(
+        PathBuf::from(local_app_data)
+            .join("winsmux")
+            .join("control-pipe")
+            .join("token"),
+    )
+}
+
+fn process_env_control_pipe_token() -> Option<String> {
+    match std::env::var(WINSMUX_CONTROL_PIPE_TOKEN_ENV) {
+        Ok(value) if !value.trim().is_empty() => Some(value),
+        _ => None,
+    }
+}
+
+fn read_control_pipe_token_file() -> Option<String> {
+    let path = control_pipe_token_file_path()?;
+    let contents = fs::read_to_string(path).ok()?;
+    let trimmed = contents.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+pub fn control_pipe_auth_is_available() -> bool {
+    process_env_control_pipe_token().is_some() || read_control_pipe_token_file().is_some()
+}
+
+fn generate_control_pipe_token() -> Result<String, String> {
+    let mut bytes = [0u8; CONTROL_PIPE_TOKEN_RANDOM_BYTES];
+    fill_random_bytes(&mut bytes)?;
+    Ok(bytes.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+#[cfg(windows)]
+fn fill_random_bytes(bytes: &mut [u8]) -> Result<(), String> {
+    const BCRYPT_USE_SYSTEM_PREFERRED_RNG: u32 = 0x0000_0002;
+    #[link(name = "bcrypt")]
+    extern "system" {
+        fn BCryptGenRandom(
+            h_algorithm: *mut core::ffi::c_void,
+            pb_buffer: *mut u8,
+            cb_buffer: u32,
+            dw_flags: u32,
+        ) -> i32;
+    }
+    let status = unsafe {
+        BCryptGenRandom(
+            core::ptr::null_mut(),
+            bytes.as_mut_ptr(),
+            bytes.len() as u32,
+            BCRYPT_USE_SYSTEM_PREFERRED_RNG,
+        )
+    };
+    if status == 0 {
+        Ok(())
+    } else {
+        Err("control-pipe token rotate failed".to_string())
+    }
+}
+
+#[cfg(not(windows))]
+fn fill_random_bytes(bytes: &mut [u8]) -> Result<(), String> {
+    use std::io::Read;
+    fs::File::open("/dev/urandom")
+        .and_then(|mut file| file.read_exact(bytes))
+        .map_err(|_| "control-pipe token rotate failed".to_string())
+}
+
+fn write_control_pipe_token_file(path: &Path, token: &str) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "control-pipe token rotate failed".to_string())?;
+    fs::create_dir_all(parent).map_err(|_| "control-pipe token rotate failed".to_string())?;
+    #[cfg(windows)]
+    apply_user_only_dacl(parent)?;
+    fs::write(path, token.as_bytes()).map_err(|_| "control-pipe token rotate failed".to_string())?;
+    #[cfg(windows)]
+    apply_user_only_dacl(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+    }
+    Ok(())
+}
+
+fn bootstrap_control_pipe_token() -> Result<(), String> {
+    let path = control_pipe_token_file_path()
+        .ok_or_else(|| "control-pipe token rotate failed".to_string())?;
+    let previous = read_control_pipe_token_file();
+    let current = generate_control_pipe_token()?;
+    write_control_pipe_token_file(&path, &current)?;
+    *control_pipe_auth_state_lock() = Some(ControlPipeAuthState {
+        current,
+        previous,
+        previous_deadline: Instant::now() + PREVIOUS_TOKEN_TTL,
+    });
+    eprintln!("{CONTROL_PIPE_TOKEN_ROTATED_MARKER}");
+    Ok(())
+}
+
+#[cfg(windows)]
+fn bootstrap_control_pipe_token_on_start() {
+    if bootstrap_control_pipe_token().is_err() {
+        eprintln!("winsmux control pipe token rotate failed");
+    }
+}
+
+fn authorize_rotated_or_file_token(provided: &str) -> bool {
+    let mut guard = control_pipe_auth_state_lock();
+    if let Some(state) = guard.as_mut() {
+        if constant_time_string_eq(provided.as_bytes(), state.current.as_bytes()) {
+            state.previous = None;
+            return true;
+        }
+        if state.previous.is_some() && Instant::now() >= state.previous_deadline {
+            state.previous = None;
+            return false;
+        }
+        if let Some(previous) = state.previous.as_ref() {
+            return constant_time_string_eq(provided.as_bytes(), previous.as_bytes());
+        }
+        return false;
+    }
+    drop(guard);
+    match read_control_pipe_token_file() {
+        Some(file_token) => constant_time_string_eq(provided.as_bytes(), file_token.as_bytes()),
+        None => false,
+    }
+}
+
+#[cfg(windows)]
+fn path_to_wide(path: &Path) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
+    path.as_os_str().encode_wide().chain(Some(0)).collect()
+}
+
+#[cfg(windows)]
+fn local_free_ptr(ptr: *mut core::ffi::c_void) {
+    use windows_sys::Win32::Foundation::LocalFree;
+    if !ptr.is_null() {
+        unsafe {
+            LocalFree(ptr);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn current_user_sid_string() -> Result<String, String> {
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows_sys::Win32::Security::{GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER};
+    use windows_sys::Win32::Security::Authorization::ConvertSidToStringSidW;
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    unsafe {
+        let mut token: HANDLE = core::ptr::null_mut();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
+            return Err("control-pipe token rotate failed".to_string());
+        }
+        let mut required = 0u32;
+        GetTokenInformation(token, TokenUser, core::ptr::null_mut(), 0, &mut required);
+        if required == 0 {
+            CloseHandle(token);
+            return Err("control-pipe token rotate failed".to_string());
+        }
+        let mut buffer = vec![0u8; required as usize];
+        if GetTokenInformation(
+            token,
+            TokenUser,
+            buffer.as_mut_ptr().cast(),
+            required,
+            &mut required,
+        ) == 0
+        {
+            CloseHandle(token);
+            return Err("control-pipe token rotate failed".to_string());
+        }
+        CloseHandle(token);
+        let token_user = &*(buffer.as_ptr() as *const TOKEN_USER);
+        let mut sid_string: windows_sys::core::PWSTR = core::ptr::null_mut();
+        if ConvertSidToStringSidW(token_user.User.Sid, &mut sid_string) == 0 {
+            return Err("control-pipe token rotate failed".to_string());
+        }
+        let mut len = 0usize;
+        while *sid_string.add(len) != 0 {
+            len += 1;
+        }
+        let text = String::from_utf16_lossy(std::slice::from_raw_parts(sid_string, len));
+        local_free_ptr(sid_string.cast());
+        Ok(text)
+    }
+}
+
+#[cfg(windows)]
+fn apply_user_only_dacl(path: &Path) -> Result<(), String> {
+    use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+    use windows_sys::Win32::Security::{
+        GetSecurityDescriptorDacl, ACL, DACL_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION,
+        PSECURITY_DESCRIPTOR,
+    };
+    use windows_sys::Win32::Security::Authorization::{
+        ConvertStringSecurityDescriptorToSecurityDescriptorW, SetNamedSecurityInfoW, SDDL_REVISION_1,
+        SE_FILE_OBJECT,
+    };
+
+    let sid = current_user_sid_string()?;
+    let sddl = format!("D:P(A;;FA;;;{sid})");
+    let sddl_wide: Vec<u16> = sddl.encode_utf16().chain(Some(0)).collect();
+    let mut path_wide = path_to_wide(path);
+    unsafe {
+        let mut sd: PSECURITY_DESCRIPTOR = core::ptr::null_mut();
+        if ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl_wide.as_ptr(),
+            SDDL_REVISION_1,
+            &mut sd,
+            core::ptr::null_mut(),
+        ) == 0
+        {
+            return Err("control-pipe token rotate failed".to_string());
+        }
+        let mut present: windows_sys::core::BOOL = 0;
+        let mut defaulted: windows_sys::core::BOOL = 0;
+        let mut dacl: *mut ACL = core::ptr::null_mut();
+        if GetSecurityDescriptorDacl(sd, &mut present, &mut dacl, &mut defaulted) == 0 || present == 0 {
+            local_free_ptr(sd);
+            return Err("control-pipe token rotate failed".to_string());
+        }
+        let status = SetNamedSecurityInfoW(
+            path_wide.as_mut_ptr(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            core::ptr::null_mut(),
+            core::ptr::null_mut(),
+            dacl,
+            core::ptr::null_mut(),
+        );
+        local_free_ptr(sd);
+        if status != ERROR_SUCCESS {
+            Err("control-pipe token rotate failed".to_string())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(windows)]
+fn control_pipe_token_file_dacl_is_user_only(path: &Path) -> Result<bool, String> {
+    use windows_sys::Win32::Foundation::{CloseHandle, ERROR_SUCCESS, HANDLE};
+    use windows_sys::Win32::Security::{
+        EqualSid, GetAce, GetAclInformation, GetTokenInformation, TokenUser, ACE_HEADER, ACL,
+        ACL_SIZE_INFORMATION, AclSizeInformation, DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR,
+        PSID, TOKEN_QUERY, TOKEN_USER,
+    };
+    use windows_sys::Win32::Security::Authorization::{GetNamedSecurityInfoW, SE_FILE_OBJECT};
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    let path_wide = path_to_wide(path);
+    unsafe {
+        let mut owner: PSID = core::ptr::null_mut();
+        let mut group: PSID = core::ptr::null_mut();
+        let mut dacl: *mut ACL = core::ptr::null_mut();
+        let mut sacl: *mut ACL = core::ptr::null_mut();
+        let mut sd: PSECURITY_DESCRIPTOR = core::ptr::null_mut();
+        let status = GetNamedSecurityInfoW(
+            path_wide.as_ptr(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            &mut owner,
+            &mut group,
+            &mut dacl,
+            &mut sacl,
+            &mut sd,
+        );
+        if status != ERROR_SUCCESS || dacl.is_null() {
+            local_free_ptr(sd);
+            return Err("control-pipe token rotate failed".to_string());
+        }
+
+        let mut size_info = ACL_SIZE_INFORMATION {
+            AceCount: 0,
+            AclBytesInUse: 0,
+            AclBytesFree: 0,
+        };
+        if GetAclInformation(
+            dacl,
+            std::ptr::addr_of_mut!(size_info).cast(),
+            std::mem::size_of::<ACL_SIZE_INFORMATION>() as u32,
+            AclSizeInformation,
+        ) == 0
+        {
+            local_free_ptr(sd);
+            return Err("control-pipe token rotate failed".to_string());
+        }
+        if size_info.AceCount != 1 {
+            local_free_ptr(sd);
+            return Ok(false);
+        }
+
+        let mut ace_ptr: *mut core::ffi::c_void = core::ptr::null_mut();
+        if GetAce(dacl, 0, &mut ace_ptr) == 0 {
+            local_free_ptr(sd);
+            return Err("control-pipe token rotate failed".to_string());
+        }
+        let header = &*(ace_ptr as *const ACE_HEADER);
+        // ACCESS_ALLOWED_ACE_TYPE is 0; avoid extra SystemServices feature.
+        if header.AceType != 0 {
+            local_free_ptr(sd);
+            return Ok(false);
+        }
+        let sid: PSID = ace_ptr.cast::<u8>().add(8).cast();
+
+        let mut token: HANDLE = core::ptr::null_mut();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
+            local_free_ptr(sd);
+            return Err("control-pipe token rotate failed".to_string());
+        }
+        let mut required = 0u32;
+        GetTokenInformation(token, TokenUser, core::ptr::null_mut(), 0, &mut required);
+        if required == 0 {
+            CloseHandle(token);
+            local_free_ptr(sd);
+            return Err("control-pipe token rotate failed".to_string());
+        }
+        let mut buffer = vec![0u8; required as usize];
+        if GetTokenInformation(
+            token,
+            TokenUser,
+            buffer.as_mut_ptr().cast(),
+            required,
+            &mut required,
+        ) == 0
+        {
+            CloseHandle(token);
+            local_free_ptr(sd);
+            return Err("control-pipe token rotate failed".to_string());
+        }
+        CloseHandle(token);
+        let token_user = &*(buffer.as_ptr() as *const TOKEN_USER);
+        let equal = EqualSid(sid, token_user.User.Sid) != 0;
+        local_free_ptr(sd);
+        Ok(equal)
+    }
+}
+
 
 const JSON_RPC_PARSE_ERROR: i32 = -32700;
 const JSON_RPC_METHOD_NOT_FOUND: i32 = -32601;
@@ -184,6 +563,7 @@ fn control_pipe_contract() -> Value {
     "auth": {
         "required_for_methods": true,
         "token_env": WINSMUX_CONTROL_PIPE_TOKEN_ENV,
+        "token_file": WINSMUX_CONTROL_PIPE_TOKEN_FILE_TEMPLATE,
         "request_field": "auth.token",
     },
     "methods": control_pipe_methods(),
@@ -195,10 +575,6 @@ fn control_pipe_contract() -> Value {
 }
 
 fn is_authorized_control_pipe_request(request_value: &Value) -> bool {
-    let expected_token = match std::env::var(WINSMUX_CONTROL_PIPE_TOKEN_ENV) {
-        Ok(value) if !value.trim().is_empty() => value,
-        _ => return false,
-    };
     let provided_token = match request_value
         .get("auth")
         .and_then(|auth| auth.get("token"))
@@ -208,7 +584,11 @@ fn is_authorized_control_pipe_request(request_value: &Value) -> bool {
         None => return false,
     };
 
-    constant_time_string_eq(provided_token.as_bytes(), expected_token.as_bytes())
+    if let Some(expected_token) = process_env_control_pipe_token() {
+        return constant_time_string_eq(provided_token.as_bytes(), expected_token.as_bytes());
+    }
+
+    authorize_rotated_or_file_token(provided_token)
 }
 
 fn constant_time_string_eq(left: &[u8], right: &[u8]) -> bool {
@@ -259,6 +639,7 @@ fn serialize_control_pipe_result(id: Value, result: Value) -> Vec<u8> {
 
 #[cfg(windows)]
 pub fn start_control_pipe_server(pty_transport: Arc<dyn PtyCommandTransport + Send + Sync>) {
+    bootstrap_control_pipe_token_on_start();
     std::thread::spawn(move || loop {
         if let Err(err) = serve_one_control_pipe_client(pty_transport.as_ref()) {
             if is_control_pipe_startup_error(&err) {
@@ -397,36 +778,75 @@ mod tests {
     use std::sync::{Mutex, MutexGuard};
 
     static CONTROL_PIPE_TOKEN_ENV_LOCK: Mutex<()> = Mutex::new(());
+    static CONTROL_PIPE_TEST_ISOLATION: std::sync::atomic::AtomicU64 =
+        std::sync::atomic::AtomicU64::new(0);
 
     struct ControlPipeTokenEnvGuard {
-        previous: Option<OsString>,
+        previous_token: Option<OsString>,
+        previous_localappdata: Option<OsString>,
+        isolated_root: PathBuf,
         _lock: MutexGuard<'static, ()>,
     }
 
     impl Drop for ControlPipeTokenEnvGuard {
         fn drop(&mut self) {
-            if let Some(previous) = self.previous.take() {
+            reset_control_pipe_auth_state();
+            if let Some(previous) = self.previous_token.take() {
                 std::env::set_var(WINSMUX_CONTROL_PIPE_TOKEN_ENV, previous);
             } else {
                 std::env::remove_var(WINSMUX_CONTROL_PIPE_TOKEN_ENV);
             }
+            if let Some(previous) = self.previous_localappdata.take() {
+                std::env::set_var("LOCALAPPDATA", previous);
+            } else {
+                std::env::remove_var("LOCALAPPDATA");
+            }
+            let _ = fs::remove_dir_all(&self.isolated_root);
+        }
+    }
+
+    fn isolate_control_pipe_paths_for_test() -> ControlPipeTokenEnvGuard {
+        let lock = CONTROL_PIPE_TOKEN_ENV_LOCK
+            .lock()
+            .expect("control pipe token env lock");
+        reset_control_pipe_auth_state();
+        let previous_token = std::env::var_os(WINSMUX_CONTROL_PIPE_TOKEN_ENV);
+        let previous_localappdata = std::env::var_os("LOCALAPPDATA");
+        std::env::remove_var(WINSMUX_CONTROL_PIPE_TOKEN_ENV);
+        let isolated_root = std::env::temp_dir().join(format!(
+            "winsmux-control-pipe-test-{}-{}",
+            std::process::id(),
+            CONTROL_PIPE_TEST_ISOLATION.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&isolated_root).expect("isolated LOCALAPPDATA");
+        std::env::set_var("LOCALAPPDATA", &isolated_root);
+        ControlPipeTokenEnvGuard {
+            previous_token,
+            previous_localappdata,
+            isolated_root,
+            _lock: lock,
         }
     }
 
     fn set_control_pipe_token_for_test(token: Option<&str>) -> ControlPipeTokenEnvGuard {
-        let lock = CONTROL_PIPE_TOKEN_ENV_LOCK
-            .lock()
-            .expect("control pipe token env lock");
-        let previous = std::env::var_os(WINSMUX_CONTROL_PIPE_TOKEN_ENV);
+        let guard = isolate_control_pipe_paths_for_test();
         if let Some(value) = token {
             std::env::set_var(WINSMUX_CONTROL_PIPE_TOKEN_ENV, value);
-        } else {
-            std::env::remove_var(WINSMUX_CONTROL_PIPE_TOKEN_ENV);
         }
-        ControlPipeTokenEnvGuard {
-            previous,
-            _lock: lock,
+        guard
+    }
+
+    fn expire_previous_control_pipe_token_for_test() {
+        if let Some(state) = control_pipe_auth_state_lock().as_mut() {
+            state.previous_deadline = Instant::now() - Duration::from_secs(1);
         }
+    }
+
+    fn capture_payload_with_token(token: &str) -> Vec<u8> {
+        format!(
+            r#"{{"jsonrpc":"2.0","id":1,"method":"pty.capture","params":{{"paneId":"pane-1"}},"auth":{{"token":"{token}"}}}}"#
+        )
+        .into_bytes()
     }
 
     struct StubDesktopTransport;
@@ -520,6 +940,10 @@ mod tests {
         assert_eq!(
             value["result"]["auth"]["token_env"],
             WINSMUX_CONTROL_PIPE_TOKEN_ENV
+        );
+        assert_eq!(
+            value["result"]["auth"]["token_file"],
+            WINSMUX_CONTROL_PIPE_TOKEN_FILE_TEMPLATE
         );
         assert_eq!(value["result"]["auth"]["request_field"], "auth.token");
         assert_eq!(
@@ -777,4 +1201,193 @@ mod tests {
         assert_eq!(value["id"], 1);
         assert_eq!(value["error"]["code"], JSON_RPC_METHOD_NOT_FOUND);
     }
+
+    #[test]
+    fn control_pipe_bootstrap_creates_token_file() {
+        let _guard = isolate_control_pipe_paths_for_test();
+        let path = control_pipe_token_file_path().expect("token path");
+        assert!(!path.exists());
+        bootstrap_control_pipe_token().expect("bootstrap");
+        let contents = fs::read_to_string(&path).expect("token file");
+        assert_eq!(contents.len(), CONTROL_PIPE_TOKEN_RANDOM_BYTES * 2);
+        assert!(contents.chars().all(|ch| ch.is_ascii_hexdigit()));
+        assert!(contents.chars().all(|ch| !ch.is_whitespace()));
+        assert!(control_pipe_auth_is_available());
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn control_pipe_token_file_uses_user_only_dacl() {
+        let _guard = isolate_control_pipe_paths_for_test();
+        bootstrap_control_pipe_token().expect("bootstrap");
+        let path = control_pipe_token_file_path().expect("token path");
+        assert!(
+            control_pipe_token_file_dacl_is_user_only(&path).expect("dacl query"),
+            "token file DACL must be user-only"
+        );
+        let dir = path.parent().expect("token dir");
+        assert!(
+            control_pipe_token_file_dacl_is_user_only(dir).expect("dir dacl query"),
+            "token directory DACL must be user-only"
+        );
+    }
+
+    #[test]
+    fn control_pipe_ignores_planted_token_files() {
+        let _guard = isolate_control_pipe_paths_for_test();
+        let local = PathBuf::from(std::env::var_os("LOCALAPPDATA").expect("LOCALAPPDATA"));
+        let planted_repo = local.join("repo").join(".winsmux").join("token");
+        let planted_wrong_name = local.join("winsmux").join("control-pipe").join("token.bak");
+        let planted_temp = std::env::temp_dir()
+            .join(format!("winsmux-planted-{}-token", std::process::id()))
+            .join("winsmux")
+            .join("control-pipe")
+            .join("token");
+        fs::create_dir_all(planted_repo.parent().expect("repo parent")).expect("repo dir");
+        fs::create_dir_all(planted_wrong_name.parent().expect("wrong parent")).expect("wrong dir");
+        fs::create_dir_all(planted_temp.parent().expect("temp parent")).expect("temp dir");
+        fs::write(&planted_repo, "planted-repo-token").expect("repo plant");
+        fs::write(&planted_wrong_name, "planted-wrong-name-token").expect("name plant");
+        fs::write(&planted_temp, "planted-temp-token").expect("temp plant");
+
+        let exact = control_pipe_token_file_path().expect("token path");
+        fs::create_dir_all(exact.parent().expect("exact parent")).expect("exact dir");
+        fs::write(&exact, "exact-file-token").expect("exact token");
+
+        let pty_transport = StubPtyTransport::new();
+        for planted in ["planted-repo-token", "planted-wrong-name-token", "planted-temp-token"] {
+            let response = handle_control_pipe_payload(
+                &StubDesktopTransport,
+                &pty_transport,
+                &capture_payload_with_token(planted),
+                None,
+            );
+            let value: Value = serde_json::from_slice(&response).expect("json");
+            assert_eq!(value["error"]["code"], JSON_RPC_INVALID_REQUEST);
+        }
+
+        let response = handle_control_pipe_payload(
+            &StubDesktopTransport,
+            &pty_transport,
+            &capture_payload_with_token("exact-file-token"),
+            None,
+        );
+        let value: Value = serde_json::from_slice(&response).expect("json");
+        assert_eq!(value["result"]["paneId"], "pane-1");
+        let _ = fs::remove_dir_all(planted_temp.parent().and_then(|p| p.parent()).and_then(|p| p.parent()).unwrap_or(planted_temp.as_path()));
+    }
+
+    #[test]
+    fn control_pipe_rotate_accepts_previous_until_current_auth() {
+        let _guard = isolate_control_pipe_paths_for_test();
+        let path = control_pipe_token_file_path().expect("token path");
+        fs::create_dir_all(path.parent().expect("parent")).expect("token dir");
+        fs::write(&path, "previous-rotate-token").expect("previous token");
+        bootstrap_control_pipe_token().expect("bootstrap");
+        let current = fs::read_to_string(&path).expect("current token");
+        assert_ne!(current, "previous-rotate-token");
+
+        let pty_transport = StubPtyTransport::new();
+        let previous_response = handle_control_pipe_payload(
+            &StubDesktopTransport,
+            &pty_transport,
+            &capture_payload_with_token("previous-rotate-token"),
+            None,
+        );
+        let previous_value: Value =
+            serde_json::from_slice(&previous_response).expect("previous json");
+        assert_eq!(previous_value["result"]["paneId"], "pane-1");
+
+        let current_response = handle_control_pipe_payload(
+            &StubDesktopTransport,
+            &pty_transport,
+            &capture_payload_with_token(&current),
+            None,
+        );
+        let current_value: Value = serde_json::from_slice(&current_response).expect("current json");
+        assert_eq!(current_value["result"]["paneId"], "pane-1");
+
+        let rejected = handle_control_pipe_payload(
+            &StubDesktopTransport,
+            &pty_transport,
+            &capture_payload_with_token("previous-rotate-token"),
+            None,
+        );
+        let rejected_value: Value = serde_json::from_slice(&rejected).expect("rejected json");
+        assert_eq!(rejected_value["error"]["code"], JSON_RPC_INVALID_REQUEST);
+    }
+
+    #[test]
+    fn control_pipe_drops_previous_token_after_process_ttl() {
+        let _guard = isolate_control_pipe_paths_for_test();
+        let path = control_pipe_token_file_path().expect("token path");
+        fs::create_dir_all(path.parent().expect("parent")).expect("token dir");
+        fs::write(&path, "previous-ttl-token").expect("previous token");
+        bootstrap_control_pipe_token().expect("bootstrap");
+        expire_previous_control_pipe_token_for_test();
+
+        let pty_transport = StubPtyTransport::new();
+        let rejected = handle_control_pipe_payload(
+            &StubDesktopTransport,
+            &pty_transport,
+            &capture_payload_with_token("previous-ttl-token"),
+            None,
+        );
+        let rejected_value: Value = serde_json::from_slice(&rejected).expect("rejected json");
+        assert_eq!(rejected_value["error"]["code"], JSON_RPC_INVALID_REQUEST);
+
+        let current = fs::read_to_string(&path).expect("current token");
+        let accepted = handle_control_pipe_payload(
+            &StubDesktopTransport,
+            &pty_transport,
+            &capture_payload_with_token(&current),
+            None,
+        );
+        let accepted_value: Value = serde_json::from_slice(&accepted).expect("accepted json");
+        assert_eq!(accepted_value["result"]["paneId"], "pane-1");
+    }
+
+    #[test]
+    fn control_pipe_env_token_wins_over_token_file() {
+        let _guard = isolate_control_pipe_paths_for_test();
+        let path = control_pipe_token_file_path().expect("token path");
+        fs::create_dir_all(path.parent().expect("parent")).expect("token dir");
+        fs::write(&path, "file-token-value").expect("file token");
+        std::env::set_var(WINSMUX_CONTROL_PIPE_TOKEN_ENV, "env-token-value");
+
+        let pty_transport = StubPtyTransport::new();
+        let file_rejected = handle_control_pipe_payload(
+            &StubDesktopTransport,
+            &pty_transport,
+            &capture_payload_with_token("file-token-value"),
+            None,
+        );
+        let file_value: Value = serde_json::from_slice(&file_rejected).expect("file json");
+        assert_eq!(file_value["error"]["code"], JSON_RPC_INVALID_REQUEST);
+
+        let env_accepted = handle_control_pipe_payload(
+            &StubDesktopTransport,
+            &pty_transport,
+            &capture_payload_with_token("env-token-value"),
+            None,
+        );
+        let env_value: Value = serde_json::from_slice(&env_accepted).expect("env json");
+        assert_eq!(env_value["result"]["paneId"], "pane-1");
+    }
+
+    #[test]
+    fn control_pipe_operator_snapshot_accepts_file_token() {
+        let _guard = isolate_control_pipe_paths_for_test();
+        let path = control_pipe_token_file_path().expect("token path");
+        fs::create_dir_all(path.parent().expect("parent")).expect("token dir");
+        fs::write(&path, "operator-file-token").expect("file token");
+        let payload = br#"{"jsonrpc":"2.0","id":1,"method":"desktop.operator.snapshot","params":{"lines":40},"auth":{"token":"operator-file-token"}}"#;
+        let pty_transport = StubPtyTransport::new();
+        let response =
+            handle_control_pipe_payload(&StubDesktopTransport, &pty_transport, payload, None);
+        let value: Value = serde_json::from_slice(&response).expect("json");
+        assert_eq!(value["id"], 1);
+        assert!(value.get("error").is_none() || value["error"].is_null());
+    }
+
 }

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -156,10 +156,39 @@ fn write_control_pipe_token_file(path: &Path, token: &str) -> Result<(), String>
     Ok(())
 }
 
+fn existing_token_file_is_trusted(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    #[cfg(windows)]
+    {
+        control_pipe_token_file_dacl_is_user_only(path).unwrap_or(false)
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::metadata(path)
+            .map(|metadata| metadata.permissions().mode() & 0o777 == 0o600)
+            .unwrap_or(false)
+    }
+    #[cfg(not(any(windows, unix)))]
+    {
+        false
+    }
+}
+
+fn read_trusted_previous_control_pipe_token() -> Option<String> {
+    let path = control_pipe_token_file_path()?;
+    if !existing_token_file_is_trusted(&path) {
+        return None;
+    }
+    read_control_pipe_token_file()
+}
+
 fn bootstrap_control_pipe_token() -> Result<(), String> {
     let path = control_pipe_token_file_path()
         .ok_or_else(|| "control-pipe token rotate failed".to_string())?;
-    let previous = read_control_pipe_token_file();
+    let previous = read_trusted_previous_control_pipe_token();
     let current = generate_control_pipe_token()?;
     write_control_pipe_token_file(&path, &current)?;
     *control_pipe_auth_state_lock() = Some(ControlPipeAuthState {
@@ -891,6 +920,16 @@ mod tests {
         guard
     }
 
+    fn harden_existing_token_file_for_test(path: &Path) {
+        #[cfg(windows)]
+        apply_user_only_dacl(path).expect("harden previous token file");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o600)).expect("chmod 0600");
+        }
+    }
+
     fn expire_previous_control_pipe_token_for_test() {
         if let Some(state) = control_pipe_auth_state_lock().as_mut() {
             state.previous_deadline = Instant::now() - Duration::from_secs(1);
@@ -1348,6 +1387,7 @@ mod tests {
         let path = control_pipe_token_file_path().expect("token path");
         fs::create_dir_all(path.parent().expect("parent")).expect("token dir");
         fs::write(&path, "previous-rotate-token").expect("previous token");
+        harden_existing_token_file_for_test(&path);
         bootstrap_control_pipe_token().expect("bootstrap");
         let current = fs::read_to_string(&path).expect("current token");
         assert_ne!(current, "previous-rotate-token");
@@ -1383,11 +1423,43 @@ mod tests {
     }
 
     #[test]
+    fn control_pipe_untrusted_previous_token_is_not_accepted() {
+        let _guard = isolate_control_pipe_paths_for_test();
+        let path = control_pipe_token_file_path().expect("token path");
+        fs::create_dir_all(path.parent().expect("parent")).expect("token dir");
+        fs::write(&path, "planted-previous-token").expect("planted token");
+        assert!(!existing_token_file_is_trusted(&path));
+        bootstrap_control_pipe_token().expect("bootstrap");
+        let current = fs::read_to_string(&path).expect("current token");
+        assert_ne!(current, "planted-previous-token");
+
+        let pty_transport = StubPtyTransport::new();
+        let rejected = handle_control_pipe_payload(
+            &StubDesktopTransport,
+            &pty_transport,
+            &capture_payload_with_token("planted-previous-token"),
+            None,
+        );
+        let rejected_value: Value = serde_json::from_slice(&rejected).expect("rejected json");
+        assert_eq!(rejected_value["error"]["code"], JSON_RPC_INVALID_REQUEST);
+
+        let accepted = handle_control_pipe_payload(
+            &StubDesktopTransport,
+            &pty_transport,
+            &capture_payload_with_token(&current),
+            None,
+        );
+        let accepted_value: Value = serde_json::from_slice(&accepted).expect("accepted json");
+        assert_eq!(accepted_value["result"]["paneId"], "pane-1");
+    }
+
+    #[test]
     fn control_pipe_drops_previous_token_after_process_ttl() {
         let _guard = isolate_control_pipe_paths_for_test();
         let path = control_pipe_token_file_path().expect("token path");
         fs::create_dir_all(path.parent().expect("parent")).expect("token dir");
         fs::write(&path, "previous-ttl-token").expect("previous token");
+        harden_existing_token_file_for_test(&path);
         bootstrap_control_pipe_token().expect("bootstrap");
         expire_previous_control_pipe_token_for_test();
 

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ mod desktop_team_profile;
 mod pty_backend;
 mod remote_debug_gate;
 
-use control_pipe::{start_control_pipe_server, WINSMUX_CONTROL_PIPE_TOKEN_ENV};
+use control_pipe::{control_pipe_auth_is_available, start_control_pipe_server, WINSMUX_CONTROL_PIPE_TOKEN_ENV};
 use desktop_backend::{
     handle_desktop_json_rpc, load_desktop_run_explain, load_desktop_summary_snapshot,
     resolve_repo_root, spawn_desktop_summary_refresh_stream, DesktopExplainPayload,
@@ -254,7 +254,7 @@ fn desktop_write_orchestra_mode(
 
 #[tauri::command]
 fn desktop_control_pipe_enabled() -> bool {
-    std::env::var_os(WINSMUX_CONTROL_PIPE_TOKEN_ENV).is_some()
+    control_pipe_auth_is_available()
 }
 
 #[derive(Debug, Deserialize)]

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -5,7 +5,9 @@ mod desktop_team_profile;
 mod pty_backend;
 mod remote_debug_gate;
 
-use control_pipe::{control_pipe_auth_is_available, start_control_pipe_server, WINSMUX_CONTROL_PIPE_TOKEN_ENV};
+use control_pipe::{
+    control_pipe_ui_is_enabled, start_control_pipe_server, WINSMUX_CONTROL_PIPE_TOKEN_ENV,
+};
 use desktop_backend::{
     handle_desktop_json_rpc, load_desktop_run_explain, load_desktop_summary_snapshot,
     resolve_repo_root, spawn_desktop_summary_refresh_stream, DesktopExplainPayload,
@@ -254,7 +256,7 @@ fn desktop_write_orchestra_mode(
 
 #[tauri::command]
 fn desktop_control_pipe_enabled() -> bool {
-    control_pipe_auth_is_available()
+    control_pipe_ui_is_enabled()
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

TASK-835 pairing contract: a new external agent can follow public docs from an already-running desktop (no `WINSMUX_CONTROL_PIPE_TOKEN` set before launch) to a successful `desktop.operator.snapshot`, using the token file at `%LOCALAPPDATA%\winsmux\control-pipe\token`. Lane A/B architecture docs now match live kebab-case keys `team-profile` and `agent-slots`.

Closes #1107 #1110 #1204

Draft only. Local operator owns ready and merge. Tag and npm are not this PR's job. VERSION stays `0.36.32`.

## Surface Classification

- [x] Public product surface
- [x] Runtime contract surface
- [x] Contributor/test surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Frozen pairing contract (#1107)

Protected asset: control-pipe token bytes. Trust boundary: local user profile, not the git repo, not project `.winsmux`.

Discovery is the exact path template `%LOCALAPPDATA%\winsmux\control-pipe\token` only. A planted file under the repo, project `.winsmux`, `TEMP`, or any other name does not win.

Token source precedence (desktop pipe + CLI):

1. Non-empty process env `WINSMUX_CONTROL_PIPE_TOKEN`
2. Else the exact token file above
3. Else fail closed

On desktop start the app creates the directory and file with a user-only DACL (Windows equivalent of `0600`), writes a new current token, and keeps the previous token in process memory only. Previous is accepted until the first successful auth with the new token, or 60 seconds of process time, then the old bytes are dropped. Logs may contain `control-pipe token: rotated`. They must not contain the token value or the expanded filesystem path.

`desktop_control_pipe_enabled` is true when a non-empty env token exists or the exact file token exists, not only when the env var is set.

No network pairing handshake. Frozen design is the local file (issue #1107 option a). Docs secret slots use `<token-file>`.

## Docs (#1110 / #1204)

- `docs/external-control-plane.md` and `.ja.md`: launch modes, file bootstrap, CLI token source, contract vs `auth.token`, existing `-32600` fail-closed semantics, local-only boundary / user-approved bridge.
- Lane A/B architecture docs follow live kebab-case product keys. Snake_case is documented only as a load-only alias where the live loader already accepts it. Scalar `team-profile: default` is documented as rejected by the live parser. Slot/session launch is task-agnostic; dispatch carries task metadata later. `orchestra-start.ps1` is unchanged.

## Extra path beyond the task file allowlist

- `winsmux-app/src-tauri/Cargo.toml`: enable `Win32_Security_Authorization` and `Win32_System_Threading` on the existing `windows-sys` dependency so the token file can receive a user-only DACL and the current-user SID can be read. No new public Rust module.

`.githooks/pre-commit-whitelist.ps1` adds the already-edited `docs/project/v03629-declarative-workspace-architecture.md`. That file has no `psmux` / `pmux` / `tmux` literals, so `docs/project/legacy-compat-surface-inventory.json` is unchanged.

## Responsibility And Cutover

- Replaced behavior, workflow, config path, or responsibility: control-pipe auth used to require `WINSMUX_CONTROL_PIPE_TOKEN` in the process environment. Normal desktop start now bootstraps the exact local token file and accepts that file when the env is unset. Explicit env launchers still win.
- Expected outcome: an external agent can call `desktop.control_plane.contract` with no token, then `desktop.operator.snapshot` with `auth.token` from the env override or the exact token file.
- Source of truth: this PR plus `docs/external-control-plane.md`. Live YAML keys remain kebab-case in the production parsers; this PR does not change those parsers.
- Old paths preserved, redirected, deprecated, or removed: env override kept. Fail-closed JSON-RPC code stays `-32600`. CLI missing-token message still names `WINSMUX_CONTROL_PIPE_TOKEN`. No second discoverable token file.

## Verification

- Linux (`cargo test --locked --manifest-path winsmux-app/src-tauri/Cargo.toml --lib control_pipe -- --test-threads=1`): 19 passed. The `cfg(windows)` user-only DACL test is not compiled here and is not claimed GREEN from this Ubuntu VM. GitHub Actions `Desktop Build and Test` on `windows-latest` is the DACL proof surface (`control_pipe_token_file_uses_user_only_dacl`).
- `Parser.ParseFile` on edited `scripts/winsmux-core.ps1` (and the edited Pester/whitelist scripts): 0 errors.
- CLI token smoke on pwsh: env still wins; when env is unset the exact `LOCALAPPDATA` file is used; a planted repo `.winsmux` file is ignored. Generated values, wiped in `finally`.
- Pester `Describe 'winsmux control-rpc command'` is the Windows CI coverage for the same CLI path.

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.

Rollback: restore the previous desktop/CLI revision. Token file bytes live only under the local user profile and are not in git. Do not paste a token or an expanded `%LOCALAPPDATA%` path with a username into review comments.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae94dc2d-d59c-4019-80b8-bfa46ba377bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae94dc2d-d59c-4019-80b8-bfa46ba377bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


