### PR TITLE
feat(control-plane): delete owned control-pipe token on clean desktop exit (TASK-676)

### DIFF
--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -31,6 +31,8 @@ pub const WINSMUX_CONTROL_PIPE_TOKEN_ENV: &str = "WINSMUX_CONTROL_PIPE_TOKEN";
 pub const WINSMUX_CONTROL_PIPE_TOKEN_FILE_TEMPLATE: &str =
     r"%LOCALAPPDATA%\winsmux\control-pipe\token";
 const CONTROL_PIPE_TOKEN_ROTATED_MARKER: &str = "control-pipe token: rotated";
+const CONTROL_PIPE_TOKEN_REVOKED_MARKER: &str = "control-pipe token: revoked";
+const CONTROL_PIPE_TOKEN_REVOKE_FAILED_MARKER: &str = "control-pipe token: revoke failed";
 const PREVIOUS_TOKEN_TTL: Duration = Duration::from_secs(60);
 const CONTROL_PIPE_TOKEN_RANDOM_BYTES: usize = 32;
 
@@ -240,6 +242,29 @@ fn bootstrap_control_pipe_token() -> Result<(), String> {
     });
     eprintln!("{CONTROL_PIPE_TOKEN_ROTATED_MARKER}");
     Ok(())
+}
+
+pub fn revoke_control_pipe_token_on_exit() {
+    let mut guard = control_pipe_auth_state_lock();
+    if guard.is_none() {
+        return;
+    }
+    // Unlink first while this process still owns Some-state. Clearing the lock
+    // before remove_file would fall through to the untrusted file-token read.
+    let unlink_ok = match control_pipe_token_file_path() {
+        Some(path) => match fs::remove_file(&path) {
+            Ok(()) => true,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => true,
+            Err(_) => false,
+        },
+        None => false,
+    };
+    *guard = None;
+    if unlink_ok {
+        eprintln!("{CONTROL_PIPE_TOKEN_REVOKED_MARKER}");
+    } else {
+        eprintln!("{CONTROL_PIPE_TOKEN_REVOKE_FAILED_MARKER}");
+    }
 }
 
 fn bootstrap_control_pipe_token_after_exclusive_pipe(
@@ -3512,5 +3537,77 @@ mod tests {
         let value: Value = serde_json::from_slice(&response).expect("json");
         assert_eq!(value["id"], 1);
         assert!(value.get("error").is_none() || value["error"].is_null());
+    }
+
+    #[test]
+    fn control_pipe_revoke_on_exit_deletes_owned_token_file() {
+        let _guard = isolate_control_pipe_paths_for_test();
+        bootstrap_control_pipe_token().expect("bootstrap");
+        let path = control_pipe_token_file_path().expect("token path");
+        let current = fs::read_to_string(&path).expect("owned token");
+        assert!(control_pipe_auth_state_lock().is_some());
+
+        revoke_control_pipe_token_on_exit();
+
+        assert!(!path.exists(), "owned token file must be deleted");
+        assert!(control_pipe_auth_state_lock().is_none());
+        assert!(!authorize_rotated_or_file_token(&current));
+    }
+
+    #[test]
+    fn control_pipe_revoke_on_exit_leaves_unowned_file() {
+        let _guard = isolate_control_pipe_paths_for_test();
+        let path = control_pipe_token_file_path().expect("token path");
+        fs::create_dir_all(path.parent().expect("parent")).expect("token dir");
+        fs::write(&path, "planted-token").expect("planted file");
+        assert!(control_pipe_auth_state_lock().is_none());
+
+        revoke_control_pipe_token_on_exit();
+
+        assert_eq!(
+            fs::read_to_string(&path).expect("planted file remains"),
+            "planted-token"
+        );
+        assert!(control_pipe_auth_state_lock().is_none());
+    }
+
+    #[test]
+    fn control_pipe_revoke_on_exit_leaves_env_skip_planted_file() {
+        let _guard = set_control_pipe_token_for_test(Some("env-token-value"));
+        let path = control_pipe_token_file_path().expect("token path");
+        fs::create_dir_all(path.parent().expect("parent")).expect("token dir");
+        fs::write(&path, "keep-file-token").expect("file token");
+        let mut bootstrapped = false;
+        bootstrap_control_pipe_token_after_exclusive_pipe(&mut bootstrapped)
+            .expect("env skip");
+        assert!(bootstrapped);
+        assert!(control_pipe_auth_state_lock().is_none());
+
+        revoke_control_pipe_token_on_exit();
+
+        assert_eq!(
+            fs::read_to_string(&path).expect("env-skip planted file remains"),
+            "keep-file-token"
+        );
+    }
+
+    #[test]
+    fn control_pipe_bootstrap_recovers_after_revoke() {
+        let _guard = isolate_control_pipe_paths_for_test();
+        bootstrap_control_pipe_token().expect("bootstrap");
+        let path = control_pipe_token_file_path().expect("token path");
+        let first = fs::read_to_string(&path).expect("first token");
+        revoke_control_pipe_token_on_exit();
+        assert!(!path.exists());
+
+        bootstrap_control_pipe_token().expect("bootstrap after revoke");
+        let second = fs::read_to_string(&path).expect("new token");
+        assert_ne!(second, first);
+        assert!(authorize_rotated_or_file_token(&second));
+        #[cfg(windows)]
+        assert!(
+            existing_token_file_is_trusted(&path),
+            "restart after revoke must recreate a user-only token file"
+        );
     }
 }

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -10,7 +10,8 @@ mod pty_backend;
 mod remote_debug_gate;
 
 use control_pipe::{
-    control_pipe_ui_is_enabled, start_control_pipe_server, WINSMUX_CONTROL_PIPE_TOKEN_ENV,
+    control_pipe_ui_is_enabled, revoke_control_pipe_token_on_exit, start_control_pipe_server,
+    WINSMUX_CONTROL_PIPE_TOKEN_ENV,
 };
 use desktop_backend::{
     handle_desktop_json_rpc, load_desktop_run_explain,
@@ -1916,6 +1917,10 @@ fn request_desktop_runtime_shutdown(
     summary.stop_requested.store(true, Ordering::SeqCst);
     let voice_cleanup_completed = request_voice_capture_shutdown(voice, voice_timeout);
     let (pty_count, pty_exited_count) = drain_all_ptys(pty, pty_timeout);
+    // Exclusive pipe stays with the control-pipe server thread until process
+    // death, so unlink here cannot race a successor rotate. updater `app.exit(0)`
+    // reaches this function via RunEvent ExitRequested/Exit.
+    revoke_control_pipe_token_on_exit();
     Some(DesktopShutdownReport {
         voice_stop_requested: voice_cleanup_completed.is_some(),
         voice_cleanup_completed,


### PR DESCRIPTION
## Summary

- On clean desktop shutdown, the process that rotated the control-pipe token file deletes it once, best-effort.
- Guard is in-memory `Some` auth state (this process wrote the file after exclusive-pipe bootstrap). Never-bootstrapped and env-skip processes do not unlink a planted file.
- Crash / `process::exit` leave the file. Discover still treats live pipe as running, not file existence.

Not this PR: explicit revoke CLI/method, TTL change, untrusted file fallback, HMAC, consent pairing, ACCESS_DENIED class, VERSION. tag / npm はこの PR の仕事ではない.

## Surface Classification

- [x] Runtime contract surface
- [ ] Public product surface
- [ ] Contributor/test surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Responsibility And Cutover

- Replaced behavior, workflow, config path, or responsibility: clean desktop exit left a live-looking bearer file under `%LOCALAPPDATA%\winsmux\control-pipe\token`.
- Expected outcome: the rotator process unlinks that file once on `request_desktop_runtime_shutdown` after PTY drain.
- Source of truth: in-memory `CONTROL_PIPE_AUTH_STATE` is `Some` only after exclusive-pipe rotate.
- Old paths preserved, redirected, deprecated, or removed: crash leftover files stay; 802 `desktop_running` remains live-pipe only.

## Verification

- Local: `cargo test --lib control_pipe::tests -- --test-threads=1` (60 passed, including owned-delete / unowned-leave / env-skip-leave / bootstrap-after-revoke)
- Local: `desktop_shutdown_stops_summary_voice_and_empty_pty_registry_once`
- Inventory: `.references/operator-plans/task676-revocation-inventory.md`
- Grok design: APPROVE_WITH_CHANGES (env-skip test, exclusive-pipe comment, success/fail markers, updater `app.exit(0)` path)

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.

## Test plan

- [x] Isolated LOCALAPPDATA bootstrap then revoke: file gone, state `None`, old token no longer authorizes
- [x] Planted file + never bootstrap: file remains
- [x] Env-skip + planted file: file remains
- [x] Bootstrap after revoke: new user-only file, new token authorizes
- [ ] CI Tests + Merge Gate
