### PR TITLE
feat(control-plane): require trusted DACL for None-state file tokens (TASK-676)

### DIFF
--- a/winsmux-app/src-tauri/src/control_pipe.rs
+++ b/winsmux-app/src-tauri/src/control_pipe.rs
@@ -299,7 +299,7 @@ fn authorize_rotated_or_file_token(provided: &str) -> bool {
         return false;
     }
     drop(guard);
-    match read_control_pipe_token_file() {
+    match read_trusted_previous_control_pipe_token() {
         Some(file_token) => constant_time_string_eq(provided.as_bytes(), file_token.as_bytes()),
         None => false,
     }
@@ -2323,6 +2323,7 @@ mod tests {
         let path = control_pipe_token_file_path().expect("token path");
         fs::create_dir_all(path.parent().expect("parent")).expect("token dir");
         fs::write(&path, "scope-file-token").expect("file token");
+        harden_existing_token_file_for_test(&path);
         let pty_transport = StubPtyTransport::new();
         let response = handle_control_pipe_payload(
             &StubDesktopTransport,
@@ -3173,6 +3174,7 @@ mod tests {
         let exact = control_pipe_token_file_path().expect("token path");
         fs::create_dir_all(exact.parent().expect("exact parent")).expect("exact dir");
         fs::write(&exact, "exact-file-token").expect("exact token");
+        harden_existing_token_file_for_test(&exact);
 
         let pty_transport = StubPtyTransport::new();
         for planted in [
@@ -3530,6 +3532,7 @@ mod tests {
         let path = control_pipe_token_file_path().expect("token path");
         fs::create_dir_all(path.parent().expect("parent")).expect("token dir");
         fs::write(&path, "operator-file-token").expect("file token");
+        harden_existing_token_file_for_test(&path);
         let payload = br#"{"jsonrpc":"2.0","id":1,"method":"desktop.operator.snapshot","params":{"lines":40},"auth":{"token":"operator-file-token"}}"#;
         let pty_transport = StubPtyTransport::new();
         let response =
@@ -3537,6 +3540,33 @@ mod tests {
         let value: Value = serde_json::from_slice(&response).expect("json");
         assert_eq!(value["id"], 1);
         assert!(value.get("error").is_none() || value["error"].is_null());
+    }
+
+    #[test]
+    fn control_pipe_operator_snapshot_rejects_untrusted_file_token() {
+        let _guard = isolate_control_pipe_paths_for_test();
+        let path = control_pipe_token_file_path().expect("token path");
+        fs::create_dir_all(path.parent().expect("parent")).expect("token dir");
+        fs::write(&path, "planted-file-token").expect("planted file");
+        assert!(
+            control_pipe_auth_is_available(),
+            "existence is not authorization"
+        );
+        let payload = br#"{"jsonrpc":"2.0","id":1,"method":"desktop.operator.snapshot","params":{"lines":40},"auth":{"token":"planted-file-token"}}"#;
+        let pty_transport = StubPtyTransport::new();
+        let response =
+            handle_control_pipe_payload(&StubDesktopTransport, &pty_transport, payload, None);
+        let value: Value = serde_json::from_slice(&response).expect("json");
+        assert_eq!(value["error"]["code"], JSON_RPC_INVALID_REQUEST);
+        assert!(value["error"]["message"]
+            .as_str()
+            .expect("error message")
+            .contains(WINSMUX_CONTROL_PIPE_TOKEN_ENV));
+        assert!(pty_transport
+            .commands
+            .lock()
+            .expect("commands lock")
+            .is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- TASK-676: when in-memory control-pipe auth state is `None`, a file token authorizes only via the same trusted-handle DACL read used for bootstrap previous (`read_trusted_previous_control_pipe_token`). An untrusted planted file does not authorize.
- HMAC is not in this PR. Consent pairing is not in this PR. VERSION stays `0.36.34`. tag / npm はこの PR の仕事ではない。

## Surface Classification
- [x] Runtime contract surface
- [ ] Public product surface
- [ ] Contributor/test surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Responsibility And Cutover
- Replaced behavior, workflow, config path, or responsibility: `authorize_rotated_or_file_token` None-state file compare (`control_pipe.rs` `:302`)
- Expected outcome: untrusted `fs::write` token files fail closed (`-32600`); user-only DACL file tokens still authorize; `Some`-state rotate/TTL and env-wins unchanged; UI existence (`control_pipe_auth_is_available`) still reads any file
- Source of truth: `.references/operator-plans/task676-file-fallback-inventory.md`; Grok APPROVE; Sol APPROVE on `bd92604b`
- Old paths preserved, redirected, deprecated, or removed: 835 token path unchanged; `read_control_pipe_token_file` remains for UI existence only

## Verification
- Local: `cargo test --lib control_pipe::tests -- --test-threads=1` → 61 passed (MSVC), including `control_pipe_operator_snapshot_rejects_untrusted_file_token`
- Existing planted-wrong-path / rotate / TTL / DACL / ACCESS_DENIED tests stay in that suite

## Security And Privacy
- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.
