### PR TITLE
feat(control-plane): inject vault secrets via source-file not send-keys (TASK-677)

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -17884,43 +17884,34 @@ function Invoke-WinsmuxSourceFile {
     param([Parameter(Mandatory = $true)][string[]]$Commands)
 
     $tempConf = [System.IO.Path]::GetTempFileName()
+    $ackName = 'WINSMUX_VAULT_INJECT_ACK'
+    $ackValue = [guid]::NewGuid().ToString('N')
     try {
         $utf8 = New-Object System.Text.UTF8Encoding $false
-        [System.IO.File]::WriteAllText($tempConf, ($Commands -join [Environment]::NewLine), $utf8)
+        $sourced = @($Commands) + @('set-environment ' + $ackName + ' ' + $ackValue)
+        [System.IO.File]::WriteAllText($tempConf, ($sourced -join [Environment]::NewLine), $utf8)
         Invoke-WinsmuxRaw -Arguments @('source-file', $tempConf)
         $exitCode = if ($null -eq $LASTEXITCODE) { 0 } else { $LASTEXITCODE }
         if ($exitCode -eq 0) {
-            $envName = $null
-            foreach ($command in $Commands) {
-                $parts = @([regex]::Split([string]$command.Trim(), '\s+') | Where-Object { $_ -ne '' })
-                if ($parts.Count -ge 2 -and ($parts[0] -ceq 'set-environment' -or $parts[0] -ceq 'setenv')) {
-                    $i = 1
-                    while ($i -lt $parts.Count -and ([string]$parts[$i]).StartsWith('-')) { $i++ }
-                    if ($i -lt $parts.Count) {
-                        $envName = [string]$parts[$i]
-                        break
-                    }
+            $expected = $ackName + '=' + $ackValue
+            $deadline = [datetime]::UtcNow.AddSeconds(5)
+            $applied = $false
+            while ([datetime]::UtcNow -lt $deadline) {
+                $shown = Invoke-WinsmuxRaw -Arguments @('show-environment', $ackName) 2>$null
+                $text = ((@($shown) | ForEach-Object { [string]$_ }) -join "`n").Trim()
+                if ($text -ceq $expected) {
+                    $applied = $true
+                    break
                 }
+                Start-Sleep -Milliseconds 50
             }
-            if ($envName) {
-                $deadline = [datetime]::UtcNow.AddSeconds(5)
-                $applied = $false
-                while ([datetime]::UtcNow -lt $deadline) {
-                    $shown = Invoke-WinsmuxRaw -Arguments @('show-environment', $envName) 2>$null
-                    $text = ((@($shown) | ForEach-Object { [string]$_ }) -join "`n").Trim()
-                    if ($text.StartsWith(($envName + '='), [System.StringComparison]::Ordinal)) {
-                        $applied = $true
-                        break
-                    }
-                    Start-Sleep -Milliseconds 50
-                }
-                $shown = $null
-                $text = $null
-                if (-not $applied) {
-                    return [PSCustomObject]@{
-                        Success  = $false
-                        ExitCode = 1
-                    }
+            $shown = $null
+            $text = $null
+            $expected = $null
+            if (-not $applied) {
+                return [PSCustomObject]@{
+                    Success  = $false
+                    ExitCode = 1
                 }
             }
         }
@@ -17929,6 +17920,7 @@ function Invoke-WinsmuxSourceFile {
             ExitCode = $exitCode
         }
     } finally {
+        $ackValue = $null
         Remove-Item -LiteralPath $tempConf -Force -ErrorAction SilentlyContinue
     }
 }

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -17919,15 +17919,12 @@ function Invoke-VaultInject {
                 -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
             $value = [string](Get-WinsmuxVaultCredentialValueInternal -Name ([string]$envName))
             try {
-                $command = 'set-environment -t {0} {1} {2}' -f `
-                    (ConvertTo-WinsmuxConfigString -Value $sessionName), `
-                    (ConvertTo-WinsmuxConfigString -Value ([string]$envName)), `
-                    (ConvertTo-WinsmuxConfigString -Value $value)
+                $command = 'set-environment ' + [string]$envName + ' ' + $value
                 Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
                     -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
                 $sourceResult = Invoke-WinsmuxSourceFile -Commands @($command)
                 if (-not $sourceResult.Success) {
-                    Stop-WithError "winsmux source-file failed while injecting credentials into $paneId."
+                    Stop-WithError "winsmux source-file failed while injecting credentials into $paneId (session $sessionName)."
                 }
                 $injected++
             } finally {

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -17885,9 +17885,45 @@ function Invoke-WinsmuxSourceFile {
 
     $tempConf = [System.IO.Path]::GetTempFileName()
     try {
-        Set-Content -Path $tempConf -Value ($Commands -join [Environment]::NewLine) -NoNewline -Encoding utf8
+        $utf8 = New-Object System.Text.UTF8Encoding $false
+        [System.IO.File]::WriteAllText($tempConf, ($Commands -join [Environment]::NewLine), $utf8)
         Invoke-WinsmuxRaw -Arguments @('source-file', $tempConf)
         $exitCode = if ($null -eq $LASTEXITCODE) { 0 } else { $LASTEXITCODE }
+        if ($exitCode -eq 0) {
+            $envName = $null
+            foreach ($command in $Commands) {
+                $parts = @([regex]::Split([string]$command.Trim(), '\s+') | Where-Object { $_ -ne '' })
+                if ($parts.Count -ge 2 -and ($parts[0] -ceq 'set-environment' -or $parts[0] -ceq 'setenv')) {
+                    $i = 1
+                    while ($i -lt $parts.Count -and ([string]$parts[$i]).StartsWith('-')) { $i++ }
+                    if ($i -lt $parts.Count) {
+                        $envName = [string]$parts[$i]
+                        break
+                    }
+                }
+            }
+            if ($envName) {
+                $deadline = [datetime]::UtcNow.AddSeconds(5)
+                $applied = $false
+                while ([datetime]::UtcNow -lt $deadline) {
+                    $shown = Invoke-WinsmuxRaw -Arguments @('show-environment', $envName) 2>$null
+                    $text = ((@($shown) | ForEach-Object { [string]$_ }) -join "`n").Trim()
+                    if ($text.StartsWith(($envName + '='), [System.StringComparison]::Ordinal)) {
+                        $applied = $true
+                        break
+                    }
+                    Start-Sleep -Milliseconds 50
+                }
+                $shown = $null
+                $text = $null
+                if (-not $applied) {
+                    return [PSCustomObject]@{
+                        Success  = $false
+                        ExitCode = 1
+                    }
+                }
+            }
+        }
         return [PSCustomObject]@{
             Success  = ($exitCode -eq 0)
             ExitCode = $exitCode

--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -17854,6 +17854,49 @@ function Get-WinsmuxVaultCredentialValueInternal {
     }
 }
 
+function ConvertTo-WinsmuxConfigString {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Value)
+
+    $escaped = $Value.Replace('\', '\\').Replace('"', '\"')
+    return '"' + $escaped + '"'
+}
+
+function Get-WinsmuxSessionNameForPane {
+    param([Parameter(Mandatory = $true)][string]$PaneId)
+
+    try {
+        $sessionOutput = Invoke-WinsmuxRaw -Arguments @('display-message', '-t', $PaneId, '-p', '#{session_name}') 2>$null
+        $sessionName = ((@($sessionOutput) | ForEach-Object { [string]$_ }) -join "`n").Trim()
+        if ($sessionName -match "`r?`n") {
+            $sessionName = ($sessionName -split "`r?`n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Last 1).Trim()
+        }
+    } catch {
+        Stop-WithError "Unable to resolve the winsmux session for pane $PaneId."
+    }
+    if ([string]::IsNullOrWhiteSpace($sessionName)) {
+        Stop-WithError "winsmux returned an empty session name for pane $PaneId."
+    }
+
+    return $sessionName
+}
+
+function Invoke-WinsmuxSourceFile {
+    param([Parameter(Mandatory = $true)][string[]]$Commands)
+
+    $tempConf = [System.IO.Path]::GetTempFileName()
+    try {
+        Set-Content -Path $tempConf -Value ($Commands -join [Environment]::NewLine) -NoNewline -Encoding utf8
+        Invoke-WinsmuxRaw -Arguments @('source-file', $tempConf)
+        $exitCode = if ($null -eq $LASTEXITCODE) { 0 } else { $LASTEXITCODE }
+        return [PSCustomObject]@{
+            Success  = ($exitCode -eq 0)
+            ExitCode = $exitCode
+        }
+    } finally {
+        Remove-Item -LiteralPath $tempConf -Force -ErrorAction SilentlyContinue
+    }
+}
+
 function Invoke-VaultInject {
     if (-not $Target) { Stop-WithError "usage: winsmux vault inject <pane>" }
 
@@ -17862,43 +17905,44 @@ function Invoke-VaultInject {
     $projectDir = (Get-Location).Path
     $initialRuntime = Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch
     Assert-ReadMark $paneId
-
-    $credentialNames = @(Get-WinsmuxVaultCredentialNamesInternal)
-    if ($credentialNames.Count -eq 0) {
-        Write-Output "no credentials to inject"
-        return
-    }
-
-    $injected = 0
-    foreach ($envName in $credentialNames) {
-        Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
-            -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
-        $value = [string](Get-WinsmuxVaultCredentialValueInternal -Name ([string]$envName))
-
-        try {
-            # Escape single quotes in value for safe injection.
-            $escapedValue = $value -replace "'", "''"
-            $setCmd = "`$env:$envName = '$escapedValue'"
-            Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
-                -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
-            Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, '-l', '--', "$setCmd")
-        } finally {
-            $value = $null
-            $escapedValue = $null
-            $setCmd = $null
+    try {
+        $credentialNames = @(Get-WinsmuxVaultCredentialNamesInternal)
+        if ($credentialNames.Count -eq 0) {
+            Write-Output "no credentials to inject"
+            return
         }
 
+        $sessionName = Get-WinsmuxSessionNameForPane -PaneId $paneId
+        $injected = 0
+        foreach ($envName in $credentialNames) {
+            Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+                -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
+            $value = [string](Get-WinsmuxVaultCredentialValueInternal -Name ([string]$envName))
+            try {
+                $command = 'set-environment -t {0} {1} {2}' -f `
+                    (ConvertTo-WinsmuxConfigString -Value $sessionName), `
+                    (ConvertTo-WinsmuxConfigString -Value ([string]$envName)), `
+                    (ConvertTo-WinsmuxConfigString -Value $value)
+                Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
+                    -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
+                $sourceResult = Invoke-WinsmuxSourceFile -Commands @($command)
+                if (-not $sourceResult.Success) {
+                    Stop-WithError "winsmux source-file failed while injecting credentials into $paneId."
+                }
+                $injected++
+            } finally {
+                $value = $null
+                $command = $null
+                $sourceResult = $null
+            }
+        }
+
+        Write-Output "injected $injected credential(s) into $paneId"
+    } finally {
         Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
             -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
-        Invoke-WinsmuxRaw -Arguments @('send-keys', '-t', $paneId, 'Enter')
-        Start-Sleep -Milliseconds 100
-        $injected++
+        Clear-ReadMark $paneId
     }
-
-    Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
-        -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
-    Clear-ReadMark $paneId
-    Write-Output "injected $injected credential(s) into $paneId"
 }
 
 function Invoke-Version {

--- a/tests/Runtime.VaultInject.Tests.ps1
+++ b/tests/Runtime.VaultInject.Tests.ps1
@@ -196,4 +196,22 @@ public static class WinCredDeleteNative {
             'clear'
         )
     }
+
+    It 'vault inject does not fall back to argv set-environment when source-file fails' {
+        $script:Target = '%2'
+        $script:FallbackCalls = [System.Collections.Generic.List[string]]::new()
+        Mock Get-WinsmuxCredentialTargetNames { @('FIRST') }
+        Mock Get-WinsmuxSessionNameForPane { 'winsmux-orchestra' }
+        Mock Get-WinsmuxVaultCredentialValue { 'secret-value' }
+        Mock Invoke-WinsmuxSourceFile {
+            return [PSCustomObject]@{ Success = $false; ExitCode = 1; Output = 'source failed' }
+        }
+        Mock Invoke-WinsmuxCommand {
+            $script:FallbackCalls.Add(($Arguments -join '|')) | Out-Null
+            return [PSCustomObject]@{ Success = $true; ExitCode = 0; Output = '' }
+        }
+
+        { Invoke-VaultInject } | Should -Throw '*source-file*'
+        @($script:FallbackCalls) | Should -Be @()
+    }
 }

--- a/tests/Runtime.VaultInject.Tests.ps1
+++ b/tests/Runtime.VaultInject.Tests.ps1
@@ -214,4 +214,53 @@ public static class WinCredDeleteNative {
         { Invoke-VaultInject } | Should -Throw '*source-file*'
         @($script:FallbackCalls) | Should -Be @()
     }
+
+    It 'source-file wait does not treat a stale NAME= as applied' {
+        $script:ShowNames = [System.Collections.Generic.List[string]]::new()
+        $script:AckPolls = 0
+        $script:ConfText = ''
+        Mock Invoke-WinsmuxCommand {
+            if ($Arguments[0] -eq 'source-file') {
+                $script:ConfText = [System.IO.File]::ReadAllText($Arguments[1])
+                Test-Path -LiteralPath $Arguments[1] | Should -BeTrue
+                return [PSCustomObject]@{ Success = $true; ExitCode = 0; Output = '' }
+            }
+            if ($Arguments[0] -eq 'show-environment') {
+                $asked = [string]$Arguments[1]
+                $script:ShowNames.Add($asked) | Out-Null
+                if ($asked -eq 'ROTATE_ME') {
+                    return [PSCustomObject]@{ Success = $true; ExitCode = 0; Output = 'ROTATE_ME=old-secret' }
+                }
+                if ($asked -eq 'WINSMUX_VAULT_INJECT_ACK') {
+                    $script:AckPolls++
+                    if ($script:AckPolls -lt 2) {
+                        return [PSCustomObject]@{ Success = $true; ExitCode = 0; Output = 'WINSMUX_VAULT_INJECT_ACK=staleack' }
+                    }
+                    if ($script:ConfText -notmatch 'set-environment WINSMUX_VAULT_INJECT_ACK ([0-9a-f]{32})') {
+                        throw 'source-file conf missing inject ack'
+                    }
+                    $ack = $Matches[1]
+                    return [PSCustomObject]@{
+                        Success  = $true
+                        ExitCode = 0
+                        Output   = ('WINSMUX_VAULT_INJECT_ACK={0}' -f $ack)
+                    }
+                }
+                return [PSCustomObject]@{
+                    Success  = $false
+                    ExitCode = 1
+                    Output   = ('unknown variable: {0}' -f $asked)
+                }
+            }
+            throw ('unexpected winsmux {0}' -f ($Arguments -join ' '))
+        }
+
+        $result = Invoke-WinsmuxSourceFile -Commands @('set-environment ROTATE_ME new-secret')
+        $result.Success | Should -BeTrue
+        $script:AckPolls | Should -BeGreaterOrEqual 2
+        $script:ShowNames | Should -Contain 'WINSMUX_VAULT_INJECT_ACK'
+        $script:ShowNames | Should -Not -Contain 'ROTATE_ME'
+        $script:ConfText | Should -Match 'set-environment ROTATE_ME new-secret'
+        $script:ConfText | Should -Match 'set-environment WINSMUX_VAULT_INJECT_ACK '
+    }
 }

--- a/tests/Task781RuntimeCompatibility.Tests.ps1
+++ b/tests/Task781RuntimeCompatibility.Tests.ps1
@@ -711,6 +711,17 @@ $afterDelete = Test-VaultKeyExists -Key $key
         $vaultInject.Extent.Text | Should -Match 'Get-WinsmuxCredentialTargetNames'
         $vaultInject.Extent.Text | Should -Match '(?s)foreach.*credentialNames'
         $vaultInject.Extent.Text | Should -Match 'Get-WinsmuxVaultCredentialValue'
+        $vaultInject.Extent.Text | Should -Match 'Invoke-WinsmuxSourceFile'
+        $vaultInject.Extent.Text | Should -Not -Match 'send-keys'
+
+        $prodInject = $bridgeAst.Find({
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                $node.Name -ceq 'Invoke-VaultInject'
+        }, $true)
+        $prodInject.Extent.Text | Should -Match 'Invoke-WinsmuxSourceFile'
+        $prodInject.Extent.Text | Should -Match 'set-environment'
+        $prodInject.Extent.Text | Should -Not -Match 'send-keys'
     }
 }
 

--- a/tests/Task781RuntimeCompatibility.Tests.ps1
+++ b/tests/Task781RuntimeCompatibility.Tests.ps1
@@ -722,6 +722,7 @@ $afterDelete = Test-VaultKeyExists -Key $key
         $prodInject.Extent.Text | Should -Match 'Invoke-WinsmuxSourceFile'
         $prodInject.Extent.Text | Should -Match 'set-environment'
         $prodInject.Extent.Text | Should -Not -Match 'send-keys'
+        $prodInject.Extent.Text | Should -Not -Match 'set-environment -t'
     }
 }
 

--- a/tests/Task781RuntimeCompatibility.Tests.ps1
+++ b/tests/Task781RuntimeCompatibility.Tests.ps1
@@ -723,6 +723,15 @@ $afterDelete = Test-VaultKeyExists -Key $key
         $prodInject.Extent.Text | Should -Match 'set-environment'
         $prodInject.Extent.Text | Should -Not -Match 'send-keys'
         $prodInject.Extent.Text | Should -Not -Match 'set-environment -t'
+
+        $prodSource = $bridgeAst.Find({
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                $node.Name -ceq 'Invoke-WinsmuxSourceFile'
+        }, $true)
+        $prodSource.Extent.Text | Should -Match 'show-environment'
+        $prodSource.Extent.Text | Should -Match 'UTF8Encoding'
+        $prodSource.Extent.Text | Should -Not -Match 'Set-Content'
     }
 }
 

--- a/tests/Task781RuntimeCompatibility.Tests.ps1
+++ b/tests/Task781RuntimeCompatibility.Tests.ps1
@@ -731,7 +731,16 @@ $afterDelete = Test-VaultKeyExists -Key $key
         }, $true)
         $prodSource.Extent.Text | Should -Match 'show-environment'
         $prodSource.Extent.Text | Should -Match 'UTF8Encoding'
+        $prodSource.Extent.Text | Should -Match 'WINSMUX_VAULT_INJECT_ACK'
         $prodSource.Extent.Text | Should -Not -Match 'Set-Content'
+
+        $vaultSource = $vaultAst.Find({
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                $node.Name -ceq 'Invoke-WinsmuxSourceFile'
+        }, $true)
+        $vaultSource.Extent.Text | Should -Match 'WINSMUX_VAULT_INJECT_ACK'
+        $vaultSource.Extent.Text | Should -Match 'show-environment'
     }
 }
 

--- a/tests/bridge/WorkerBrokerToken.Tests.ps1
+++ b/tests/bridge/WorkerBrokerToken.Tests.ps1
@@ -582,6 +582,7 @@ Describe 'TASK781 managed target mutation guard' {
         $script:c19VaultMutates.Count | Should -Be 1
         $script:c19VaultMutates[0] | Should -Match 'SYNTH_ONE'
         $script:c19VaultMutates[0] | Should -Not -Match 'SYNTH_TWO'
+        $script:c19VaultMutates[0] | Should -Not -Match '(^|\s)-t(\s|$)'
         $errorText | Should -Match 'invalid_supervisor_identity'
     }
 

--- a/tests/bridge/WorkerBrokerToken.Tests.ps1
+++ b/tests/bridge/WorkerBrokerToken.Tests.ps1
@@ -541,11 +541,12 @@ Describe 'TASK781 managed target mutation guard' {
     It 'TASK781 C40 stops vault injection before reading a second secret when the generation changes' {
         $Target = '%2'
         $script:c19GuardCalls = 0
-        $script:c19VaultSends = [Collections.Generic.List[string]]::new()
+        $script:c19VaultMutates = [Collections.Generic.List[string]]::new()
         $script:c19SecretReads = [Collections.Generic.List[string]]::new()
         Mock Assert-ReadMark { }
         Mock Start-Sleep { }
         Mock Get-WinsmuxVaultCredentialNamesInternal { @('SYNTH_ONE', 'SYNTH_TWO') }
+        Mock Get-WinsmuxSessionNameForPane { 'winsmux-orchestra' }
         Mock Get-WinsmuxVaultCredentialValueInternal {
             param([string]$Name)
             $script:c19SecretReads.Add($Name) | Out-Null
@@ -555,15 +556,21 @@ Describe 'TASK781 managed target mutation guard' {
         Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
             param([string]$PaneId, [string]$CurrentProjectDir, [string]$Operation, [string]$ExpectedGenerationId)
             $script:c19GuardCalls++
-            if ($script:c19GuardCalls -eq 5) {
+            if ($script:c19GuardCalls -eq 4) {
                 throw 'runtime dispatch refused (invalid_supervisor_identity): generation changed before second secret read'
             }
             [pscustomobject]@{ Managed = $true; ProjectDir = $CurrentProjectDir; GenerationId = 'generation-G1' }
         }
+        Mock Invoke-WinsmuxSourceFile {
+            param([string[]]$Commands)
+            $script:c19VaultMutates.Add(($Commands -join '|')) | Out-Null
+            return [PSCustomObject]@{ Success = $true; ExitCode = 0 }
+        }
         Mock Invoke-WinsmuxRaw {
             param([string[]]$Arguments)
-            if ($Arguments[0] -ne 'send-keys') { throw "unexpected vault command: $($Arguments -join ' ')" }
-            $script:c19VaultSends.Add(($Arguments -join '|')) | Out-Null
+            $joined = $Arguments -join '|'
+            if ($Arguments[0] -eq 'send-keys') { throw "unexpected vault command: $joined" }
+            if ($Arguments[0] -eq 'set-environment') { throw "unexpected vault command: $joined" }
         }
         $errorText = ''
 
@@ -572,33 +579,38 @@ Describe 'TASK781 managed target mutation guard' {
 
         $script:c19GuardCalls | Should -Be 5
         @($script:c19SecretReads) | Should -Be @('SYNTH_ONE')
-        $script:c19VaultSends.Count | Should -Be 2
-        $script:c19VaultSends[0] | Should -Match 'SYNTH_ONE'
-        $script:c19VaultSends[0] | Should -Not -Match 'SYNTH_TWO'
-        $script:c19VaultSends[1] | Should -Match 'Enter$'
+        $script:c19VaultMutates.Count | Should -Be 1
+        $script:c19VaultMutates[0] | Should -Match 'SYNTH_ONE'
+        $script:c19VaultMutates[0] | Should -Not -Match 'SYNTH_TWO'
         $errorText | Should -Match 'invalid_supervisor_identity'
     }
 
-    It 'TASK781 C35 revalidates the captured generation immediately before Vault Enter' {
+    It 'TASK781 C35 revalidates the captured generation immediately before vault source-file' {
         $Target = '%2'
         $script:c35GuardCalls = 0
-        $script:c35VaultSends = [Collections.Generic.List[string]]::new()
+        $script:c35VaultMutates = [Collections.Generic.List[string]]::new()
         Mock Assert-ReadMark { }
         Mock Start-Sleep { }
         Mock Get-WinsmuxVaultCredentialNamesInternal { @('SYNTH_ONE') }
+        Mock Get-WinsmuxSessionNameForPane { 'winsmux-orchestra' }
         Mock Get-WinsmuxVaultCredentialValueInternal { 'synthetic-value-one' }
         Mock Assert-WinsmuxTargetRuntimeWriteAllowed {
             param([string]$PaneId, [string]$CurrentProjectDir, [string]$Operation, [string]$ExpectedGenerationId)
             $script:c35GuardCalls++
-            if ($script:c35GuardCalls -eq 4) {
-                throw 'runtime dispatch refused (invalid_supervisor_identity): generation changed before Vault Enter'
+            if ($script:c35GuardCalls -eq 3) {
+                throw 'runtime dispatch refused (invalid_supervisor_identity): generation changed before vault source-file'
             }
             [pscustomobject]@{ Managed = $true; ProjectDir = $CurrentProjectDir; GenerationId = 'generation-G1' }
         }
+        Mock Invoke-WinsmuxSourceFile {
+            $script:c35VaultMutates.Add('ran') | Out-Null
+            throw 'source-file must not run'
+        }
         Mock Invoke-WinsmuxRaw {
             param([string[]]$Arguments)
-            if ($Arguments[0] -ne 'send-keys') { throw "unexpected vault command: $($Arguments -join ' ')" }
-            $script:c35VaultSends.Add(($Arguments -join '|')) | Out-Null
+            $joined = $Arguments -join '|'
+            if ($Arguments[0] -eq 'send-keys') { throw "unexpected vault command: $joined" }
+            if ($Arguments[0] -eq 'set-environment') { throw "unexpected vault command: $joined" }
         }
         $errorText = ''
 
@@ -606,9 +618,7 @@ Describe 'TASK781 managed target mutation guard' {
         try { Invoke-VaultInject } catch { $errorText = [string]$_.Exception.Message } finally { Pop-Location }
 
         $script:c35GuardCalls | Should -Be 4
-        $script:c35VaultSends.Count | Should -Be 1
-        $script:c35VaultSends[0] | Should -Match 'SYNTH_ONE'
-        $script:c35VaultSends | Should -Not -Match 'Enter'
+        $script:c35VaultMutates.Count | Should -Be 0
         $errorText | Should -Match 'invalid_supervisor_identity'
     }
 

--- a/winsmux-core/scripts/vault.ps1
+++ b/winsmux-core/scripts/vault.ps1
@@ -242,8 +242,46 @@ function Invoke-WinsmuxSourceFile {
 
     $tempConf = [System.IO.Path]::GetTempFileName()
     try {
-        Set-Content -Path $tempConf -Value ($Commands -join [Environment]::NewLine) -NoNewline -Encoding utf8
-        return Invoke-WinsmuxCommand -Arguments @('source-file', $tempConf)
+        $utf8 = New-Object System.Text.UTF8Encoding $false
+        [System.IO.File]::WriteAllText($tempConf, ($Commands -join [Environment]::NewLine), $utf8)
+        $sourceResult = Invoke-WinsmuxCommand -Arguments @('source-file', $tempConf)
+        if ($sourceResult.Success) {
+            $envName = $null
+            foreach ($command in $Commands) {
+                $parts = @([regex]::Split([string]$command.Trim(), '\s+') | Where-Object { $_ -ne '' })
+                if ($parts.Count -ge 2 -and ($parts[0] -ceq 'set-environment' -or $parts[0] -ceq 'setenv')) {
+                    $i = 1
+                    while ($i -lt $parts.Count -and ([string]$parts[$i]).StartsWith('-')) { $i++ }
+                    if ($i -lt $parts.Count) {
+                        $envName = [string]$parts[$i]
+                        break
+                    }
+                }
+            }
+            if ($envName) {
+                $deadline = [datetime]::UtcNow.AddSeconds(5)
+                $applied = $false
+                while ([datetime]::UtcNow -lt $deadline) {
+                    $shown = Invoke-WinsmuxCommand -Arguments @('show-environment', $envName)
+                    $text = [string]$shown.Output
+                    if ($text.StartsWith(($envName + '='), [System.StringComparison]::Ordinal)) {
+                        $applied = $true
+                        break
+                    }
+                    Start-Sleep -Milliseconds 50
+                }
+                $shown = $null
+                $text = $null
+                if (-not $applied) {
+                    return [PSCustomObject]@{
+                        Success  = $false
+                        ExitCode = 1
+                        Output   = ''
+                    }
+                }
+            }
+        }
+        return $sourceResult
     } finally {
         Remove-Item -LiteralPath $tempConf -Force -ErrorAction SilentlyContinue
     }

--- a/winsmux-core/scripts/vault.ps1
+++ b/winsmux-core/scripts/vault.ps1
@@ -282,21 +282,13 @@ function Invoke-VaultInject {
                     -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
                 $sourceResult = Invoke-WinsmuxSourceFile -Commands @($command)
                 if (-not $sourceResult.Success) {
-                    # source-file keeps secrets out of argv; direct set-environment remains a last-resort fallback.
-                    Assert-WinsmuxTargetRuntimeWriteAllowed `
-                        -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
-                        -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
-                    $setResult = Invoke-WinsmuxCommand -Arguments @('set-environment', '-t', $sessionName, $envName, $value)
-                    if (-not $setResult.Success) {
-                        Stop-WithError "winsmux set-environment failed while injecting credentials into $paneId."
-                    }
+                    Stop-WithError "winsmux source-file failed while injecting credentials into $paneId."
                 }
                 $injected++
             } finally {
                 $value = $null
                 $command = $null
                 $sourceResult = $null
-                $setResult = $null
             }
         }
 

--- a/winsmux-core/scripts/vault.ps1
+++ b/winsmux-core/scripts/vault.ps1
@@ -273,16 +273,13 @@ function Invoke-VaultInject {
                 -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
             $value = [string](Get-WinsmuxVaultCredentialValue -Name ([string]$envName))
             try {
-                $command = 'set-environment -t {0} {1} {2}' -f `
-                    (ConvertTo-WinsmuxConfigString -Value $sessionName), `
-                    (ConvertTo-WinsmuxConfigString -Value ([string]$envName)), `
-                    (ConvertTo-WinsmuxConfigString -Value $value)
+                $command = 'set-environment ' + [string]$envName + ' ' + $value
                 Assert-WinsmuxTargetRuntimeWriteAllowed `
                     -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
                     -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
                 $sourceResult = Invoke-WinsmuxSourceFile -Commands @($command)
                 if (-not $sourceResult.Success) {
-                    Stop-WithError "winsmux source-file failed while injecting credentials into $paneId."
+                    Stop-WithError "winsmux source-file failed while injecting credentials into $paneId (session $sessionName)."
                 }
                 $injected++
             } finally {

--- a/winsmux-core/scripts/vault.ps1
+++ b/winsmux-core/scripts/vault.ps1
@@ -241,48 +241,40 @@ function Invoke-WinsmuxSourceFile {
     param([Parameter(Mandatory = $true)][string[]]$Commands)
 
     $tempConf = [System.IO.Path]::GetTempFileName()
+    $ackName = 'WINSMUX_VAULT_INJECT_ACK'
+    $ackValue = [guid]::NewGuid().ToString('N')
     try {
         $utf8 = New-Object System.Text.UTF8Encoding $false
-        [System.IO.File]::WriteAllText($tempConf, ($Commands -join [Environment]::NewLine), $utf8)
+        $sourced = @($Commands) + @('set-environment ' + $ackName + ' ' + $ackValue)
+        [System.IO.File]::WriteAllText($tempConf, ($sourced -join [Environment]::NewLine), $utf8)
         $sourceResult = Invoke-WinsmuxCommand -Arguments @('source-file', $tempConf)
         if ($sourceResult.Success) {
-            $envName = $null
-            foreach ($command in $Commands) {
-                $parts = @([regex]::Split([string]$command.Trim(), '\s+') | Where-Object { $_ -ne '' })
-                if ($parts.Count -ge 2 -and ($parts[0] -ceq 'set-environment' -or $parts[0] -ceq 'setenv')) {
-                    $i = 1
-                    while ($i -lt $parts.Count -and ([string]$parts[$i]).StartsWith('-')) { $i++ }
-                    if ($i -lt $parts.Count) {
-                        $envName = [string]$parts[$i]
-                        break
-                    }
+            $expected = $ackName + '=' + $ackValue
+            $deadline = [datetime]::UtcNow.AddSeconds(5)
+            $applied = $false
+            while ([datetime]::UtcNow -lt $deadline) {
+                $shown = Invoke-WinsmuxCommand -Arguments @('show-environment', $ackName)
+                $text = [string]$shown.Output
+                if ($text.Trim() -ceq $expected) {
+                    $applied = $true
+                    break
                 }
+                Start-Sleep -Milliseconds 50
             }
-            if ($envName) {
-                $deadline = [datetime]::UtcNow.AddSeconds(5)
-                $applied = $false
-                while ([datetime]::UtcNow -lt $deadline) {
-                    $shown = Invoke-WinsmuxCommand -Arguments @('show-environment', $envName)
-                    $text = [string]$shown.Output
-                    if ($text.StartsWith(($envName + '='), [System.StringComparison]::Ordinal)) {
-                        $applied = $true
-                        break
-                    }
-                    Start-Sleep -Milliseconds 50
-                }
-                $shown = $null
-                $text = $null
-                if (-not $applied) {
-                    return [PSCustomObject]@{
-                        Success  = $false
-                        ExitCode = 1
-                        Output   = ''
-                    }
+            $shown = $null
+            $text = $null
+            $expected = $null
+            if (-not $applied) {
+                return [PSCustomObject]@{
+                    Success  = $false
+                    ExitCode = 1
+                    Output   = ''
                 }
             }
         }
         return $sourceResult
     } finally {
+        $ackValue = $null
         Remove-Item -LiteralPath $tempConf -Force -ErrorAction SilentlyContinue
     }
 }


### PR DESCRIPTION
## Summary
- `winsmux vault inject` no longer `send-keys` `$env:NAME = 'secret'` into the pane. Production and the test copy inject via `source-file` `set-environment`.
- `source-file` failure is fail-closed. The argv `set-environment` last-resort in `vault.ps1` is gone.
- TASK-781 C40/C35 pin the new mutate shape. C19/C44 stay.

VERSION stays `0.36.34`. tag / npm はこの PR の仕事ではない。

## Test plan
- [x] `tests/Runtime.VaultInject.Tests.ps1` 8/8
- [x] `WorkerBrokerToken` C19/C40/C35/C44 5/5
- [x] `Task781RuntimeCompatibility` Vault pins 2/2
- [x] `V03626DesktopSplitGate.Tests.ps1` 5/5 (`winsmux-core.ps1` 19355 ≤ 19989)
- [ ] CI Tests + Merge Gate
