### PR TITLE
feat(control-plane): reject vault set secret on argv (TASK-677)

### DIFF
--- a/docs/TROUBLESHOOTING.ja.md
+++ b/docs/TROUBLESHOOTING.ja.md
@@ -150,7 +150,7 @@ Get-Process winsmux-app -ErrorAction SilentlyContinue |
 対処:
 
 ```powershell
-winsmux vault set <name> <value>
+winsmux vault set <name>
 winsmux vault inject <name> <pane>
 ```
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -168,7 +168,7 @@ Cause: the key is not stored in Windows Credential Manager.
 Fix:
 
 ```powershell
-winsmux vault set <name> <value>
+winsmux vault set <name>
 winsmux vault inject <name> <pane>
 ```
 

--- a/docs/customization.ja.md
+++ b/docs/customization.ja.md
@@ -270,7 +270,7 @@ agent-slots:
 ペインへ渡す必要がある資格情報は Windows DPAPI で保存します。
 
 ```powershell
-winsmux vault set <name> <value>
+winsmux vault set <name>
 winsmux vault inject <name> <pane>
 ```
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -332,7 +332,7 @@ Use this model when assigning work:
 Store credentials that must be injected into a pane with Windows DPAPI:
 
 ```powershell
-winsmux vault set <name> <value>
+winsmux vault set <name>
 winsmux vault inject <name> <pane>
 ```
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -17738,7 +17738,13 @@ function Invoke-Profile {
 function Invoke-VaultSet {
     $key = $Target
     if (-not $key) { Stop-WithError "usage: winsmux vault set <key>" }
-    if ($Rest) {
+    $restLen = 0
+    if ($Rest -is [System.Array]) {
+        $restLen = $Rest.Length
+    } elseif ($null -ne $Rest) {
+        $restLen = 1
+    }
+    if ($restLen -gt 0) {
         Stop-WithError "vault set does not accept the value on the command line"
     }
 

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -17737,17 +17737,18 @@ function Invoke-Profile {
 
 function Invoke-VaultSet {
     $key = $Target
-    $value = if ($Rest) { $Rest -join ' ' } else { '' }
-    if (-not $key) { Stop-WithError "usage: winsmux vault set <key> [value]" }
-    if (-not $value) {
-        $secure = Read-Host -AsSecureString "Enter value for '$key'"
-        $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
-        try {
-            $value = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
-        } finally {
-            if ($bstr -ne [IntPtr]::Zero) {
-                [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
-            }
+    if (-not $key) { Stop-WithError "usage: winsmux vault set <key>" }
+    if ($Rest) {
+        Stop-WithError "vault set does not accept the value on the command line"
+    }
+
+    $secure = Read-Host -AsSecureString "Enter value for '$key'"
+    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
+    try {
+        $value = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+    } finally {
+        if ($bstr -ne [IntPtr]::Zero) {
+            [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
         }
     }
     if ([string]::IsNullOrWhiteSpace($value)) {
@@ -18698,7 +18699,7 @@ promote-tactic <run_id> [--title <text>] [--kind <playbook|prewarm|verification>
   harness-check [--json] [--project-dir <path>]  Validate hook/settings/attach contracts before external-operator startup
   shadow-cutover-gate --expected <path> --actual <path> [--surface <name>] [--json]  Compare PowerShell/Rust shadow outputs before cutover
   powershell-deescalation [--json]  Print the PowerShell shrink contract for runtime cutover
-  vault set <key> [value]   Store a credential securely (DPAPI)
+  vault set <key>           Store a credential securely (DPAPI)
   vault get <key>           Retrieve a stored credential
   vault inject <pane>       Inject all credentials as env vars into a pane
   vault list                List stored credential keys

--- a/tests/Runtime.VaultInject.Tests.ps1
+++ b/tests/Runtime.VaultInject.Tests.ps1
@@ -113,6 +113,16 @@ public static class WinCredDeleteNative {
         $storedTargets | Should -Not -Contain ('winsmux:{0}' -f $script:Target)
     }
 
+    It 'vault set rejects an empty argv token before prompting' {
+        $script:Target = '{0}:empty-argv' -f $script:RunPrefix
+        $script:Rest = @('')
+
+        { Invoke-VaultSet } | Should -Throw '*command line*'
+
+        $storedTargets = @(Get-StoredCredentialTargets -Filter ("winsmux:{0}:*" -f $script:RunPrefix))
+        $storedTargets | Should -Not -Contain ('winsmux:{0}' -f $script:Target)
+    }
+
     It 'vault get through pwsh -File keeps a single rest token intact' {
         $bridge = Join-Path (Split-Path -Parent $PSScriptRoot) 'scripts\winsmux-core.ps1'
         $key = 'WINSMUX_BRIDGE_REST_SINGLE_TOKEN'

--- a/tests/Runtime.VaultInject.Tests.ps1
+++ b/tests/Runtime.VaultInject.Tests.ps1
@@ -96,12 +96,21 @@ public static class WinCredDeleteNative {
 
     It 'vault set stores a credential under the unique winsmux-test prefix' {
         $script:Target = '{0}:set' -f $script:RunPrefix
-        $script:Rest = @('set-secret')
 
-        Invoke-VaultSet | Out-Null
+        Write-WinsmuxVaultCredentialInternal -Key $script:Target -Value 'set-secret'
 
         $storedTargets = @(Get-StoredCredentialTargets -Filter ("winsmux:{0}:*" -f $script:RunPrefix))
         $storedTargets | Should -Contain ('winsmux:{0}' -f $script:Target)
+    }
+
+    It 'vault set rejects a value passed on the command line' {
+        $script:Target = '{0}:argv' -f $script:RunPrefix
+        $script:Rest = @('argv-secret')
+
+        { Invoke-VaultSet } | Should -Throw '*command line*'
+
+        $storedTargets = @(Get-StoredCredentialTargets -Filter ("winsmux:{0}:*" -f $script:RunPrefix))
+        $storedTargets | Should -Not -Contain ('winsmux:{0}' -f $script:Target)
     }
 
     It 'vault get through pwsh -File keeps a single rest token intact' {
@@ -116,18 +125,14 @@ public static class WinCredDeleteNative {
 
     It 'vault get retrieves a stored credential' {
         $script:Target = '{0}:get' -f $script:RunPrefix
-        $script:Rest = @('get-secret')
-        Invoke-VaultSet | Out-Null
-
-        $script:Rest = @()
+        Write-WinsmuxVaultCredentialInternal -Key $script:Target -Value 'get-secret'
 
         (Invoke-VaultGet) | Should -Be 'get-secret'
     }
 
     It 'vault list includes the stored credential key' {
         $script:Target = '{0}:list' -f $script:RunPrefix
-        $script:Rest = @('list-secret')
-        Invoke-VaultSet | Out-Null
+        Write-WinsmuxVaultCredentialInternal -Key $script:Target -Value 'list-secret'
 
         $listedKeys = @(Invoke-VaultList)
 

--- a/tests/bridge/Foundation.Tests.ps1
+++ b/tests/bridge/Foundation.Tests.ps1
@@ -679,13 +679,8 @@ public static class WinsmuxVaultTestCleanupNative {
     }
 
     It 'stores, retrieves, and lists credentials inside the test prefix only' {
-        $script:Target = 'alpha'
-        $script:Rest = @('one')
-        Invoke-VaultSet | Out-Null
-
-        $script:Target = 'beta'
-        $script:Rest = @('two')
-        Invoke-VaultSet | Out-Null
+        Write-WinsmuxVaultCredentialInternal -Key 'alpha' -Value 'one'
+        Write-WinsmuxVaultCredentialInternal -Key 'beta' -Value 'two'
 
         $script:Target = 'alpha'
         $script:Rest = @()

--- a/winsmux-core/scripts/vault.ps1
+++ b/winsmux-core/scripts/vault.ps1
@@ -102,7 +102,13 @@ function Write-WinsmuxVaultCredentialInternal {
 function Invoke-VaultSet {
     $key = $Target
     if (-not $key) { Stop-WithError "usage: winsmux vault set <key>" }
-    if ($Rest) {
+    $restLen = 0
+    if ($Rest -is [System.Array]) {
+        $restLen = $Rest.Length
+    } elseif ($null -ne $Rest) {
+        $restLen = 1
+    }
+    if ($restLen -gt 0) {
         Stop-WithError "vault set does not accept the value on the command line"
     }
 

--- a/winsmux-core/scripts/vault.ps1
+++ b/winsmux-core/scripts/vault.ps1
@@ -64,27 +64,18 @@ public class WinsmuxVaultCredentialNative {
 '@ -ErrorAction SilentlyContinue
 }
 
-function Invoke-VaultSet {
-    $key = $Target
-    $value = if ($Rest) { $Rest -join ' ' } else { '' }
-    if (-not $key) { Stop-WithError "usage: winsmux vault set <key> [value]" }
-    if (-not $value) {
-        $secure = Read-Host -AsSecureString "Enter value for '$key'"
-        $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
-        try {
-            $value = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
-        } finally {
-            if ($bstr -ne [IntPtr]::Zero) {
-                [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
-            }
-        }
-    }
-    if ([string]::IsNullOrWhiteSpace($value)) {
-        Stop-WithError "vault value for '$key' must not be empty"
+function Write-WinsmuxVaultCredentialInternal {
+    param(
+        [Parameter(Mandatory = $true)][string]$Key,
+        [Parameter(Mandatory = $true)][string]$Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        Stop-WithError "vault value for '$Key' must not be empty"
     }
 
-    $credTarget = "winsmux:$key"
-    $valueBytes = [System.Text.Encoding]::Unicode.GetBytes($value)
+    $credTarget = "winsmux:$Key"
+    $valueBytes = [System.Text.Encoding]::Unicode.GetBytes($Value)
     $blobPtr = [Runtime.InteropServices.Marshal]::AllocHGlobal($valueBytes.Length)
     [Runtime.InteropServices.Marshal]::Copy($valueBytes, 0, $blobPtr, $valueBytes.Length)
 
@@ -102,10 +93,30 @@ function Invoke-VaultSet {
             $errCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
             Stop-WithError "CredWrite failed (error $errCode)"
         }
-        Write-Host "Stored credential: $key"
+        Write-Host "Stored credential: $Key"
     } finally {
         [Runtime.InteropServices.Marshal]::FreeHGlobal($blobPtr)
     }
+}
+
+function Invoke-VaultSet {
+    $key = $Target
+    if (-not $key) { Stop-WithError "usage: winsmux vault set <key>" }
+    if ($Rest) {
+        Stop-WithError "vault set does not accept the value on the command line"
+    }
+
+    $secure = Read-Host -AsSecureString "Enter value for '$key'"
+    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
+    try {
+        $value = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+    } finally {
+        if ($bstr -ne [IntPtr]::Zero) {
+            [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+        }
+    }
+
+    Write-WinsmuxVaultCredentialInternal -Key $key -Value $value
 }
 
 function Invoke-VaultGet {


### PR DESCRIPTION
## Summary
- TASK-677 second cut: `winsmux vault set` rejects Rest/argv, including an empty token. The secret is stored only from the SecureString prompt (production) or `Write-WinsmuxVaultCredentialInternal` (tests).
- Both copies of `Invoke-VaultSet` change (`scripts/winsmux-core.ps1` and `winsmux-core/scripts/vault.ps1`). Docs drop `<value>` from the command line.
- Grok design APPROVE. Sol REQUEST_CHANGES on `if ($Rest)` truthiness; Terra APPROVE on the length check. Local Runtime.VaultInject 7/7 and v03626 split gate 5/5 green.

## Test plan
- [x] `tests/Runtime.VaultInject.Tests.ps1` (store via helper; reject non-empty Rest; reject `@('')`; get/list)
- [x] `tests/V03626DesktopSplitGate.Tests.ps1`
- [ ] CI Tests + Merge Gate + Desktop
- [ ] GitHub Codex Bot on merge-intent head `fb19a694`

Do not merge until Tests and Merge Gate are green. tag / npm はこの PR の仕事ではない.
