### PR TITLE
feat(cli): fail-closed UTF-16 argv and native automation-contract (TASK-670)

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -51,6 +51,10 @@ name = "operator_cli"
 path = "tests-rs/operator_cli.rs"
 
 [[test]]
+name = "automation_contract"
+path = "tests-rs/automation_contract.rs"
+
+[[test]]
 name = "condensed_events"
 path = "tests-rs/condensed_events.rs"
 
@@ -111,6 +115,8 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_Memory",
     "Win32_System_DataExchange",
     "Win32_System_Threading",
+    "Win32_System_Pipes",
+    "Win32_Security",
 ] }
 
 [[bin]]

--- a/core/src/control_pipe_client.rs
+++ b/core/src/control_pipe_client.rs
@@ -1,0 +1,144 @@
+use std::io;
+
+pub const AUTOMATION_CONTRACT_COMMAND: &str = "automation-contract";
+pub const DESKTOP_CONTROL_PIPE_NAME: &str = r"\\.\pipe\winsmux-control";
+const AUTOMATION_CONTRACT_REQUEST: &[u8] =
+    br#"{"jsonrpc":"2.0","id":1,"method":"desktop.control_plane.contract"}"#;
+const PIPE_UNAVAILABLE: &str = "desktop control pipe is not available";
+
+pub fn run_automation_contract_command() -> io::Result<()> {
+    let response = send_control_pipe_request(AUTOMATION_CONTRACT_REQUEST)?;
+    let value: serde_json::Value = serde_json::from_slice(&response).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("desktop control pipe returned invalid JSON: {err}"),
+        )
+    })?;
+    if let Some(message) = value
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .and_then(|message| message.as_str())
+    {
+        return Err(io::Error::new(io::ErrorKind::Other, message.to_string()));
+    }
+    let result = value.get("result").ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "desktop control pipe returned no JSON-RPC result",
+        )
+    })?;
+    println!(
+        "{}",
+        serde_json::to_string(result).map_err(|err| io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("desktop control pipe result could not be serialized: {err}"),
+        ))?
+    );
+    Ok(())
+}
+
+fn send_control_pipe_request(payload: &[u8]) -> io::Result<Vec<u8>> {
+    #[cfg(windows)]
+    {
+        send_control_pipe_request_windows(payload)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = payload;
+        Err(io::Error::new(io::ErrorKind::NotFound, PIPE_UNAVAILABLE))
+    }
+}
+
+#[cfg(windows)]
+fn send_control_pipe_request_windows(payload: &[u8]) -> io::Result<Vec<u8>> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use std::ptr::null_mut;
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, GetLastError, ERROR_FILE_NOT_FOUND, ERROR_PIPE_BUSY, GENERIC_READ,
+        GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE,
+    };
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, ReadFile, WriteFile, FILE_ATTRIBUTE_NORMAL, OPEN_EXISTING,
+        SECURITY_IDENTIFICATION, SECURITY_SQOS_PRESENT,
+    };
+    use windows_sys::Win32::System::Pipes::{SetNamedPipeHandleState, WaitNamedPipeW, PIPE_READMODE_MESSAGE};
+
+    struct PipeHandle(HANDLE);
+    impl Drop for PipeHandle {
+        fn drop(&mut self) {
+            unsafe {
+                CloseHandle(self.0);
+            }
+        }
+    }
+
+    let pipe_name: Vec<u16> = OsStr::new(DESKTOP_CONTROL_PIPE_NAME)
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+
+    let handle = unsafe {
+        let mut attempt = 0;
+        loop {
+            let opened = CreateFileW(
+                pipe_name.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                0,
+                null_mut(),
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL | SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION,
+                null_mut(),
+            );
+            if opened != INVALID_HANDLE_VALUE {
+                break opened;
+            }
+            let error = GetLastError();
+            if error == ERROR_FILE_NOT_FOUND {
+                return Err(io::Error::new(io::ErrorKind::NotFound, PIPE_UNAVAILABLE));
+            }
+            if error != ERROR_PIPE_BUSY || attempt >= 20 {
+                return Err(io::Error::new(io::ErrorKind::NotFound, PIPE_UNAVAILABLE));
+            }
+            WaitNamedPipeW(pipe_name.as_ptr(), 250);
+            attempt += 1;
+        }
+    };
+    let pipe = PipeHandle(handle);
+    let read_mode = PIPE_READMODE_MESSAGE;
+    let mode_ok = unsafe { SetNamedPipeHandleState(pipe.0, &read_mode, null_mut(), null_mut()) };
+    if mode_ok == 0 {
+        return Err(io::Error::new(io::ErrorKind::NotFound, PIPE_UNAVAILABLE));
+    }
+
+    let mut bytes_written = 0u32;
+    let write_ok = unsafe {
+        WriteFile(
+            pipe.0,
+            payload.as_ptr().cast(),
+            payload.len() as u32,
+            &mut bytes_written,
+            null_mut(),
+        )
+    };
+    if write_ok == 0 {
+        return Err(io::Error::new(io::ErrorKind::NotFound, PIPE_UNAVAILABLE));
+    }
+
+    let mut buffer = vec![0u8; 1024 * 1024];
+    let mut bytes_read = 0u32;
+    let read_ok = unsafe {
+        ReadFile(
+            pipe.0,
+            buffer.as_mut_ptr().cast(),
+            buffer.len() as u32,
+            &mut bytes_read,
+            null_mut(),
+        )
+    };
+    if read_ok == 0 {
+        return Err(io::Error::new(io::ErrorKind::NotFound, PIPE_UNAVAILABLE));
+    }
+    buffer.truncate(bytes_read as usize);
+    Ok(buffer)
+}

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -42,6 +42,7 @@ mod instruction_pack;
 mod prompt_bundle;
 mod worker_artifact;
 mod project_settings_render;
