### PR TITLE
feat(control-plane): expose provider capabilities on the typed pipe (TASK-672)

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -213,6 +213,7 @@ $whitelistPatterns = @(
     'winsmux-app/src-tauri/scripts/*.ps1',
     'winsmux-app/src-tauri/src/control_pipe.rs',
     'winsmux-app/src-tauri/src/desktop_control_plane_params.rs',
+    'winsmux-app/src-tauri/src/desktop_provider_capabilities.rs',
     'winsmux-app/src-tauri/src/desktop_session_restore.rs',
     'winsmux-app/src-tauri/src/desktop_companion_cli.rs',
     'winsmux-app/src-tauri/src/desktop_events.rs',

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -698,6 +698,7 @@ mod tests {
             "consult-result",
             "workers",
             "provider-switch",
+            "provider-capabilities",
             "runtime-roles",
             "dogfood",
             "team-profile",
@@ -712,6 +713,7 @@ mod tests {
                             | "promote-tactic"
                             | "consult-result"
                             | "provider-switch"
+                            | "provider-capabilities"
                             | "dogfood"
                             | "team-profile"
                     ),

--- a/docs/control-plane-contract.v2.json
+++ b/docs/control-plane-contract.v2.json
@@ -12,7 +12,8 @@
     "desktop.run.compare",
     "desktop.run.promote",
     "desktop.run.pick_winner",
-    "desktop.voice.capture_status"
+    "desktop.voice.capture_status",
+    "desktop.provider.capabilities"
   ],
   "internal_desktop_methods_excluded": [
     "desktop.workers.status",
@@ -32,6 +33,7 @@
     "desktop.run.promote",
     "desktop.run.pick_winner",
     "desktop.voice.capture_status",
+    "desktop.provider.capabilities",
     "pty.spawn",
     "pty.write",
     "pty.resize",
@@ -153,6 +155,33 @@
           "version"
         ],
         "title": "PairingConfirmResult",
+        "type": "object"
+      }
+    },
+    "desktop.provider.capabilities": {
+      "params": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "DesktopProviderCapabilitiesParams",
+        "type": "object"
+      },
+      "result": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "providers": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "version": {
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "providers",
+          "version"
+        ],
+        "title": "DesktopProviderCapabilitiesSnapshot",
         "type": "object"
       }
     },

--- a/docs/external-control-plane.ja.md
+++ b/docs/external-control-plane.ja.md
@@ -120,6 +120,7 @@ v2 は、ハンドラが消費する同じ serde 型から導出したメソッ�
 - `desktop.operator.snapshot`
 - `desktop.operator.submit`
 - `desktop.voice.capture_status`
+- `desktop.provider.capabilities`
 
 operator メソッドは、外部エージェントが operator と会話するための専用経路です。
 
@@ -168,6 +169,7 @@ worker ペインの指定は受け付けません。独自の named pipe クラ�
 | desktop.run.promote | yes | control-rpc only | — |
 | desktop.run.pick_winner | yes | control-rpc only | — |
 | desktop.voice.capture_status | yes | control-rpc only | — |
+| desktop.provider.capabilities | yes | control-rpc only | — |
 | pty.spawn | yes | control-rpc only | — |
 | pty.write | yes | control-rpc only | — |
 | pty.resize | yes | control-rpc only | — |

--- a/docs/external-control-plane.md
+++ b/docs/external-control-plane.md
@@ -155,6 +155,7 @@ v2 adds per-method parameter and result schemas derived from the same serde type
 - `desktop.operator.snapshot`
 - `desktop.operator.submit`
 - `desktop.voice.capture_status`
+- `desktop.provider.capabilities`
 
 The operator methods are the only external methods intended for agent-to-operator
 conversation:
@@ -208,6 +209,7 @@ The contract row is discoverable without a token. Every row is also reachable th
 | desktop.run.promote | yes | control-rpc only | — |
 | desktop.run.pick_winner | yes | control-rpc only | — |
 | desktop.voice.capture_status | yes | control-rpc only | — |
+| desktop.provider.capabilities | yes | control-rpc only | — |
 | pty.spawn | yes | control-rpc only | — |
 | pty.write | yes | control-rpc only | — |
 | pty.resize | yes | control-rpc only | — |

