### PR TITLE
feat(app): show metadata HUD from existing desktop sources (TASK-667)

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -195,6 +195,7 @@ $whitelistPatterns = @(
     'winsmux-app/src/attentionCenter.ts',
     'winsmux-app/src/attentionCenterPanel.ts',
     'winsmux-app/src/metadataHud.ts',
+    'winsmux-app/src/metadataHudPanel.ts',
     'winsmux-app/src/firstRunWizard.ts',
     'winsmux-app/src/workflowGate.ts',
     'winsmux-app/src/styles.css',

--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -194,6 +194,7 @@ $whitelistPatterns = @(
     'winsmux-app/src/agentVaultOrganize.ts',
     'winsmux-app/src/attentionCenter.ts',
     'winsmux-app/src/attentionCenterPanel.ts',
+    'winsmux-app/src/metadataHud.ts',
     'winsmux-app/src/firstRunWizard.ts',
     'winsmux-app/src/workflowGate.ts',
     'winsmux-app/src/styles.css',

--- a/winsmux-app/index.html
+++ b/winsmux-app/index.html
@@ -372,6 +372,7 @@
                   <div id="agent-vault-title" class="panel-title">Sessions</div>
                 </div>
                 <div id="agent-vault-ring" aria-label="Agent Vault notifications"></div>
+                <div id="metadata-hud" class="metadata-hud" hidden></div>
               </div>
               <div class="agent-vault-search-row">
                 <input id="agent-vault-search" type="search" placeholder="Search sessions" aria-label="Search Agent Vault sessions" />

--- a/winsmux-app/package.json
+++ b/winsmux-app/package.json
@@ -43,6 +43,7 @@
     "test:first-run-onboarding": "node ./scripts/first-run-onboarding-check.mjs",
     "test:agent-vault-organize": "node ./scripts/agent-vault-organize-check.mjs",
     "test:attention-center": "node ./scripts/attention-center-check.mjs",
+    "test:metadata-hud": "node ./scripts/metadata-hud-check.mjs",
     "test:source-graph": "node ./scripts/source-graph-check.mjs",
     "test:windows-context-menu": "pwsh -NoProfile -ExecutionPolicy Bypass -File ./scripts/windows-context-menu-e2e.ps1",
     "test:viewport-harness": "npm run build && node ./scripts/viewport-harness.mjs",

--- a/winsmux-app/scripts/metadata-hud-check.mjs
+++ b/winsmux-app/scripts/metadata-hud-check.mjs
@@ -97,19 +97,26 @@ assert.equal(chipById(h07, "cpu")?.value, "0");
 assert.equal(chipById(h07, "memory")?.value, "0");
 assert.deepEqual(chipIds(hudChipsFromSources({})), []);
 
-// H08: main.ts source imports metadataHud; does not invent cpu/memory HUD defaults
+// H08: main.ts wires the panel, not the domain module; does not invent cpu/memory HUD defaults
 const mainSource = await readFile(path.resolve("src/main.ts"), "utf8");
-assert.match(mainSource, /from "\.\/metadataHud"/);
-assert.match(mainSource, /hudChipsFromSources/);
-assert.doesNotMatch(mainSource, /cpuPercent:\s*0/);
-assert.doesNotMatch(mainSource, /memoryMb:\s*0/);
-
+const panelSource = await readFile(path.resolve("src/metadataHudPanel.ts"), "utf8");
 const htmlSource = await readFile(path.resolve("index.html"), "utf8");
 const stylesSource = await readFile(path.resolve("src/styles.css"), "utf8");
 const splitGateSource = await readFile(path.resolve("../scripts/test-v03626-desktop-split-gate.ps1"), "utf8");
 
-assert.match(mainSource, /getLanguageText\("Metadata", "メタデータ"\)/);
-assert.match(mainSource, /openPreviewTarget/);
+assert.match(mainSource, /from "\.\/metadataHudPanel"/);
+assert.doesNotMatch(mainSource, /from "\.\/metadataHud"/);
+assert.doesNotMatch(mainSource, /function collectMetadataHudSources|function renderMetadataHud|function metadataHudChipLabel/);
+assert.match(mainSource, /bindAndLoadMetadataHud/);
+assert.match(mainSource, /renderMetadataHud/);
+assert.doesNotMatch(mainSource, /cpuPercent:\s*0/);
+assert.doesNotMatch(mainSource, /memoryMb:\s*0/);
+
+assert.match(panelSource, /from "\.\/metadataHud"/);
+assert.match(panelSource, /hudChipsFromSources/);
+assert.match(panelSource, /getLanguageText\("Metadata", "メタデータ"\)/);
+assert.match(panelSource, /openPreviewTarget/);
+
 assert.match(htmlSource, /id="metadata-hud"/);
 assert.match(stylesSource, /\.metadata-hud\b/);
 assert.doesNotMatch(stylesSource, /#pane-worker-[2-6][^{]*\{[^}]*(?:display\s*:\s*none|visibility\s*:\s*hidden)/);
@@ -121,5 +128,10 @@ assert.doesNotMatch(
   /appendPaneOutputBuffer|capture-pane|capturePtyPane|outputBuffer|pty_capture/,
 );
 assert.doesNotMatch(hudSource, /JSON\.parse\(\s*(?:pane|buffer|capture)/i);
+assert.doesNotMatch(
+  panelSource,
+  /appendPaneOutputBuffer|capture-pane|capturePtyPane|outputBuffer|pty_capture/,
+);
+assert.doesNotMatch(panelSource, /JSON\.parse\(\s*(?:pane|buffer|capture)/i);
 
 console.log("metadata-hud-check: ok");

--- a/winsmux-app/scripts/metadata-hud-check.mjs
+++ b/winsmux-app/scripts/metadata-hud-check.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+async function loadMetadataHudModule() {
+  const sourcePath = path.resolve("src/metadataHud.ts");
+  const source = await readFile(sourcePath, "utf8");
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: sourcePath,
+  });
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "winsmux-metadata-hud-"));
+  const modulePath = path.join(tempDir, "metadataHud.mjs");
+  await writeFile(modulePath, transpiled.outputText, "utf8");
+
+  try {
+    return await import(pathToFileURL(modulePath).href);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+const { hudChipsFromSources, truncateSha } = await loadMetadataHudModule();
+const hudSource = await readFile(path.resolve("src/metadataHud.ts"), "utf8");
+
+function chipIds(chips) {
+  return chips.map((chip) => chip.id);
+}
+
+function chipById(chips, id) {
+  return chips.find((chip) => chip.id === id) ?? null;
+}
+
+// H01: empty input → no chips
+const h01 = hudChipsFromSources({});
+assert.deepEqual(h01, []);
+assert.deepEqual(hudChipsFromSources(), []);
+assert.equal(truncateSha(""), null);
+assert.equal(truncateSha("abc"), null);
+assert.equal(truncateSha(undefined), null);
+
+// H02: cost hosted + heartbeat running → those two chips only
+const h02 = hudChipsFromSources({ cost: "hosted", heartbeat: "running" });
+assert.deepEqual(chipIds(h02), ["cost", "heartbeat"]);
+assert.equal(chipById(h02, "cost")?.value, "hosted");
+assert.equal(chipById(h02, "heartbeat")?.value, "running");
+assert.equal(chipById(h02, "cpu"), null);
+assert.equal(chipById(h02, "memory"), null);
+
+// H03: tokens_remaining "12k" → context chip
+const h03 = hudChipsFromSources({ tokensRemaining: "12k" });
+assert.deepEqual(chipIds(h03), ["context"]);
+assert.equal(chipById(h03, "context")?.label, "context");
+assert.equal(chipById(h03, "context")?.value, "12k");
+
+// H04: branch + 40-char sha → branch chip + head 8 chars
+const fullSha = "abcdef0123456789abcdef0123456789abcdef01";
+assert.equal(fullSha.length, 40);
+assert.equal(truncateSha(fullSha), "abcdef01");
+const h04 = hudChipsFromSources({ branch: "cursor/task-667-metadata-hud", headSha: fullSha });
+assert.deepEqual(chipIds(h04), ["branch", "head"]);
+assert.equal(chipById(h04, "branch")?.value, "cursor/task-667-metadata-hud");
+assert.equal(chipById(h04, "head")?.value, "abcdef01");
+assert.equal(chipById(h04, "head")?.value.length, 8);
+assert.equal(hudChipsFromSources({ headSha: "1234567" }).length, 0);
+assert.equal(truncateSha("12345678"), "12345678");
+
+// H05: preview url present → preview chip
+const h05 = hudChipsFromSources({ previewUrl: "http://127.0.0.1:4173/" });
+assert.deepEqual(chipIds(h05), ["preview"]);
+assert.equal(chipById(h05, "preview")?.value, "http://127.0.0.1:4173/");
+assert.deepEqual(hudChipsFromSources({ previewUrl: "   " }), []);
+
+// H06: cpu/memory undefined → no cpu/memory chips (including no "0" / "n/a")
+const h06 = hudChipsFromSources({
+  cost: "local",
+  cpuPercent: undefined,
+  memoryMb: undefined,
+});
+assert.deepEqual(chipIds(h06), ["cost"]);
+assert.equal(chipById(h06, "cpu"), null);
+assert.equal(chipById(h06, "memory"), null);
+assert.equal(h06.some((chip) => chip.value === "0" || chip.value.toLowerCase() === "n/a"), false);
+assert.equal(hudChipsFromSources({ cpuPercent: Number.NaN, memoryMb: Number.POSITIVE_INFINITY }).length, 0);
+
+// H07: cpu 0 / memory 0 passed explicitly → chips allowed (real zero is data)
+const h07 = hudChipsFromSources({ cpuPercent: 0, memoryMb: 0 });
+assert.deepEqual(chipIds(h07), ["cpu", "memory"]);
+assert.equal(chipById(h07, "cpu")?.value, "0");
+assert.equal(chipById(h07, "memory")?.value, "0");
+assert.deepEqual(chipIds(hudChipsFromSources({})), []);
+
+// H08: main.ts source imports metadataHud; does not invent cpu/memory HUD defaults
+const mainSource = await readFile(path.resolve("src/main.ts"), "utf8");
+assert.match(mainSource, /from "\.\/metadataHud"/);
+assert.match(mainSource, /hudChipsFromSources/);
+assert.doesNotMatch(mainSource, /cpuPercent:\s*0/);
+assert.doesNotMatch(mainSource, /memoryMb:\s*0/);
+
+const htmlSource = await readFile(path.resolve("index.html"), "utf8");
+const stylesSource = await readFile(path.resolve("src/styles.css"), "utf8");
+const splitGateSource = await readFile(path.resolve("../scripts/test-v03626-desktop-split-gate.ps1"), "utf8");
+
+assert.match(mainSource, /getLanguageText\("Metadata", "メタデータ"\)/);
+assert.match(mainSource, /openPreviewTarget/);
+assert.match(htmlSource, /id="metadata-hud"/);
+assert.match(stylesSource, /\.metadata-hud\b/);
+assert.doesNotMatch(stylesSource, /#pane-worker-[2-6][^{]*\{[^}]*(?:display\s*:\s*none|visibility\s*:\s*hidden)/);
+assert.doesNotMatch(splitGateSource, /metadata-hud-check/);
+
+// H09: serializer/helper does not parse pane buffer strings
+assert.doesNotMatch(
+  hudSource,
+  /appendPaneOutputBuffer|capture-pane|capturePtyPane|outputBuffer|pty_capture/,
+);
+assert.doesNotMatch(hudSource, /JSON\.parse\(\s*(?:pane|buffer|capture)/i);
+
+console.log("metadata-hud-check: ok");

--- a/winsmux-app/src/main.ts
+++ b/winsmux-app/src/main.ts
@@ -121,7 +121,7 @@ import {
 } from "./firstRunWizard";
 import * as vaultOrganize from "./agentVaultOrganize";
 import * as attentionCenterPanel from "./attentionCenterPanel";
-
+import * as metadataHudPanel from "./metadataHudPanel";
 interface PaneEntry {
   terminal: Terminal;
   fitAddon: FitAddon;
@@ -2698,7 +2698,7 @@ function renderWorkerStatusSurface() {
   bar.hidden = !workerStatusStripVisible;
   bar.setAttribute("aria-hidden", workerStatusStripVisible ? "false" : "true");
   if (!workerStatusStripVisible) {
-    bar.replaceChildren();
+    bar.replaceChildren(); metadataHudPanel.renderMetadataHud();
     return;
   }
 
@@ -2798,7 +2798,7 @@ function renderWorkerStatusSurface() {
   const shadowProposal = renderLocalRouterShadowProposal(rows, focusedPaneId);
   if (shadowProposal) {
     bar.appendChild(shadowProposal);
-  }
+  } metadataHudPanel.renderMetadataHud();
 }
 
 function setWorkerStatusStripVisible(visible: boolean, options?: { persist?: boolean }) {
@@ -3170,7 +3170,7 @@ function renderAgentVaultPanel() {
     return;
   }
   panel.hidden = !agentVaultOpen;
-  updateAgentVaultToggleButton();
+  updateAgentVaultToggleButton(); metadataHudPanel.renderMetadataHud();
   if (!agentVaultOpen) {
     return;
   }
@@ -15739,7 +15739,7 @@ function trapCommandBarTab(event: KeyboardEvent) {
 }
 
 function renderEditorSurface() {
-  const title = document.getElementById("editor-surface-title");
+  metadataHudPanel.renderMetadataHud(); const title = document.getElementById("editor-surface-title");
   const summary = document.getElementById("editor-surface-summary");
   const path = document.getElementById("editor-file-path");
   const meta = document.getElementById("editor-meta-row");
@@ -18455,7 +18455,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     agentVaultStatusMessage = getLanguageText("Agent Vault organize data was rejected. Previous state was kept.", "Agent Vault の整理データを読み込めませんでした。以前の状態を保持します。");
   }
   attentionCenterPanel.bindAndLoadAttentionCenter({ getLanguageText, normalizeProjectDirInput, getActiveProjectDirPayload, getAvailableRunIds, focusWorkerPaneFromStatus, getPaneDisplayLabel, setSelectedRun, renderDesktopSurfaces, renderAgentVaultPanel });
-
+  metadataHudPanel.bindAndLoadMetadataHud({ getLanguageText, openPreviewTarget, getWorkerStatusRowsForSurface, getFocusedWorkbenchPaneId, getWorkerStatusTarget, getWorkerApiPosture, getWorkerHeartbeatHealth, getWorkerHeartbeatState, getPrimaryRunProjection, getExplainForRunId: (runId) => desktopExplainCache.get(runId) ?? null, getPreviewUrl: () => selectedPreviewUrl });
   applyShellPreferences();
   applyLanguageChrome();
   syncResponsiveShell();

--- a/winsmux-app/src/metadataHud.ts
+++ b/winsmux-app/src/metadataHud.ts
@@ -1,0 +1,81 @@
+export interface MetadataHudSources {
+  cost?: string;
+  heartbeat?: string;
+  tokensRemaining?: string;
+  branch?: string;
+  headSha?: string;
+  worktree?: string;
+  previewUrl?: string;
+  cpuPercent?: number;
+  memoryMb?: number;
+}
+
+export interface MetadataHudChip {
+  id: "cost" | "heartbeat" | "context" | "branch" | "head" | "worktree" | "preview" | "cpu" | "memory";
+  label: string;
+  value: string;
+}
+
+function presentText(value: string | undefined | null): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function presentFiniteNumber(value: number | undefined): string | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+  return String(value);
+}
+
+export function truncateSha(sha: string | undefined | null): string | null {
+  const trimmed = presentText(sha);
+  if (!trimmed || trimmed.length < 8) {
+    return null;
+  }
+  return trimmed.slice(0, 8);
+}
+
+export function hudChipsFromSources(input: MetadataHudSources = {}): MetadataHudChip[] {
+  const chips: MetadataHudChip[] = [];
+  const cost = presentText(input.cost);
+  if (cost) {
+    chips.push({ id: "cost", label: "cost", value: cost });
+  }
+  const heartbeat = presentText(input.heartbeat);
+  if (heartbeat) {
+    chips.push({ id: "heartbeat", label: "heartbeat", value: heartbeat });
+  }
+  const tokensRemaining = presentText(input.tokensRemaining);
+  if (tokensRemaining) {
+    chips.push({ id: "context", label: "context", value: tokensRemaining });
+  }
+  const branch = presentText(input.branch);
+  if (branch) {
+    chips.push({ id: "branch", label: "branch", value: branch });
+  }
+  const head = truncateSha(input.headSha);
+  if (head) {
+    chips.push({ id: "head", label: "head", value: head });
+  }
+  const worktree = presentText(input.worktree);
+  if (worktree) {
+    chips.push({ id: "worktree", label: "worktree", value: worktree });
+  }
+  const previewUrl = presentText(input.previewUrl);
+  if (previewUrl) {
+    chips.push({ id: "preview", label: "preview", value: previewUrl });
+  }
+  const cpu = presentFiniteNumber(input.cpuPercent);
+  if (cpu !== null) {
+    chips.push({ id: "cpu", label: "cpu", value: cpu });
+  }
+  const memory = presentFiniteNumber(input.memoryMb);
+  if (memory !== null) {
+    chips.push({ id: "memory", label: "memory", value: memory });
+  }
+  return chips;
+}

--- a/winsmux-app/src/metadataHudPanel.ts
+++ b/winsmux-app/src/metadataHudPanel.ts
@@ -1,0 +1,139 @@
+import type { DesktopExplainPayload, DesktopRunProjection, DesktopWorkerStatusRow } from "./desktopClient";
+import { hudChipsFromSources, type MetadataHudChip, type MetadataHudSources } from "./metadataHud";
+
+export type MetadataHudHost = {
+  getLanguageText: (en: string, ja: string) => string;
+  openPreviewTarget: (url: string) => void;
+  getWorkerStatusRowsForSurface: () => DesktopWorkerStatusRow[];
+  getFocusedWorkbenchPaneId: () => string | null;
+  getWorkerStatusTarget: (row: DesktopWorkerStatusRow) => string;
+  getWorkerApiPosture: (row: DesktopWorkerStatusRow) => { cost: string };
+  getWorkerHeartbeatHealth: (row: DesktopWorkerStatusRow) => string;
+  getWorkerHeartbeatState: (row: DesktopWorkerStatusRow) => string;
+  getPrimaryRunProjection: () => DesktopRunProjection | null;
+  getExplainForRunId: (runId: string) => DesktopExplainPayload | null;
+  getPreviewUrl: () => string;
+};
+
+let host: MetadataHudHost | null = null;
+
+function requireHost(): MetadataHudHost {
+  if (!host) {
+    throw new Error("metadata HUD host is not bound");
+  }
+  return host;
+}
+
+export function bindAndLoadMetadataHud(nextHost: MetadataHudHost) {
+  host = nextHost;
+}
+
+function collectMetadataHudSources(): MetadataHudSources {
+  const bound = requireHost();
+  const sources: MetadataHudSources = {};
+  const rows = bound.getWorkerStatusRowsForSurface();
+  const focusedPaneId = bound.getFocusedWorkbenchPaneId();
+  const focusedRow = rows.find((row) => bound.getWorkerStatusTarget(row) === focusedPaneId) ?? rows[0] ?? null;
+  if (focusedRow) {
+    const cost = bound.getWorkerApiPosture(focusedRow).cost.trim();
+    if (cost) {
+      sources.cost = cost;
+    }
+    const heartbeat = (bound.getWorkerHeartbeatHealth(focusedRow) || bound.getWorkerHeartbeatState(focusedRow)).trim();
+    if (heartbeat) {
+      sources.heartbeat = heartbeat;
+    }
+  }
+
+  const projection = bound.getPrimaryRunProjection();
+  const explain = projection ? bound.getExplainForRunId(projection.run_id) : null;
+  const tokensRemaining = (explain?.run.tokens_remaining || "").trim();
+  if (tokensRemaining) {
+    sources.tokensRemaining = tokensRemaining;
+  }
+  const branch = (projection?.branch || explain?.run.branch || "").trim();
+  if (branch) {
+    sources.branch = branch;
+  }
+  const headSha = (explain?.run.head_sha || projection?.head_sha || "").trim();
+  if (headSha) {
+    sources.headSha = headSha;
+  }
+  const worktree = (explain?.run.worktree || projection?.worktree || "").trim();
+  if (worktree) {
+    sources.worktree = worktree;
+  }
+  const previewUrl = bound.getPreviewUrl().trim();
+  if (previewUrl) {
+    sources.previewUrl = previewUrl;
+  }
+  return sources;
+}
+
+function metadataHudChipLabel(id: MetadataHudChip["id"]) {
+  const bound = requireHost();
+  switch (id) {
+    case "cost":
+      return bound.getLanguageText("cost", "コスト");
+    case "heartbeat":
+      return bound.getLanguageText("heartbeat", "生存確認");
+    case "context":
+      return bound.getLanguageText("context", "コンテキスト");
+    case "branch":
+      return bound.getLanguageText("branch", "ブランチ");
+    case "head":
+      return bound.getLanguageText("head", "HEAD");
+    case "worktree":
+      return bound.getLanguageText("worktree", "ワークツリー");
+    case "preview":
+      return bound.getLanguageText("preview", "プレビュー");
+    case "cpu":
+      return bound.getLanguageText("cpu", "CPU");
+    case "memory":
+      return bound.getLanguageText("memory", "メモリ");
+    default:
+      return id;
+  }
+}
+
+export function renderMetadataHud() {
+  const root = document.getElementById("metadata-hud");
+  if (!root || !host) {
+    return;
+  }
+
+  const chips = hudChipsFromSources(collectMetadataHudSources());
+  root.replaceChildren();
+  root.hidden = chips.length === 0;
+  root.setAttribute("aria-label", host.getLanguageText("Metadata", "メタデータ"));
+  if (chips.length === 0) {
+    return;
+  }
+
+  const title = document.createElement("span");
+  title.className = "metadata-hud-title";
+  title.textContent = host.getLanguageText("Metadata", "メタデータ");
+  root.appendChild(title);
+
+  for (const chip of chips) {
+    const label = metadataHudChipLabel(chip.id);
+    const text = `${label}:${chip.value}`;
+    if (chip.id === "preview") {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "metadata-hud-chip";
+      button.dataset.hudChip = chip.id;
+      button.textContent = text;
+      button.title = chip.value;
+      button.addEventListener("click", () => host?.openPreviewTarget(chip.value));
+      root.appendChild(button);
+      continue;
+    }
+    const span = document.createElement("span");
+    span.className = "metadata-hud-chip";
+    span.dataset.hudChip = chip.id;
+    span.textContent = text;
+    span.title = chip.value;
+    root.appendChild(span);
+  }
+}

--- a/winsmux-app/src/styles.css
+++ b/winsmux-app/src/styles.css
@@ -3240,6 +3240,72 @@ body[data-popout-surface="1"] #editor-surface {
   gap: 10px;
 }
 
+.metadata-hud {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: auto hidden;
+}
+
+.metadata-hud[hidden] {
+  display: none;
+}
+
+.metadata-hud-title {
+  flex: 0 0 auto;
+  color: var(--ws-fg-muted);
+  font-size: var(--text-xs);
+  font-weight: 700;
+}
+
+.metadata-hud-chip {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  max-width: 168px;
+  border: 1px solid var(--border-muted);
+  border-radius: 3px;
+  background: var(--ws-bg-elevated);
+  color: var(--text-secondary);
+  padding: 1px 5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--text-2xs);
+}
+
+button.metadata-hud-chip {
+  margin: 0;
+  cursor: pointer;
+  font: inherit;
+}
+
+button.metadata-hud-chip:hover,
+button.metadata-hud-chip:focus-visible {
+  color: var(--ws-fg);
+  outline: none;
+}
+
+.metadata-hud-chip[data-hud-chip="cost"] {
+  color: var(--status-warning);
+  border-color: var(--status-warning-border);
+  background: color-mix(in srgb, var(--status-warning) 9%, var(--ws-bg-elevated));
+}
+
+.metadata-hud-chip[data-hud-chip="heartbeat"] {
+  color: var(--ws-accent);
+  border-color: color-mix(in srgb, var(--ws-accent) 28%, var(--border-muted));
+  background: color-mix(in srgb, var(--ws-accent) 8%, var(--ws-bg-elevated));
+}
+
+.metadata-hud-chip[data-hud-chip="preview"] {
+  color: var(--status-info);
+  border-color: color-mix(in srgb, var(--status-info) 38%, var(--border-muted));
+  background: color-mix(in srgb, var(--status-info) 9%, var(--ws-bg-elevated));
+}
+
 #agent-vault-ring {
   width: 42px;
   min-height: 42px;


### PR DESCRIPTION
## Summary

TASK-667 only. Recut onto `main` after #1281. Replaces stacked draft #1276 (base was the old TASK-666 branch, not `main`).

Adds a compact **metadata HUD** in the Agent Vault header from sources the desktop app already has:

- Worker cost posture from `getWorkerApiPosture` (`hosted` / `local` / `external-api`).
- Heartbeat from `getWorkerHeartbeatHealth` / `getWorkerHeartbeatState`.
- Run metadata from selected-run explain / projection (`tokens_remaining`, `branch`, `worktree`, `head_sha`).
- Preview from `selectedPreviewUrl`. The preview chip calls `openPreviewTarget`. Branch/head chips do not run git.

Chips render only when the backing field is present and non-empty. There is no process sampler in this tree, so CPU and memory chips are omitted unless a finite number is explicitly passed into `hudChipsFromSources`. No pane PTY/capture parsing. No second event store. `winsmux events` is unchanged. No TASK-789 spawn/archive. Worker panes are not CSS-hidden.

Domain: `winsmux-app/src/metadataHud.ts`. UI: `winsmux-app/src/metadataHudPanel.ts`. `main.ts` only binds the host and calls `renderMetadataHud` (19171 lines, cap 19172).

VERSION remains **0.36.33**.

## Surface Classification

- [x] Public product surface
- [x] Contributor/test surface
- [ ] Runtime contract surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Responsibility And Cutover

- Replaced behavior, workflow, config path, or responsibility: none. The HUD is additive in the Agent Vault header.
- Expected outcome: cost, heartbeat, context, branch, head, worktree, and preview chips appear only from existing desktop sources; missing fields omit the chip.
- Source of truth: existing worker status posture/heartbeat, run projection/explain payload, and `selectedPreviewUrl`.
- Old paths preserved, redirected, deprecated, or removed: worker status strip, run summary, and preview helpers are unchanged. Pane buffers are not a HUD source.

## Verification

```
cd winsmux-app
node ./scripts/metadata-hud-check.mjs
npm run build
```

From repo root:

```
git diff --check -- winsmux-app/src/main.ts
pwsh -NoProfile -File scripts/test-v03626-desktop-split-gate.ps1
```

Local results on `46116560`:

- `metadata-hud-check.mjs`: exit 0
- `npm run build` (`tsc && vite build`): exit 0
- `git diff --check -- winsmux-app/src/main.ts`: clean
- `main.ts`: 19171 lines (cap 19172), `bare_lf` 530
- desktop-split gate: `all_pass`; `desktop_backend.rs` 6152/6152

`test:metadata-hud` is not added to `scripts/test-v03626-desktop-split-gate.ps1`.

RED then GREEN: `a4639fd9` adds H01–H09; H08 fails on unmodified `main.ts`. `46116560` wires `metadataHudPanel.ts` and the same node check passes.

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.

HUD values are existing desktop labels and URLs already shown in worker status, run explain, and preview. No pane buffer parsing. No invented load numbers.

Do not tag. Do not npm publish. Do not bump VERSION.