+mod control_pipe_client;
 mod client;
 mod app;
 mod ssh_input;
@@ -921,8 +922,24 @@ mod tests {
     }
 }
 
+fn decode_cli_args() -> io::Result<Vec<String>> {
+    let mut decoded = Vec::new();
+    for (index, arg) in env::args_os().enumerate() {
+        match arg.into_string() {
+            Ok(value) => decoded.push(value),
+            Err(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("argument {index} is not valid Unicode"),
+                ));
+            }
+        }
+    }
+    Ok(decoded)
+}
+
 fn run_main() -> io::Result<()> {
-    let args: Vec<String> = env::args().collect();
+    let args = decode_cli_args()?;
 
     // Private, side-effect-free bridge used by the PowerShell settings writer.
     // Handle it before runtime cleanup so rendering cannot mutate session state.
@@ -1088,6 +1105,10 @@ fn run_main() -> io::Result<()> {
             return Ok(());
         }
         _ => {}
+    }
+
+    if cmd == control_pipe_client::AUTOMATION_CONTRACT_COMMAND {
+        return control_pipe_client::run_automation_contract_command();
     }
 
     if is_winsmux_core_bridge_command(cmd) {

--- a/core/tests-rs/automation_contract.rs
+++ b/core/tests-rs/automation_contract.rs
@@ -1,0 +1,83 @@
+use std::process::Command;
+
+fn winsmux_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_winsmux")
+}
+
+#[cfg(windows)]
+#[test]
+fn cli_rejects_undecodable_utf16_argv_without_panic() {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    let output = Command::new(winsmux_bin())
+        .arg(OsString::from_wide(&[0xD800]))
+        .output()
+        .expect("spawn winsmux");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "undecodable argv must fail closed: {stderr}");
+    assert!(
+        stderr.contains("argument 1 is not valid Unicode"),
+        "stderr must name the argument index, got {stderr}"
+    );
+    assert!(
+        !stderr.to_lowercase().contains("panicked"),
+        "stderr must not panic: {stderr}"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn cli_undecodable_argv_error_names_index_not_bytes() {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    let output = Command::new(winsmux_bin())
+        .arg(OsString::from_wide(&[0xD800]))
+        .output()
+        .expect("spawn winsmux");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("argument 1 is not valid Unicode"));
+    assert!(
+        !stderr.contains('\u{FFFD}'),
+        "error must not echo lossy bytes: {stderr}"
+    );
+    assert!(
+        !stderr.to_lowercase().contains("u+0000") && !stderr.contains("NUL"),
+        "error must not claim U+0000 was received: {stderr}"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn cli_valid_non_ascii_utf16_argv_parses_unchanged() {
+    let output = Command::new(winsmux_bin())
+        .args(["-t", "日本語セッション", "machine-contract", "--json"])
+        .output()
+        .expect("spawn winsmux");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.to_lowercase().contains("panicked"),
+        "valid CJK argv must not panic: {stderr}"
+    );
+    assert!(
+        output.status.success(),
+        "valid CJK argv must still dispatch: status={:?} stderr={stderr}",
+        output.status
+    );
+}
+
+#[test]
+fn automation_contract_fails_closed_when_pipe_absent() {
+    let output = Command::new(winsmux_bin())
+        .arg("automation-contract")
+        .output()
+        .expect("spawn winsmux");
+    if output.status.success() {
+        return;
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("desktop control pipe is not available"),
+        "missing pipe must fail closed without pwsh: {stderr}"
+    );
+    assert!(!stderr.to_lowercase().contains("pwsh"));
+}

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -1267,70 +1267,73 @@ mod tests {
         }
     }
 
