### PR TITLE
feat(control-plane): scrub control-pipe token from non-companion children (TASK-677)

### DIFF
--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -54,17 +54,12 @@ const WINSMUX_DISABLE_WINDOWS_TERMINAL_ATTACH_ENV: &str =
     "WINSMUX_ORCHESTRA_DISABLE_WINDOWS_TERMINAL_ATTACH";
 const WINSMUX_BIN_ENV: &str = "WINSMUX_BIN";
 const WINSMUX_RAW_EXE_ENV: &str = "WINSMUX_RAW_EXE";
-const WINSMUX_CONTROL_PIPE_TOKEN_ENV: &str = "WINSMUX_CONTROL_PIPE_TOKEN";
 
 pub(crate) fn hide_subprocess_window(command: &mut Command) {
     crate::remote_debug_gate::scrub_gate_env_from_command(command);
     #[cfg(windows)] {
         command.creation_flags(CREATE_NO_WINDOW);
     }
-}
-
-pub(crate) fn scrub_control_pipe_token_from_command(command: &mut Command) {
-    command.env_remove(WINSMUX_CONTROL_PIPE_TOKEN_ENV);
 }
 
 fn resolve_companion_winsmux_cli_from_exe_path(current_exe: &Path) -> Option<PathBuf> {
@@ -2382,8 +2377,7 @@ fn collect_desktop_ignored_paths(root: &Path, relative_paths: &[String]) -> Hash
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
-    hide_subprocess_window(&mut command);
-    scrub_control_pipe_token_from_command(&mut command);
+    crate::hide_non_companion_subprocess_window(&mut command);
 
     let Ok(mut child) = command.spawn() else {
         return HashSet::new();
@@ -2770,36 +2764,6 @@ mod tests {
         assert_eq!(
             command_env_value(&command, WINSMUX_RAW_EXE_ENV).as_deref(),
             Some(r"C:\repo\target\release\winsmux.exe")
-        );
-        let removed: Vec<std::ffi::OsString> = command
-            .get_envs()
-            .filter_map(|(key, value)| value.is_none().then(|| key.to_os_string()))
-            .collect();
-        assert!(
-            !removed
-                .iter()
-                .any(|key| key == WINSMUX_CONTROL_PIPE_TOKEN_ENV),
-            "companion children must keep launcher token inherit; removed={removed:?}"
-        );
-    }
-
-    #[test]
-    fn scrub_control_pipe_token_records_explicit_removal() {
-        let mut command = Command::new("cmd.exe");
-        scrub_control_pipe_token_from_command(&mut command);
-        let removed_keys: Vec<std::ffi::OsString> = command
-            .get_envs()
-            .filter_map(|(key, value)| {
-                if value.is_none() {
-                    Some(key.to_os_string())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        assert!(
-            removed_keys.contains(&std::ffi::OsString::from(WINSMUX_CONTROL_PIPE_TOKEN_ENV)),
-            "expected env_remove entry for {WINSMUX_CONTROL_PIPE_TOKEN_ENV}, got {removed_keys:?}"
         );
     }
 

--- a/winsmux-app/src-tauri/src/desktop_backend.rs
+++ b/winsmux-app/src-tauri/src/desktop_backend.rs
@@ -54,12 +54,17 @@ const WINSMUX_DISABLE_WINDOWS_TERMINAL_ATTACH_ENV: &str =
     "WINSMUX_ORCHESTRA_DISABLE_WINDOWS_TERMINAL_ATTACH";
 const WINSMUX_BIN_ENV: &str = "WINSMUX_BIN";
 const WINSMUX_RAW_EXE_ENV: &str = "WINSMUX_RAW_EXE";
+const WINSMUX_CONTROL_PIPE_TOKEN_ENV: &str = "WINSMUX_CONTROL_PIPE_TOKEN";
 
 pub(crate) fn hide_subprocess_window(command: &mut Command) {
     crate::remote_debug_gate::scrub_gate_env_from_command(command);
     #[cfg(windows)] {
         command.creation_flags(CREATE_NO_WINDOW);
     }
+}
+
+pub(crate) fn scrub_control_pipe_token_from_command(command: &mut Command) {
+    command.env_remove(WINSMUX_CONTROL_PIPE_TOKEN_ENV);
 }
 
 fn resolve_companion_winsmux_cli_from_exe_path(current_exe: &Path) -> Option<PathBuf> {
@@ -2378,6 +2383,7 @@ fn collect_desktop_ignored_paths(root: &Path, relative_paths: &[String]) -> Hash
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
     hide_subprocess_window(&mut command);
+    scrub_control_pipe_token_from_command(&mut command);
 
     let Ok(mut child) = command.spawn() else {
         return HashSet::new();
@@ -2764,6 +2770,36 @@ mod tests {
         assert_eq!(
             command_env_value(&command, WINSMUX_RAW_EXE_ENV).as_deref(),
             Some(r"C:\repo\target\release\winsmux.exe")
+        );
+        let removed: Vec<std::ffi::OsString> = command
+            .get_envs()
+            .filter_map(|(key, value)| value.is_none().then(|| key.to_os_string()))
+            .collect();
+        assert!(
+            !removed
+                .iter()
+                .any(|key| key == WINSMUX_CONTROL_PIPE_TOKEN_ENV),
+            "companion children must keep launcher token inherit; removed={removed:?}"
+        );
+    }
+
+    #[test]
+    fn scrub_control_pipe_token_records_explicit_removal() {
+        let mut command = Command::new("cmd.exe");
+        scrub_control_pipe_token_from_command(&mut command);
+        let removed_keys: Vec<std::ffi::OsString> = command
+            .get_envs()
+            .filter_map(|(key, value)| {
+                if value.is_none() {
+                    Some(key.to_os_string())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert!(
+            removed_keys.contains(&std::ffi::OsString::from(WINSMUX_CONTROL_PIPE_TOKEN_ENV)),
+            "expected env_remove entry for {WINSMUX_CONTROL_PIPE_TOKEN_ENV}, got {removed_keys:?}"
         );
     }
 

--- a/winsmux-app/src-tauri/src/desktop_companion_cli.rs
+++ b/winsmux-app/src-tauri/src/desktop_companion_cli.rs
@@ -1,9 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use crate::desktop_backend::{
-    apply_desktop_winsmux_child_env, hide_subprocess_window, scrub_control_pipe_token_from_command,
-};
+use crate::desktop_backend::{apply_desktop_winsmux_child_env, hide_subprocess_window};
+use crate::scrub_control_pipe_token_from_command;
 
 const WINSMUX_CORE_SCRIPT_ENV: &str = "WINSMUX_CORE_SCRIPT";
 

--- a/winsmux-app/src-tauri/src/desktop_companion_cli.rs
+++ b/winsmux-app/src-tauri/src/desktop_companion_cli.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use crate::desktop_backend::{apply_desktop_winsmux_child_env, hide_subprocess_window};
+use crate::desktop_backend::{
+    apply_desktop_winsmux_child_env, hide_subprocess_window, scrub_control_pipe_token_from_command,
+};
 
 const WINSMUX_CORE_SCRIPT_ENV: &str = "WINSMUX_CORE_SCRIPT";
 
@@ -94,6 +96,7 @@ pub(crate) fn force_terminate_pid(pid: u32) {
             .stdout(Stdio::null())
             .stderr(Stdio::null());
         hide_subprocess_window(&mut command);
+        scrub_control_pipe_token_from_command(&mut command);
         let _ = command.status();
     }
     #[cfg(not(windows))]

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -15,7 +15,8 @@ use control_pipe::{
 };
 use desktop_backend::{
     handle_desktop_json_rpc, load_desktop_run_explain,
-    load_desktop_summary_snapshot, resolve_repo_root, spawn_desktop_summary_refresh_stream,
+    load_desktop_summary_snapshot, resolve_repo_root, scrub_control_pipe_token_from_command,
+    spawn_desktop_summary_refresh_stream,
     DesktopExplainPayload,
     DesktopJsonRpcRequest, DesktopJsonRpcResponse, DesktopStreamCommand,
     DesktopSummaryRefreshSignal, DesktopSummarySnapshot, DesktopVoiceCaptureStatus,
@@ -1356,6 +1357,7 @@ fn build_update_restart_command(
         .stdout(Stdio::null())
         .stderr(Stdio::null());
     remote_debug_gate::scrub_gate_env_from_command(&mut command);
+    scrub_control_pipe_token_from_command(&mut command);
     command
 }
 
@@ -2420,6 +2422,9 @@ mod tests {
         assert!(removed
             .iter()
             .any(|key| key == remote_debug_gate::WINSMUX_DESKTOP_REMOTE_DEBUG_PORT_ENV));
+        assert!(removed
+            .iter()
+            .any(|key| key == WINSMUX_CONTROL_PIPE_TOKEN_ENV));
     }
 
     #[test]

--- a/winsmux-app/src-tauri/src/lib.rs
+++ b/winsmux-app/src-tauri/src/lib.rs
@@ -15,8 +15,7 @@ use control_pipe::{
 };
 use desktop_backend::{
     handle_desktop_json_rpc, load_desktop_run_explain,
-    load_desktop_summary_snapshot, resolve_repo_root, scrub_control_pipe_token_from_command,
-    spawn_desktop_summary_refresh_stream,
+    load_desktop_summary_snapshot, resolve_repo_root, spawn_desktop_summary_refresh_stream,
     DesktopExplainPayload,
     DesktopJsonRpcRequest, DesktopJsonRpcResponse, DesktopStreamCommand,
     DesktopSummaryRefreshSignal, DesktopSummarySnapshot, DesktopVoiceCaptureStatus,
@@ -1328,6 +1327,15 @@ fn spawn_pty(
 type PtyReader = Box<dyn Read + Send>;
 type SinglePtyParts = (SinglePty, PtyReader, Arc<Mutex<String>>, Arc<AtomicBool>);
 
+pub(crate) fn scrub_control_pipe_token_from_command(command: &mut Command) {
+    command.env_remove(WINSMUX_CONTROL_PIPE_TOKEN_ENV);
+}
+
+pub(crate) fn hide_non_companion_subprocess_window(command: &mut Command) {
+    desktop_backend::hide_subprocess_window(command);
+    scrub_control_pipe_token_from_command(command);
+}
+
 #[cfg(windows)]
 fn build_update_restart_command(
     restart_script_path: &Path,
@@ -2425,6 +2433,43 @@ mod tests {
         assert!(removed
             .iter()
             .any(|key| key == WINSMUX_CONTROL_PIPE_TOKEN_ENV));
+    }
+
+    #[test]
+    fn companion_child_env_does_not_record_token_removal() {
+        let companion = PathBuf::from(r"C:\repo\target\release\winsmux.exe");
+        let mut command = Command::new("pwsh");
+        desktop_backend::apply_desktop_winsmux_child_env(&mut command, Some(&companion), 4242);
+        let removed: Vec<std::ffi::OsString> = command
+            .get_envs()
+            .filter_map(|(key, value)| value.is_none().then(|| key.to_os_string()))
+            .collect();
+        assert!(
+            !removed
+                .iter()
+                .any(|key| key == WINSMUX_CONTROL_PIPE_TOKEN_ENV),
+            "companion children must keep launcher token inherit; removed={removed:?}"
+        );
+    }
+
+    #[test]
+    fn scrub_control_pipe_token_records_explicit_removal() {
+        let mut command = Command::new("cmd.exe");
+        scrub_control_pipe_token_from_command(&mut command);
+        let removed_keys: Vec<std::ffi::OsString> = command
+            .get_envs()
+            .filter_map(|(key, value)| {
+                if value.is_none() {
+                    Some(key.to_os_string())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert!(
+            removed_keys.contains(&std::ffi::OsString::from(WINSMUX_CONTROL_PIPE_TOKEN_ENV)),
+            "expected env_remove entry for {WINSMUX_CONTROL_PIPE_TOKEN_ENV}, got {removed_keys:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- TASK-677 first cut: desktop-spawned processes that are not the companion winsmux CLI record `env_remove(WINSMUX_CONTROL_PIPE_TOKEN)` so launcher-mode inherit does not reach git check-ignore, update-restart PowerShell, or taskkill.
- Companion ledger/stream keep inherit. Exclusive-pipe bootstrap skips file rotate when that env is set (`control_pipe.rs` 276-278), so stripping companion would break launcher-mode auth.
- `hide_subprocess_window` is unchanged (token scrub there would strip companion). `control_pipe.rs`, `operator_cli.rs`, `main.ts`, VERSION are zero diff.
- Grok design APPROVE. Local tests A/B/C green (MSVC). tag / npm はこの PR の仕事ではない.

## Test plan
- [x] `update_restart_command_records_gate_env_removal` includes `WINSMUX_CONTROL_PIPE_TOKEN`
- [x] companion `apply_desktop_winsmux_child_env` does not record token removal
- [x] `scrub_control_pipe_token_records_explicit_removal` records a `None` env entry
- [ ] CI Tests + Merge Gate
