### PR TITLE
test(docs): gate surface compatibility matrix against the contract artifact (TASK-671)

### DIFF
--- a/docs/external-control-plane.ja.md
+++ b/docs/external-control-plane.ja.md
@@ -154,6 +154,30 @@ worker ペインの指定は受け付けません。独自の named pipe クラ�
 - `pty.respawn`
 - `pty.close`
 
+## Surface 互換マトリクス
+
+この surface 互換マトリクスは、チェックイン済み v2 契約成果物に対して CI でゲートします。
+契約行はトークンなしで発見できます。どの行も汎用 CLI JSON-RPC ヘルパーから到達できます。discover コマンドは生存確認であり、行ではありません。
+
+| Method | Pipe | CLI | MCP |
+| --- | --- | --- | --- |
+| desktop.control_plane.contract | yes | automation-contract | winsmux_automation_contract |
+| desktop.summary.snapshot | yes | control-rpc only | — |
+| desktop.run.explain | yes | control-rpc only | — |
+| desktop.run.compare | yes | control-rpc only | — |
+| desktop.run.promote | yes | control-rpc only | — |
+| desktop.run.pick_winner | yes | control-rpc only | — |
+| desktop.voice.capture_status | yes | control-rpc only | — |
+| pty.spawn | yes | control-rpc only | — |
+| pty.write | yes | control-rpc only | — |
+| pty.resize | yes | control-rpc only | — |
+| pty.capture | yes | control-rpc only | — |
+| pty.respawn | yes | control-rpc only | — |
+| pty.close | yes | control-rpc only | — |
+| desktop.operator.snapshot | yes | operator-snapshot (ps1) | — |
+| desktop.operator.submit | yes | operator-submit (ps1) | — |
+| desktop.pairing.confirm | yes | automation-pair | winsmux_automation_pair |
+
 ## 内部専用メソッド
 
 Tauri アプリは、より広い内部 `desktop_json_rpc` 面を使います。この内部面は Tauri `invoke` 経由でデスクトップ WebView から利用できますが、そのまま外部 pipe 契約になるわけではありません。

--- a/docs/external-control-plane.md
+++ b/docs/external-control-plane.md
@@ -194,6 +194,30 @@ The same pipe also exposes these PTY methods for local pane control:
 - `pty.respawn`
 - `pty.close`
 
+## Surface compatibility matrix
+
+This surface compatibility matrix is CI-gated against the checked-in v2 contract artifact.
+The contract row is discoverable without a token. Every row is also reachable through the generic CLI JSON-RPC helper. Discover commands are liveness probes, not extra rows.
+
+| Method | Pipe | CLI | MCP |
+| --- | --- | --- | --- |
+| desktop.control_plane.contract | yes | automation-contract | winsmux_automation_contract |
+| desktop.summary.snapshot | yes | control-rpc only | — |
+| desktop.run.explain | yes | control-rpc only | — |
+| desktop.run.compare | yes | control-rpc only | — |
+| desktop.run.promote | yes | control-rpc only | — |
+| desktop.run.pick_winner | yes | control-rpc only | — |
+| desktop.voice.capture_status | yes | control-rpc only | — |
+| pty.spawn | yes | control-rpc only | — |
+| pty.write | yes | control-rpc only | — |
+| pty.resize | yes | control-rpc only | — |
+| pty.capture | yes | control-rpc only | — |
+| pty.respawn | yes | control-rpc only | — |
+| pty.close | yes | control-rpc only | — |
+| desktop.operator.snapshot | yes | operator-snapshot (ps1) | — |
+| desktop.operator.submit | yes | operator-submit (ps1) | — |
+| desktop.pairing.confirm | yes | automation-pair | winsmux_automation_pair |
+
 ## Internal-Only Methods
 
 The Tauri app uses a wider internal `desktop_json_rpc` surface. That internal

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -1588,6 +1588,253 @@ mod tests {
         );
     }
 