-    #[test]
-    fn control_pipe_returns_external_contract_matching_allowlist() {
+    fn automation_contract_jsonrpc_response() -> Value {
         let payload = br#"{"jsonrpc":"2.0","id":1,"method":"desktop.control_plane.contract"}"#;
         let pty_transport = StubPtyTransport::new();
         let response =
             handle_control_pipe_payload(&StubDesktopTransport, &pty_transport, payload, None);
-        let value: Value = serde_json::from_slice(&response).expect("response should be JSON");
+        serde_json::from_slice(&response).expect("response should be JSON")
+    }
+
+    fn assert_automation_contract_result(result: &Value) {
+        assert_eq!(result["version"], 1);
+        assert_eq!(result["scope"], "external_control_pipe");
+        assert_eq!(result["transport"], "named_pipe_json_rpc");
+        assert_eq!(result["pipe"], WINSMUX_CONTROL_PIPE_NAME);
+        assert_eq!(result["localhost_http"], false);
+        assert_eq!(result["websocket"], false);
+        assert_eq!(result["auth"]["required_for_methods"], true);
+        assert_eq!(result["auth"]["token_env"], WINSMUX_CONTROL_PIPE_TOKEN_ENV);
+        assert_eq!(
+            result["auth"]["token_file"],
+            WINSMUX_CONTROL_PIPE_TOKEN_FILE_TEMPLATE
+        );
+        assert_eq!(result["auth"]["request_field"], "auth.token");
+        assert_eq!(result["desktop_methods"], json!(DESKTOP_CONTROL_PIPE_METHODS));
+        assert_eq!(result["pty_methods"], json!(PTY_CONTROL_PIPE_METHODS));
+        assert_eq!(
+            result["operator_methods"],
+            json!(OPERATOR_CONTROL_PIPE_METHODS)
+        );
+        assert_eq!(result["methods"], json!(control_pipe_methods()));
+        assert_eq!(
+            result["internal_desktop_methods_excluded"],
+            json!(CONTROL_PIPE_EXCLUDED_INTERNAL_DESKTOP_METHODS)
+        );
+        let methods = result["methods"].as_array().expect("methods");
+        for excluded in CONTROL_PIPE_EXCLUDED_INTERNAL_DESKTOP_METHODS {
+            assert!(
+                !methods.iter().any(|method| method.as_str() == Some(*excluded)),
+                "excluded internal method leaked: {excluded}"
+            );
+        }
+        assert!(methods
+            .iter()
+            .any(|method| method.as_str() == Some("pty.capture")));
+        assert!(methods
+            .iter()
+            .any(|method| method.as_str() == Some("desktop.operator.snapshot")));
+        assert!(methods
+            .iter()
+            .any(|method| method.as_str() == Some("desktop.operator.submit")));
+    }
+
+    #[test]
+    fn control_pipe_returns_external_contract_matching_allowlist() {
+        let value = automation_contract_jsonrpc_response();
 
         assert_eq!(value["jsonrpc"], "2.0");
         assert_eq!(value["id"], 1);
-        assert_eq!(value["result"]["version"], 1);
-        assert_eq!(value["result"]["scope"], "external_control_pipe");
-        assert_eq!(value["result"]["transport"], "named_pipe_json_rpc");
-        assert_eq!(value["result"]["pipe"], WINSMUX_CONTROL_PIPE_NAME);
-        assert_eq!(value["result"]["localhost_http"], false);
-        assert_eq!(value["result"]["websocket"], false);
-        assert_eq!(value["result"]["auth"]["required_for_methods"], true);
-        assert_eq!(
-            value["result"]["auth"]["token_env"],
-            WINSMUX_CONTROL_PIPE_TOKEN_ENV
-        );
-        assert_eq!(
-            value["result"]["auth"]["token_file"],
-            WINSMUX_CONTROL_PIPE_TOKEN_FILE_TEMPLATE
-        );
-        assert_eq!(value["result"]["auth"]["request_field"], "auth.token");
-        assert_eq!(
-            value["result"]["desktop_methods"],
-            json!(DESKTOP_CONTROL_PIPE_METHODS)
-        );
-        assert_eq!(
-            value["result"]["pty_methods"],
-            json!(PTY_CONTROL_PIPE_METHODS)
-        );
-        assert_eq!(
-            value["result"]["operator_methods"],
-            json!(OPERATOR_CONTROL_PIPE_METHODS)
-        );
-        assert_eq!(value["result"]["methods"], json!(control_pipe_methods()));
-        assert!(!value["result"]["methods"]
-            .as_array()
-            .expect("methods")
-            .iter()
-            .any(|method| method.as_str() == Some("desktop.editor.read")));
-        assert!(!value["result"]["methods"]
-            .as_array()
-            .expect("methods")
-            .iter()
-            .any(|method| method.as_str() == Some("desktop.explorer.list")));
-        assert!(value["result"]["methods"]
-            .as_array()
-            .expect("methods")
-            .iter()
-            .any(|method| method.as_str() == Some("pty.capture")));
-        assert!(value["result"]["methods"]
-            .as_array()
-            .expect("methods")
-            .iter()
-            .any(|method| method.as_str() == Some("desktop.operator.snapshot")));
-        assert!(value["result"]["methods"]
-            .as_array()
-            .expect("methods")
-            .iter()
-            .any(|method| method.as_str() == Some("desktop.operator.submit")));
+        assert_automation_contract_result(&value["result"]);
+    }
+
+    #[test]
+    fn automation_contract_matches_pipe_allowlist() {
+        // Native CLI `automation-contract` prints this JSON-RPC `result` object.
+        // Pipe-name override is forbidden, so CI cannot E2E the live named pipe;
+        // this Desktop test is the frozen allowlist proof (source of truth stays here).
+        let value = automation_contract_jsonrpc_response();
+        assert_automation_contract_result(&value["result"]);
     }
 
     #[test]

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -26,6 +26,7 @@ use pty_backend::{
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -79,20 +80,26 @@ fn normalize_existing_launch_project_dir(value: &str) -> Option<String> {
 
 fn resolve_initial_project_dir_from_args<I>(args: I) -> Option<String>
 where
-    I: IntoIterator<Item = String>,
+    I: IntoIterator,
+    I::Item: AsRef<OsStr>,
 {
     let mut args = args.into_iter();
     let _ = args.next();
 
     while let Some(arg) = args.next() {
-        let trimmed = arg.trim();
+        let Some(trimmed) = arg.as_ref().to_str().map(str::trim) else {
+            continue;
+        };
         if trimmed.is_empty() || trimmed == "--" {
             continue;
         }
 
         if trimmed == "--project-dir" || trimmed == "--workspace" {
             if let Some(value) = args.next() {
-                if let Some(path) = normalize_existing_launch_project_dir(&value) {
+                let Some(value) = value.as_ref().to_str() else {
+                    continue;
+                };
+                if let Some(path) = normalize_existing_launch_project_dir(value) {
                     return Some(path);
                 }
             }
@@ -127,7 +134,7 @@ where
 
 #[tauri::command]
 fn desktop_initial_project_dir() -> Option<String> {
-    resolve_initial_project_dir_from_args(std::env::args())
+    resolve_initial_project_dir_from_args(std::env::args_os())
 }
 
 const ORCHESTRA_MODE_RELATIVE_PATH: &str = ".winsmux/orchestra-mode.json";
@@ -2190,6 +2197,24 @@ mod tests {
         ]);
 
         assert!(resolved.is_none());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn desktop_initial_project_dir_skips_undecodable_argv() {
+        use std::ffi::OsString;
+        use std::os::windows::ffi::OsStringExt;
+
+        let project_dir = make_temp_launch_project("undecodable");
+        let project_arg = project_dir.to_string_lossy().to_string();
+        let resolved = resolve_initial_project_dir_from_args([
+            OsString::from("winsmux-app.exe"),
+            OsString::from_wide(&[0xD800]),
+            OsString::from("--project-dir"),
+            OsString::from(project_arg.as_str()),
+        ]);
+        assert_eq!(resolved.as_deref(), Some(project_arg.as_str()));
+        let _ = std::fs::remove_dir_all(project_dir);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- CLI argv that `CreateProcessW` can represent but `std::env::args()` cannot no longer panics. Undecodable UTF-16 fails closed as `argument {index} is not valid Unicode`.
- Native `winsmux automation-contract` talks to `\\.\pipe\winsmux-control` and prints `desktop.control_plane.contract`. No token code, no pwsh `control-rpc` hop. Missing pipe fails closed.
- Desktop launch `--project-dir` skips undecodable args instead of panicking inside a Tauri command.

## Surface Classification

- [x] Public product surface
- [x] Runtime contract surface
- [ ] Contributor/test surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Responsibility And Cutover

- Replaced behavior, workflow, config path, or responsibility: `std::env::args()` at the shared CLI entry; Desktop launch argv parsing; capability discovery that previously required pwsh `control-rpc`.
- Expected outcome: unpaired surrogates fail closed; CJK argv still dispatches; `automation-contract` returns the pipe contract `result` or `"desktop control pipe is not available"`.
- Source of truth: pipe allowlists in `control_pipe.rs`. This PR does not copy method lists into Core.
- Old paths preserved, redirected, deprecated, or removed: pwsh `control-rpc` is unchanged for later 670 cuts. MCP and tokened operator helpers are not in this PR.

## Verification

- `core/tests-rs/automation_contract.rs`: A–D (undecodable argv, CJK argv, fail-closed when the pipe is absent)
- `control_pipe.rs`: frozen E `automation_contract_matches_pipe_allowlist` equals `control_pipe_contract()`; existing allowlist test stays
- `lib.rs`: F `desktop_initial_project_dir_skips_undecodable_argv`

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.