--- a/sdk/python/control_plane_contract.py
+++ b/sdk/python/control_plane_contract.py
@@ -13,6 +13,7 @@ CONTROL_PIPE_METHODS = (
     "desktop.run.promote",
     "desktop.run.pick_winner",
     "desktop.voice.capture_status",
+    "desktop.provider.capabilities",
     "pty.spawn",
     "pty.write",
     "pty.resize",
@@ -32,6 +33,7 @@ DESKTOP_METHODS = (
     "desktop.run.promote",
     "desktop.run.pick_winner",
     "desktop.voice.capture_status",
+    "desktop.provider.capabilities",
 )
 
 PTY_METHODS = (
@@ -86,6 +88,13 @@ class PairingConfirmParams(TypedDict):
 class PairingConfirmResult(TypedDict):
     paired: bool
     scope: str
+    version: int
+
+class DesktopProviderCapabilitiesParams(TypedDict):
+    pass
+
+class DesktopProviderCapabilitiesSnapshot(TypedDict):
+    providers: dict[str, Any]
     version: int
 
 class DesktopRunCompareParams(TypedDict):

--- a/sdk/typescript/control-plane-contract.ts
+++ b/sdk/typescript/control-plane-contract.ts
@@ -13,6 +13,7 @@ export const CONTROL_PIPE_METHODS = [
   "desktop.run.promote",
   "desktop.run.pick_winner",
   "desktop.voice.capture_status",
+  "desktop.provider.capabilities",
   "pty.spawn",
   "pty.write",
   "pty.resize",
@@ -32,6 +33,7 @@ export const DESKTOP_METHODS = [
   "desktop.run.promote",
   "desktop.run.pick_winner",
   "desktop.voice.capture_status",
+  "desktop.provider.capabilities",
 ] as const;
 
 export const PTY_METHODS = [
@@ -87,6 +89,14 @@ export interface PairingConfirmParams {
 export interface PairingConfirmResult {
   paired: boolean;
   scope: string;
+  version: number;
+}
+
+export interface DesktopProviderCapabilitiesParams {
+}
+
+export interface DesktopProviderCapabilitiesSnapshot {
+  providers: Record<string, unknown>;
   version: number;
 }
 
@@ -649,6 +659,10 @@ export interface ControlPlaneSchemas {
   "desktop.pairing.confirm": {
     params: PairingConfirmParams;
     result: PairingConfirmResult;
+  };
+  "desktop.provider.capabilities": {
+    params: DesktopProviderCapabilitiesParams;
+    result: DesktopProviderCapabilitiesSnapshot;
   };
   "desktop.run.compare": {
     params: DesktopRunCompareParams;

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -1,12 +1,13 @@
 use crate::desktop_backend::{
     handle_desktop_json_rpc, DesktopCommandTransport, DesktopCompareRunsResult,
     DesktopExplainPayload, DesktopJsonRpcRequest, DesktopPickWinnerResult,
-    DesktopPromoteTacticResult, DesktopSummarySnapshot, DesktopVoiceCaptureStatus,
-    PwshScriptTransport,
+    DesktopPromoteTacticResult, DesktopProviderCapabilitiesSnapshot, DesktopSummarySnapshot,
+    DesktopVoiceCaptureStatus, PwshScriptTransport,
 };
 use crate::desktop_control_plane_params::{
-    DesktopRunCompareParams, DesktopRunExplainParams, DesktopRunPickWinnerParams,
-    DesktopRunPromoteParams, DesktopSummarySnapshotParams, DesktopVoiceCaptureStatusParams,
+    DesktopProviderCapabilitiesParams, DesktopRunCompareParams, DesktopRunExplainParams,
+    DesktopRunPickWinnerParams, DesktopRunPromoteParams, DesktopSummarySnapshotParams,
+    DesktopVoiceCaptureStatusParams,
 };
 use crate::pty_backend::{
     handle_pty_json_rpc, OperatorSnapshotParams, OperatorSubmitParams, OperatorSubmitResult,
@@ -722,6 +723,7 @@ pub const DESKTOP_CONTROL_PIPE_METHODS: &[&str] = &[
     "desktop.run.promote",
     "desktop.run.pick_winner",
     "desktop.voice.capture_status",
+    "desktop.provider.capabilities",
 ];
 
 const PAIRING_CONTROL_PIPE_METHODS: &[&str] = &["desktop.pairing.confirm"];
@@ -941,6 +943,7 @@ fn control_pipe_method_schemas() -> Value {
         "desktop.run.promote": method_schema::<DesktopRunPromoteParams, DesktopPromoteTacticResult>(),
         "desktop.run.pick_winner": method_schema::<DesktopRunPickWinnerParams, DesktopPickWinnerResult>(),
         "desktop.voice.capture_status": method_schema::<DesktopVoiceCaptureStatusParams, DesktopVoiceCaptureStatus>(),
+        "desktop.provider.capabilities": method_schema::<DesktopProviderCapabilitiesParams, DesktopProviderCapabilitiesSnapshot>(),
         "pty.spawn": method_schema::<PtySpawnParams, PtyPaneResult>(),
         "pty.write": method_schema::<PtyWriteParams, PtyPaneResult>(),
         "pty.resize": method_schema::<PtyResizeParams, PtyPaneResult>(),
@@ -1626,6 +1629,12 @@ mod tests {
             ),
             (
                 "desktop.voice.capture_status",
+                "yes",
+                "control-rpc only",
+                "—",
+            ),
+            (
+                "desktop.provider.capabilities",
                 "yes",
                 "control-rpc only",
                 "—",

--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -1,13 +1,15 @@
 use crate::desktop_backend::{
     handle_desktop_json_rpc, DesktopCommandTransport, DesktopCompareRunsResult,
     DesktopExplainPayload, DesktopJsonRpcRequest, DesktopPickWinnerResult,
-    DesktopPromoteTacticResult, DesktopProviderCapabilitiesSnapshot, DesktopSummarySnapshot,
-    DesktopVoiceCaptureStatus, PwshScriptTransport,
+    DesktopPromoteTacticResult, DesktopSummarySnapshot, DesktopVoiceCaptureStatus,
+    PwshScriptTransport,
 };
 use crate::desktop_control_plane_params::{
-    DesktopProviderCapabilitiesParams, DesktopRunCompareParams, DesktopRunExplainParams,
-    DesktopRunPickWinnerParams, DesktopRunPromoteParams, DesktopSummarySnapshotParams,
-    DesktopVoiceCaptureStatusParams,
+    DesktopRunCompareParams, DesktopRunExplainParams, DesktopRunPickWinnerParams,
+    DesktopRunPromoteParams, DesktopSummarySnapshotParams, DesktopVoiceCaptureStatusParams,
+};
+use crate::desktop_provider_capabilities::{
+    DesktopProviderCapabilitiesParams, DesktopProviderCapabilitiesSnapshot,
 };
 use crate::pty_backend::{
     handle_pty_json_rpc, OperatorSnapshotParams, OperatorSubmitParams, OperatorSubmitResult,

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -1,7 +1,8 @@
 use crate::desktop_control_plane_params::{
     consume_external_params, deserialize_external_params, required_trimmed_desktop_string,
-    DesktopRunCompareParams, DesktopRunExplainParams, DesktopRunPickWinnerParams,
-    DesktopRunPromoteParams, DesktopSummarySnapshotParams, DesktopVoiceCaptureStatusParams,
+    DesktopProviderCapabilitiesParams, DesktopRunCompareParams, DesktopRunExplainParams,
+    DesktopRunPickWinnerParams, DesktopRunPromoteParams, DesktopSummarySnapshotParams,
+    DesktopVoiceCaptureStatusParams,
 };
 use crate::desktop_session_restore::json_rpc as session_restore_rpc;
 use crate::desktop_team_profile;
@@ -765,6 +766,12 @@ pub struct DesktopVoiceCaptureStatus {
     pub state_contract: Vec<String>,
 }
 
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub struct DesktopProviderCapabilitiesSnapshot {
+    pub version: u64,
+    pub providers: HashMap<String, Value>,
+}
+
 pub enum DesktopCommand {
     SummarySnapshot {
         project_dir: Option<String>,
@@ -808,6 +815,9 @@ pub enum DesktopCommand {
         auth_mode: Option<String>,
         reason: Option<String>,
         clear: bool,
+        project_dir: Option<String>,
+    },
+    ProviderCapabilities {
         project_dir: Option<String>,
     },
     RuntimeRolesApply {
@@ -954,6 +964,7 @@ impl DesktopCommand {
             DesktopCommand::WorkersStatus { project_dir, .. } => project_dir.as_deref(),
             DesktopCommand::WorkersStart { project_dir, .. } => project_dir.as_deref(),
             DesktopCommand::ProviderSwitch { project_dir, .. } => project_dir.as_deref(),
+            DesktopCommand::ProviderCapabilities { project_dir } => project_dir.as_deref(),
             DesktopCommand::RuntimeRolesApply { project_dir, .. } => project_dir.as_deref(),
             DesktopCommand::DogfoodEvent { project_dir, .. } => project_dir.as_deref(),
             DesktopCommand::TeamProfileSettingsView { project_dir } => project_dir.as_deref(),
@@ -1075,6 +1086,9 @@ impl DesktopCommand {
                 args.push("--json".to_string());
                 args
             }
+            DesktopCommand::ProviderCapabilities { .. } => {
+                vec!["provider-capabilities".to_string(), "--json".to_string()]
+            }
             DesktopCommand::RuntimeRolesApply { roles_json, .. } => vec![
                 "runtime-roles".to_string(),
                 "apply".to_string(),
@@ -1157,6 +1171,17 @@ pub fn load_desktop_summary_snapshot(
     let snapshot = transport.request_json(&DesktopCommand::SummarySnapshot { project_dir })?;
     serde_json::from_value(snapshot)
         .map_err(|err| format!("Failed to parse desktop summary payload: {err}"))
+}
+
+pub fn load_desktop_provider_capabilities(
+    transport: &dyn DesktopCommandTransport,
+    project_dir: Option<String>,
+) -> Result<DesktopProviderCapabilitiesSnapshot, String> {
+    let snapshot =
+        transport.request_json(&DesktopCommand::ProviderCapabilities { project_dir })?;
+    serde_json::from_value(snapshot).map_err(|err| {
+        format!("Failed to parse desktop provider capabilities payload: {err}")
+    })
 }
 
 pub fn record_desktop_dogfood_event(
@@ -1611,6 +1636,7 @@ pub fn handle_desktop_json_rpc(
                     "desktop.workers.status",
                     "desktop.workers.start",
                     "desktop.provider.switch",
+                    "desktop.provider.capabilities",
                     "desktop.runtime.roles.apply",
                     "desktop.voice.capture_status",
                     "desktop.dogfood.event",
@@ -1814,6 +1840,21 @@ pub fn handle_desktop_json_rpc(
                 resolved_project_dir,
                 params,
             );
+        }
+        "desktop.provider.capabilities" => {
+            let _params =
+                consume_external_params::<DesktopProviderCapabilitiesParams>(params.as_ref());
+            match load_desktop_provider_capabilities(transport, resolved_project_dir) {
+                Ok(snapshot) => match serde_json::to_value(snapshot) {
+                    Ok(result) => json_rpc_result(request_id, result),
+                    Err(err) => json_rpc_error(
+                        request_id,
+                        JSON_RPC_INTERNAL_ERROR,
+                        format!("Failed to serialize desktop provider capabilities payload: {err}"),
+                    ),
+                },
+                Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
+            }
         }
         "desktop.provider.switch" => {
             let slot = match get_required_string_param(params.as_ref(), &["slot", "target"]) {
@@ -5462,6 +5503,104 @@ mod tests {
         );
     }
 
+    fn serialized_result_has_no_registry_path_or_absolute_path(result: &Value) {
+        let serialized = serde_json::to_string(result).expect("serialize provider capabilities result");
+        assert!(
+            !serialized.contains("registry_path"),
+            "serialized result must drop registry_path: {serialized}"
+        );
+        assert!(
+            !serialized.contains(r"C:\") && !serialized.contains("C:/"),
+            "serialized result must not contain a drive-letter path: {serialized}"
+        );
+        assert!(
+            result.get("registry_path").is_none(),
+            "typed result must not expose registry_path"
+        );
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_routes_provider_capabilities() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({
+                "version": 1,
+                "registry_path": r"C:\Users\example\project\.winsmux\provider-capabilities.json",
+                "providers": {
+                    "codex": {
+                        "adapter": "codex",
+                        "display_name": "Codex"
+                    }
+                }
+            }),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-provider-capabilities"),
+                method: "desktop.provider.capabilities".to_string(),
+                params: None,
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-provider-capabilities"));
+                assert_eq!(result["version"], 1);
+                assert_eq!(result["providers"]["codex"]["adapter"], "codex");
+                assert_eq!(result["providers"]["codex"]["display_name"], "Codex");
+                serialized_result_has_no_registry_path_or_absolute_path(&result);
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+        assert_eq!(
+            transport.requests.borrow().as_slice(),
+            ["provider-capabilities --json"]
+        );
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_routes_provider_capabilities_empty_registry() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({
+                "version": 1,
+                "providers": {},
+                "registry_path": r"C:\Users\example\project\.winsmux\provider-capabilities.json"
+            }),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-provider-capabilities-empty"),
+                method: "desktop.provider.capabilities".to_string(),
+                params: None,
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-provider-capabilities-empty"));
+                assert_eq!(result["version"], 1);
+                assert_eq!(result["providers"], serde_json::json!({}));
+                serialized_result_has_no_registry_path_or_absolute_path(&result);
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+        assert_eq!(
+            transport.requests.borrow().as_slice(),
+            ["provider-capabilities --json"]
+        );
+    }
+
     #[test]
     fn handle_desktop_json_rpc_contract_advertises_runtime_roles_apply() {
         let transport = FakeTransport {
@@ -5491,6 +5630,7 @@ mod tests {
                     "desktop.workers.status",
                     "desktop.workers.start",
                     "desktop.provider.switch",
+                    "desktop.provider.capabilities",
                     "desktop.dogfood.event",
                     "desktop.voice.capture_status",
                     "desktop.session.restore_candidates",

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -1,8 +1,7 @@
 use crate::desktop_control_plane_params::{
     consume_external_params, deserialize_external_params, required_trimmed_desktop_string,
-    DesktopProviderCapabilitiesParams, DesktopRunCompareParams, DesktopRunExplainParams,
-    DesktopRunPickWinnerParams, DesktopRunPromoteParams, DesktopSummarySnapshotParams,
-    DesktopVoiceCaptureStatusParams,
+    DesktopRunCompareParams, DesktopRunExplainParams, DesktopRunPickWinnerParams,
+    DesktopRunPromoteParams, DesktopSummarySnapshotParams, DesktopVoiceCaptureStatusParams,
 };
 use crate::desktop_session_restore::json_rpc as session_restore_rpc;
 use crate::desktop_team_profile;
@@ -766,12 +765,6 @@ pub struct DesktopVoiceCaptureStatus {
     pub state_contract: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, JsonSchema)]
-pub struct DesktopProviderCapabilitiesSnapshot {
-    pub version: u64,
-    pub providers: HashMap<String, Value>,
-}
-
 pub enum DesktopCommand {
     SummarySnapshot {
         project_dir: Option<String>,
@@ -817,9 +810,7 @@ pub enum DesktopCommand {
         clear: bool,
         project_dir: Option<String>,
     },
-    ProviderCapabilities {
-        project_dir: Option<String>,
-    },
+    ProviderCapabilities { project_dir: Option<String> },
     RuntimeRolesApply {
         roles_json: String,
         project_dir: Option<String>,
@@ -1086,9 +1077,7 @@ impl DesktopCommand {
                 args.push("--json".to_string());
                 args
             }
-            DesktopCommand::ProviderCapabilities { .. } => {
-                vec!["provider-capabilities".to_string(), "--json".to_string()]
-            }
+            DesktopCommand::ProviderCapabilities { .. } => vec!["provider-capabilities".to_string(), "--json".to_string()],
             DesktopCommand::RuntimeRolesApply { roles_json, .. } => vec![
                 "runtime-roles".to_string(),
                 "apply".to_string(),
@@ -1171,17 +1160,6 @@ pub fn load_desktop_summary_snapshot(
     let snapshot = transport.request_json(&DesktopCommand::SummarySnapshot { project_dir })?;
     serde_json::from_value(snapshot)
         .map_err(|err| format!("Failed to parse desktop summary payload: {err}"))
-}
-
-pub fn load_desktop_provider_capabilities(
-    transport: &dyn DesktopCommandTransport,
-    project_dir: Option<String>,
-) -> Result<DesktopProviderCapabilitiesSnapshot, String> {
-    let snapshot =
-        transport.request_json(&DesktopCommand::ProviderCapabilities { project_dir })?;
-    serde_json::from_value(snapshot).map_err(|err| {
-        format!("Failed to parse desktop provider capabilities payload: {err}")
-    })
 }
 
 pub fn record_desktop_dogfood_event(
@@ -1841,21 +1819,7 @@ pub fn handle_desktop_json_rpc(
                 params,
             );
         }
-        "desktop.provider.capabilities" => {
-            let _params =
-                consume_external_params::<DesktopProviderCapabilitiesParams>(params.as_ref());
-            match load_desktop_provider_capabilities(transport, resolved_project_dir) {
-                Ok(snapshot) => match serde_json::to_value(snapshot) {
-                    Ok(result) => json_rpc_result(request_id, result),
-                    Err(err) => json_rpc_error(
-                        request_id,
-                        JSON_RPC_INTERNAL_ERROR,
-                        format!("Failed to serialize desktop provider capabilities payload: {err}"),
-                    ),
-                },
-                Err(err) => json_rpc_error(request_id, JSON_RPC_SERVER_ERROR, err),
-            }
-        }
+        "desktop.provider.capabilities" => return crate::desktop_provider_capabilities::json_rpc(transport, request_id, resolved_project_dir, params),
         "desktop.provider.switch" => {
             let slot = match get_required_string_param(params.as_ref(), &["slot", "target"]) {
                 Ok(value) => value,
@@ -5500,104 +5464,6 @@ mod tests {
         assert_eq!(
             transport.requests.borrow().as_slice(),
             ["desktop-summary --json"]
-        );
-    }
-
-    fn serialized_result_has_no_registry_path_or_absolute_path(result: &Value) {
-        let serialized = serde_json::to_string(result).expect("serialize provider capabilities result");
-        assert!(
-            !serialized.contains("registry_path"),
-            "serialized result must drop registry_path: {serialized}"
-        );
-        assert!(
-            !serialized.contains(r"C:\") && !serialized.contains("C:/"),
-            "serialized result must not contain a drive-letter path: {serialized}"
-        );
-        assert!(
-            result.get("registry_path").is_none(),
-            "typed result must not expose registry_path"
-        );
-    }
-
-    #[test]
-    fn handle_desktop_json_rpc_routes_provider_capabilities() {
-        let transport = FakeTransport {
-            requests: RefCell::new(Vec::new()),
-            response: serde_json::json!({
-                "version": 1,
-                "registry_path": r"C:\Users\example\project\.winsmux\provider-capabilities.json",
-                "providers": {
-                    "codex": {
-                        "adapter": "codex",
-                        "display_name": "Codex"
-                    }
-                }
-            }),
-        };
-        let response = handle_desktop_json_rpc(
-            &transport,
-            DesktopJsonRpcRequest {
-                jsonrpc: "2.0".to_string(),
-                id: serde_json::json!("req-provider-capabilities"),
-                method: "desktop.provider.capabilities".to_string(),
-                params: None,
-            },
-            None,
-        );
-
-        match response {
-            DesktopJsonRpcResponse::Success { id, result, .. } => {
-                assert_eq!(id, serde_json::json!("req-provider-capabilities"));
-                assert_eq!(result["version"], 1);
-                assert_eq!(result["providers"]["codex"]["adapter"], "codex");
-                assert_eq!(result["providers"]["codex"]["display_name"], "Codex");
-                serialized_result_has_no_registry_path_or_absolute_path(&result);
-            }
-            DesktopJsonRpcResponse::Error { error, .. } => {
-                panic!("expected success, got {:?}", error);
-            }
-        }
-        assert_eq!(
-            transport.requests.borrow().as_slice(),
-            ["provider-capabilities --json"]
-        );
-    }
-
-    #[test]
-    fn handle_desktop_json_rpc_routes_provider_capabilities_empty_registry() {
-        let transport = FakeTransport {
-            requests: RefCell::new(Vec::new()),
-            response: serde_json::json!({
-                "version": 1,
-                "providers": {},
-                "registry_path": r"C:\Users\example\project\.winsmux\provider-capabilities.json"
-            }),
-        };
-        let response = handle_desktop_json_rpc(
-            &transport,
-            DesktopJsonRpcRequest {
-                jsonrpc: "2.0".to_string(),
-                id: serde_json::json!("req-provider-capabilities-empty"),
-                method: "desktop.provider.capabilities".to_string(),
-                params: None,
-            },
-            None,
-        );
-
-        match response {
-            DesktopJsonRpcResponse::Success { id, result, .. } => {
-                assert_eq!(id, serde_json::json!("req-provider-capabilities-empty"));
-                assert_eq!(result["version"], 1);
-                assert_eq!(result["providers"], serde_json::json!({}));
-                serialized_result_has_no_registry_path_or_absolute_path(&result);
-            }
-            DesktopJsonRpcResponse::Error { error, .. } => {
-                panic!("expected success, got {:?}", error);
-            }
-        }
-        assert_eq!(
-            transport.requests.borrow().as_slice(),
-            ["provider-capabilities --json"]
         );
     }
 

--- a/winsmux-app/src-tauri/src/desktop_companion_cli.rs
+++ b/winsmux-app/src-tauri/src/desktop_companion_cli.rs
@@ -691,6 +691,7 @@ panes:
             DesktopCommand::RunPickWinner { .. } => "consult-result",
             DesktopCommand::WorkersStatus { .. } | DesktopCommand::WorkersStart { .. } => "workers",
             DesktopCommand::ProviderSwitch { .. } => "provider-switch",
+            DesktopCommand::ProviderCapabilities { .. } => "provider-capabilities",
             DesktopCommand::RuntimeRolesApply { .. } => "runtime-roles",
             DesktopCommand::DogfoodEvent { .. } => "dogfood",
             DesktopCommand::TeamProfileSettingsView { .. }
@@ -744,6 +745,9 @@ panes:
                 auth_mode: None,
                 reason: None,
                 clear: true,
+                project_dir: none.clone(),
+            },
+            DesktopCommand::ProviderCapabilities {
                 project_dir: none.clone(),
             },
             DesktopCommand::RuntimeRolesApply {

--- a/winsmux-app/src-tauri/src/desktop_control_plane_params.rs
+++ b/winsmux-app/src-tauri/src/desktop_control_plane_params.rs
@@ -7,6 +7,9 @@ use serde_json::Value;
 pub struct DesktopSummarySnapshotParams {}
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct DesktopProviderCapabilitiesParams {}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct DesktopVoiceCaptureStatusParams {}
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/winsmux-app/src-tauri/src/desktop_control_plane_params.rs
+++ b/winsmux-app/src-tauri/src/desktop_control_plane_params.rs
@@ -7,9 +7,6 @@ use serde_json::Value;
 pub struct DesktopSummarySnapshotParams {}
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct DesktopProviderCapabilitiesParams {}
-
-#[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct DesktopVoiceCaptureStatusParams {}
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/winsmux-app/src-tauri/src/desktop_provider_capabilities.rs
+++ b/winsmux-app/src-tauri/src/desktop_provider_capabilities.rs
@@ -1,0 +1,189 @@
+use std::collections::HashMap;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::desktop_backend::{
+    DesktopCommand, DesktopCommandTransport, DesktopJsonRpcError, DesktopJsonRpcResponse,
+    DESKTOP_JSON_RPC_VERSION, JSON_RPC_INTERNAL_ERROR, JSON_RPC_SERVER_ERROR,
+};
+use crate::desktop_control_plane_params::consume_external_params;
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct DesktopProviderCapabilitiesParams {}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub struct DesktopProviderCapabilitiesSnapshot {
+    pub version: u64,
+    pub providers: HashMap<String, Value>,
+}
+
+pub fn load_desktop_provider_capabilities(
+    transport: &dyn DesktopCommandTransport,
+    project_dir: Option<String>,
+) -> Result<DesktopProviderCapabilitiesSnapshot, String> {
+    let snapshot =
+        transport.request_json(&DesktopCommand::ProviderCapabilities { project_dir })?;
+    serde_json::from_value(snapshot).map_err(|err| {
+        format!("Failed to parse desktop provider capabilities payload: {err}")
+    })
+}
+
+pub fn json_rpc(
+    transport: &dyn DesktopCommandTransport,
+    id: Value,
+    project_dir: Option<String>,
+    params: Option<Value>,
+) -> DesktopJsonRpcResponse {
+    let _params = consume_external_params::<DesktopProviderCapabilitiesParams>(params.as_ref());
+    match load_desktop_provider_capabilities(transport, project_dir) {
+        Ok(snapshot) => match serde_json::to_value(snapshot) {
+            Ok(result) => DesktopJsonRpcResponse::Success {
+                jsonrpc: DESKTOP_JSON_RPC_VERSION.to_string(),
+                id,
+                result,
+            },
+            Err(err) => DesktopJsonRpcResponse::Error {
+                jsonrpc: DESKTOP_JSON_RPC_VERSION.to_string(),
+                id,
+                error: DesktopJsonRpcError {
+                    code: JSON_RPC_INTERNAL_ERROR,
+                    message: format!(
+                        "Failed to serialize desktop provider capabilities payload: {err}"
+                    ),
+                },
+            },
+        },
+        Err(message) => DesktopJsonRpcResponse::Error {
+            jsonrpc: DESKTOP_JSON_RPC_VERSION.to_string(),
+            id,
+            error: DesktopJsonRpcError {
+                code: JSON_RPC_SERVER_ERROR,
+                message,
+            },
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::desktop_backend::{
+        handle_desktop_json_rpc, DesktopJsonRpcRequest, DesktopJsonRpcResponse,
+    };
+    use std::cell::RefCell;
+
+    struct FakeTransport {
+        requests: RefCell<Vec<String>>,
+        response: Value,
+    }
+
+    impl DesktopCommandTransport for FakeTransport {
+        fn request_json(&self, command: &DesktopCommand) -> Result<Value, String> {
+            self.requests
+                .borrow_mut()
+                .push(command.winsmux_args().join(" "));
+            Ok(self.response.clone())
+        }
+    }
+
+    fn serialized_result_has_no_registry_path_or_absolute_path(result: &Value) {
+        let serialized =
+            serde_json::to_string(result).expect("serialize provider capabilities result");
+        assert!(
+            !serialized.contains("registry_path"),
+            "serialized result must drop registry_path: {serialized}"
+        );
+        assert!(
+            !serialized.contains(r"C:\") && !serialized.contains("C:/"),
+            "serialized result must not contain a drive-letter path: {serialized}"
+        );
+        assert!(
+            result.get("registry_path").is_none(),
+            "typed result must not expose registry_path"
+        );
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_routes_provider_capabilities() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({
+                "version": 1,
+                "registry_path": r"C:\Users\example\project\.winsmux\provider-capabilities.json",
+                "providers": {
+                    "codex": {
+                        "adapter": "codex",
+                        "display_name": "Codex"
+                    }
+                }
+            }),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-provider-capabilities"),
+                method: "desktop.provider.capabilities".to_string(),
+                params: None,
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-provider-capabilities"));
+                assert_eq!(result["version"], 1);
+                assert_eq!(result["providers"]["codex"]["adapter"], "codex");
+                assert_eq!(result["providers"]["codex"]["display_name"], "Codex");
+                serialized_result_has_no_registry_path_or_absolute_path(&result);
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+        assert_eq!(
+            transport.requests.borrow().as_slice(),
+            ["provider-capabilities --json"]
+        );
+    }
+
+    #[test]
+    fn handle_desktop_json_rpc_routes_provider_capabilities_empty_registry() {
+        let transport = FakeTransport {
+            requests: RefCell::new(Vec::new()),
+            response: serde_json::json!({
+                "version": 1,
+                "providers": {},
+                "registry_path": r"C:\Users\example\project\.winsmux\provider-capabilities.json"
+            }),
+        };
+        let response = handle_desktop_json_rpc(
+            &transport,
+            DesktopJsonRpcRequest {
+                jsonrpc: "2.0".to_string(),
+                id: serde_json::json!("req-provider-capabilities-empty"),
+                method: "desktop.provider.capabilities".to_string(),
+                params: None,
+            },
+            None,
+        );
+
+        match response {
+            DesktopJsonRpcResponse::Success { id, result, .. } => {
+                assert_eq!(id, serde_json::json!("req-provider-capabilities-empty"));
+                assert_eq!(result["version"], 1);
+                assert_eq!(result["providers"], serde_json::json!({}));
+                serialized_result_has_no_registry_path_or_absolute_path(&result);
+            }
+            DesktopJsonRpcResponse::Error { error, .. } => {
+                panic!("expected success, got {:?}", error);
+            }
+        }
+        assert_eq!(
+            transport.requests.borrow().as_slice(),
+            ["provider-capabilities --json"]
+        );
+    }
+}

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod control_pipe;
 mod desktop_backend;
 mod desktop_control_plane_params;
+mod desktop_provider_capabilities;
 mod desktop_companion_cli;
 mod desktop_events;
 mod desktop_session_restore;


### PR DESCRIPTION
## Summary

- Add `desktop.provider.capabilities` on the typed pipe so clients can read the existing provider capability registry.
- Result is `{version, providers}`. The local `registry_path` is dropped. The matrix CLI cell is `control-rpc only`.
- Regenerated the v2 contract artifact and SDK bindings. Generator, CI, MCP, and PowerShell are unchanged.

## Surface Classification

- [x] Public product surface
- [x] Runtime contract surface
- [ ] Contributor/test surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Responsibility And Cutover

- Replaced behavior, workflow, config path, or responsibility: none. This is a new discovery method on the existing pipe.
- Expected outcome: pipe clients see the same registry Core already validates.
- Source of truth: `.winsmux/provider-capabilities.json` via companion `provider-capabilities --json`.
- Old paths preserved, redirected, deprecated, or removed: Core CLI unchanged. Worker start/status stay excluded from the pipe.

## Verification

- `control_pipe::tests` 41 passed
- Route tests for a populated registry and an empty registry
- Argv-head locks in the desktop companion and Core
- `npm run test:control-plane-bindings --check`
- Codex Sol APPROVE; P0/P1 none

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.

tag / npm are not this PR. VERSION stays `0.36.33`.