+    fn repo_root_path() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+    }
+
+    fn surface_matrix_sentinel(doc_name: &str) -> &'static str {
+        if doc_name.ends_with(".ja.md") {
+            "この surface 互換マトリクスは、チェックイン済み v2 契約成果物に対して CI でゲートします。"
+        } else {
+            "This surface compatibility matrix is CI-gated against the checked-in v2 contract artifact."
+        }
+    }
+
+    fn frozen_surface_matrix_cells() -> Vec<(&'static str, &'static str, &'static str, &'static str)>
+    {
+        vec![
+            (
+                "desktop.control_plane.contract",
+                "yes",
+                "automation-contract",
+                "winsmux_automation_contract",
+            ),
+            (
+                "desktop.summary.snapshot",
+                "yes",
+                "control-rpc only",
+                "—",
+            ),
+            ("desktop.run.explain", "yes", "control-rpc only", "—"),
+            ("desktop.run.compare", "yes", "control-rpc only", "—"),
+            ("desktop.run.promote", "yes", "control-rpc only", "—"),
+            (
+                "desktop.run.pick_winner",
+                "yes",
+                "control-rpc only",
+                "—",
+            ),
+            (
+                "desktop.voice.capture_status",
+                "yes",
+                "control-rpc only",
+                "—",
+            ),
+            ("pty.spawn", "yes", "control-rpc only", "—"),
+            ("pty.write", "yes", "control-rpc only", "—"),
+            ("pty.resize", "yes", "control-rpc only", "—"),
+            ("pty.capture", "yes", "control-rpc only", "—"),
+            ("pty.respawn", "yes", "control-rpc only", "—"),
+            ("pty.close", "yes", "control-rpc only", "—"),
+            (
+                "desktop.operator.snapshot",
+                "yes",
+                "operator-snapshot (ps1)",
+                "—",
+            ),
+            (
+                "desktop.operator.submit",
+                "yes",
+                "operator-submit (ps1)",
+                "—",
+            ),
+            (
+                "desktop.pairing.confirm",
+                "yes",
+                "automation-pair",
+                "winsmux_automation_pair",
+            ),
+        ]
+    }
+
+    fn extract_surface_matrix_rows(
+        markdown: &str,
+        sentinel: &str,
+    ) -> Vec<(String, String, String, String)> {
+        let occurrences = markdown.matches(sentinel).count();
+        assert_eq!(
+            occurrences, 1,
+            "surface matrix sentinel must occur exactly once: {sentinel}"
+        );
+        let after = markdown.split_once(sentinel).expect("sentinel present").1;
+        let mut rows = Vec::new();
+        let mut seen_header = false;
+        for line in after.lines() {
+            let trimmed = line.trim();
+            if !trimmed.starts_with('|') {
+                if seen_header && !rows.is_empty() {
+                    break;
+                }
+                continue;
+            }
+            let cells: Vec<&str> = trimmed
+                .trim_matches('|')
+                .split('|')
+                .map(str::trim)
+                .collect();
+            if cells.len() != 4 {
+                continue;
+            }
+            if cells[0].eq_ignore_ascii_case("Method") {
+                seen_header = true;
+                continue;
+            }
+            if cells.iter().all(|cell| {
+                cell.chars()
+                    .all(|ch| ch == '-' || ch == ':' || ch.is_whitespace())
+            }) {
+                continue;
+            }
+            rows.push((
+                cells[0].to_string(),
+                cells[1].to_string(),
+                cells[2].to_string(),
+                cells[3].to_string(),
+            ));
+        }
+        assert!(
+            seen_header && !rows.is_empty(),
+            "surface matrix table missing after sentinel: {sentinel}"
+        );
+        rows
+    }
+
+    fn assert_surface_matrix_first_source_pins() {
+        let root = repo_root_path();
+        let ps1 = fs::read_to_string(root.join("scripts/winsmux-core.ps1")).unwrap_or_else(|err| {
+            panic!("read winsmux-core.ps1: {err}");
+        });
+        assert!(
+            ps1.contains("-Method 'desktop.operator.snapshot'"),
+            "ps1 must still send desktop.operator.snapshot"
+        );
+        assert!(
+            ps1.contains("-Method 'desktop.operator.submit'"),
+            "ps1 must still send desktop.operator.submit"
+        );
+
+        let rust = fs::read_to_string(root.join("core/src/control_pipe_client.rs")).unwrap_or_else(
+            |err| panic!("read control_pipe_client.rs: {err}"),
+        );
+        assert!(
+            rust.contains("pub const AUTOMATION_CONTRACT_COMMAND: &str = \"automation-contract\""),
+            "native automation-contract constant missing"
+        );
+        assert!(
+            rust.contains("pub const AUTOMATION_PAIR_COMMAND: &str = \"automation-pair\""),
+            "native automation-pair constant missing"
+        );
+        assert!(
+            rust.contains("\"method\": \"desktop.pairing.confirm\""),
+            "native pairing request must still name desktop.pairing.confirm"
+        );
+
+        let mcp = fs::read_to_string(root.join("winsmux-core/mcp-server.js")).unwrap_or_else(|err| {
+            panic!("read mcp-server.js: {err}");
+        });
+        assert!(
+            mcp.contains("invokeNativeCli([\"automation-contract\"])"),
+            "MCP contract tool must still invoke native automation-contract"
+        );
+        assert!(
+            mcp.contains("invokeNativeCli([\"automation-pair\"])"),
+            "MCP pair tool must still invoke native automation-pair"
+        );
+    }
+
+    fn assert_doc_surface_matrix_matches_artifact(doc_name: &str) {
+        let markdown = fs::read_to_string(repo_docs_path(doc_name)).unwrap_or_else(|err| {
+            panic!("read {doc_name}: {err}");
+        });
+        let artifact_raw =
+            fs::read_to_string(checked_in_control_pipe_contract_artifact_path()).unwrap_or_else(
+                |err| panic!("read contract artifact: {err}"),
+            );
+        let artifact: Value =
+            serde_json::from_str(&artifact_raw).expect("checked-in contract artifact should parse");
+        let expected_methods = json_string_set(&artifact["methods"]);
+        let frozen = frozen_surface_matrix_cells();
+        let frozen_methods: std::collections::HashSet<String> =
+            frozen.iter().map(|(method, _, _, _)| (*method).to_string()).collect();
+        assert_eq!(
+            frozen.len(),
+            frozen_methods.len(),
+            "frozen surface matrix mapping has duplicate methods"
+        );
+        assert_eq!(
+            frozen_methods, expected_methods,
+            "{doc_name} frozen mapping methods must equal artifact methods"
+        );
+
+        let cli_vocab: std::collections::HashSet<&str> = [
+            "automation-contract",
+            "automation-pair",
+            "operator-snapshot (ps1)",
+            "operator-submit (ps1)",
+            "control-rpc only",
+        ]
+        .into_iter()
+        .collect();
+        let mcp_vocab: std::collections::HashSet<&str> = [
+            "winsmux_automation_contract",
+            "winsmux_automation_pair",
+            "—",
+        ]
+        .into_iter()
+        .collect();
+
+        let expected_rows: std::collections::HashMap<&str, (&str, &str, &str)> = frozen
+            .iter()
+            .map(|(method, pipe, cli, mcp)| (*method, (*pipe, *cli, *mcp)))
+            .collect();
+        for (method, pipe, cli, mcp) in &frozen {
+            assert_eq!(*pipe, "yes", "{method} pipe cell must be constant yes");
+            assert!(
+                cli_vocab.contains(cli),
+                "{method} CLI cell {cli:?} is outside the frozen vocabulary"
+            );
+            assert!(
+                mcp_vocab.contains(mcp),
+                "{method} MCP cell {mcp:?} is outside the frozen vocabulary"
+            );
+        }
+
+        let rows = extract_surface_matrix_rows(&markdown, surface_matrix_sentinel(doc_name));
+        let row_methods: std::collections::HashSet<String> =
+            rows.iter().map(|(method, _, _, _)| method.clone()).collect();
+        assert_eq!(
+            row_methods.len(),
+            rows.len(),
+            "{doc_name} surface matrix has duplicate methods"
+        );
+        assert_method_sets_equal(
+            doc_name,
+            "surface-matrix",
+            &row_methods,
+            &expected_methods,
+        );
+        for (method, pipe, cli, mcp) in &rows {
+            let Some(expected) = expected_rows.get(method.as_str()) else {
+                panic!("{doc_name} surface matrix has unexpected method {method}");
+            };
+            assert_eq!(pipe, expected.0, "{doc_name} {method} pipe cell drifted");
+            assert_eq!(cli, expected.1, "{doc_name} {method} CLI cell drifted");
+            assert_eq!(mcp, expected.2, "{doc_name} {method} MCP cell drifted");
+        }
+
+        assert_surface_matrix_first_source_pins();
+    }
+
     #[test]
     fn control_pipe_contract_matches_checked_in_artifact() {
         let artifact_path = checked_in_control_pipe_contract_artifact_path();
@@ -1678,6 +1925,16 @@ mod tests {
     #[test]
     fn external_control_plane_ja_doc_method_lists_match_contract_artifact() {
         assert_doc_method_lists_match_artifact("external-control-plane.ja.md");
+    }
+
+    #[test]
+    fn external_control_plane_doc_surface_matrix_matches_contract_artifact() {
+        assert_doc_surface_matrix_matches_artifact("external-control-plane.md");
+    }
+
+    #[test]
+    fn external_control_plane_ja_doc_surface_matrix_matches_contract_artifact() {
+        assert_doc_surface_matrix_matches_artifact("external-control-plane.ja.md");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add a CI-gated surface matrix to both external-control-plane docs. Rows follow the v2 artifact methods.
- CLI and MCP cells stay on the existing wrappers. Fourteen MCP gaps stay em dash. Discover is liveness, not a row.
- Tests N/O sit next to C/D. The method-list bullets are unchanged.

## Surface Classification

- [x] Public product surface
- [ ] Runtime contract surface
- [x] Contributor/test surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Responsibility And Cutover

- Replaced behavior, workflow, config path, or responsibility: none. The pipe contract, native CLI, ps1 adapter, and MCP tools are unchanged
- Expected outcome: the documented wrappers cannot drift from the checked-in methods list
- Source of truth: `docs/control-plane-contract.v2.json` methods plus first-source pins in `core/src/control_pipe_client.rs`, `scripts/winsmux-core.ps1`, and `winsmux-core/mcp-server.js`
- Old paths preserved, redirected, deprecated, or removed: method-list bullets stay; the matrix is new prose after the PTY list

## Verification

- [x] `cargo test --manifest-path winsmux-app/src-tauri/Cargo.toml --lib external_control_plane` (C/D/N/O) green
- [ ] Tests / Merge Gate on this head

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.
