### PR TITLE
fix(control-plane): unique vault inject ACK names (TASK-677)

### DIFF
--- a/scripts/winsmux-core.ps1
+++ b/scripts/winsmux-core.ps1
@@ -17881,76 +17881,130 @@ function Get-WinsmuxSessionNameForPane {
 }
 
 function Invoke-WinsmuxSourceFile {
-    param([Parameter(Mandatory = $true)][string[]]$Commands)
+    param(
+        [Parameter(Mandatory = $true)][string[]]$Commands,
+        [Parameter(Mandatory = $true)][string[]]$CredentialNames
+    )
 
-    $ackName = 'WINSMUX_VAULT_INJECT_ACK'
-    $ackValue = [guid]::NewGuid().ToString('N')
-    $tempConf = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-src-' + [guid]::NewGuid().ToString('N') + '.conf')
-    $stream = $null
-    $ownedTemp = $false
-    try {
-        $FileSecurity = New-Object System.Security.AccessControl.FileSecurity
-        $FileSecurity.SetAccessRuleProtection($true, $false)
-        $FileSecurity.SetAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule(
-            [Security.Principal.WindowsIdentity]::GetCurrent().User,
-            [System.Security.AccessControl.FileSystemRights]::FullControl,
-            [System.Security.AccessControl.AccessControlType]::Allow
-        )))
-        try {
-            $stream = New-Object System.IO.FileStream($tempConf, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None, 4096, [System.IO.FileOptions]::None, $FileSecurity)
-            $ownedTemp = $true
-        } catch {
-            if (Test-Path -LiteralPath $tempConf) {
-                throw
-            }
-            $stream = [System.IO.FileSystemAclExtensions]::Create((New-Object System.IO.FileInfo($tempConf)), [System.IO.FileMode]::CreateNew, [System.Security.AccessControl.FileSystemRights]::FullControl, [System.IO.FileShare]::None, 4096, [System.IO.FileOptions]::None, $FileSecurity)
-            $ownedTemp = $true
-        }
-        $utf8 = New-Object System.Text.UTF8Encoding $false
-        $sourced = @($Commands) + @('set-environment ' + $ackName + ' ' + $ackValue)
-        $bytes = $utf8.GetBytes(($sourced -join [Environment]::NewLine))
-        $stream.Write($bytes, 0, $bytes.Length)
-        $stream.Dispose()
-        $stream = $null
-        Invoke-WinsmuxRaw -Arguments @('source-file', $tempConf)
-        $exitCode = if ($null -eq $LASTEXITCODE) { 0 } else { $LASTEXITCODE }
-        if ($exitCode -eq 0) {
-            $expected = $ackName + '=' + $ackValue
-            $deadline = [datetime]::UtcNow.AddSeconds(5)
-            $applied = $false
-            while ([datetime]::UtcNow -lt $deadline) {
-                $shown = Invoke-WinsmuxRaw -Arguments @('show-environment', $ackName) 2>$null
-                $text = ((@($shown) | ForEach-Object { [string]$_ }) -join "`n").Trim()
-                if ($text -ceq $expected) {
-                    $applied = $true
-                    break
-                }
-                Start-Sleep -Milliseconds 50
-            }
-            $shown = $null
-            $text = $null
-            $expected = $null
-            if (-not $applied) {
-                return [PSCustomObject]@{
-                    Success  = $false
-                    ExitCode = 1
-                }
+    $ackName = $null
+    $ackNameAttemptLimit = 8
+    for ($attempt = 0; $attempt -lt $ackNameAttemptLimit; $attempt++) {
+        $candidate = 'WINSMUX_VAULT_INJECT_ACK_' + [guid]::NewGuid().ToString('N')
+        $collides = $false
+        foreach ($credentialName in @($CredentialNames)) {
+            if ([string]$credentialName -ceq $candidate) {
+                $collides = $true
+                break
             }
         }
-        return [PSCustomObject]@{
-            Success  = ($exitCode -eq 0)
-            ExitCode = $exitCode
+        if (-not $collides) {
+            $ackName = $candidate
+            break
         }
-    } catch {
+    }
+    if ([string]::IsNullOrEmpty($ackName)) {
         return [PSCustomObject]@{
             Success  = $false
             ExitCode = 1
+        }
+    }
+
+    $ackValue = [guid]::NewGuid().ToString('N')
+    $expectedAck = $ackName + '=' + $ackValue
+    $tempConf = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-src-' + [guid]::NewGuid().ToString('N') + '.conf')
+    $stream = $null
+    $ownedTemp = $false
+    $sourceExitCode = 1
+    $sourceSucceeded = $false
+    $ackObserved = $false
+    $ackCleanupSucceeded = $false
+    $operationFailed = $false
+    try {
+        try {
+            $FileSecurity = New-Object System.Security.AccessControl.FileSecurity
+            $FileSecurity.SetAccessRuleProtection($true, $false)
+            $FileSecurity.SetAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule(
+                [Security.Principal.WindowsIdentity]::GetCurrent().User,
+                [System.Security.AccessControl.FileSystemRights]::FullControl,
+                [System.Security.AccessControl.AccessControlType]::Allow
+            )))
+            try {
+                $stream = New-Object System.IO.FileStream($tempConf, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None, 4096, [System.IO.FileOptions]::None, $FileSecurity)
+                $ownedTemp = $true
+            } catch {
+                if (Test-Path -LiteralPath $tempConf) {
+                    throw
+                }
+                $stream = [System.IO.FileSystemAclExtensions]::Create((New-Object System.IO.FileInfo($tempConf)), [System.IO.FileMode]::CreateNew, [System.Security.AccessControl.FileSystemRights]::FullControl, [System.IO.FileShare]::None, 4096, [System.IO.FileOptions]::None, $FileSecurity)
+                $ownedTemp = $true
+            }
+            $utf8 = New-Object System.Text.UTF8Encoding $false
+            $sourced = @($Commands) + @('set-environment ' + $ackName + ' ' + $ackValue)
+            $bytes = $utf8.GetBytes(($sourced -join [Environment]::NewLine))
+            $stream.Write($bytes, 0, $bytes.Length)
+            $stream.Dispose()
+            $stream = $null
+            $sourceOutput = @(Invoke-WinsmuxRaw -Arguments @('source-file', $tempConf))
+            $sourceExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { $LASTEXITCODE }
+            $sourceSucceeded = ($sourceExitCode -eq 0)
+
+            $deadline = [datetime]::UtcNow.AddSeconds(5)
+            do {
+                $shown = Invoke-WinsmuxRaw -Arguments @('show-environment', $ackName) 2>$null
+                $showExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { $LASTEXITCODE }
+                $text = ((@($shown) | ForEach-Object { [string]$_ }) -join "`n").Trim()
+                if ($showExitCode -eq 0 -and $text -ceq $expectedAck) {
+                    $ackObserved = $true
+                    break
+                }
+                if (-not $sourceSucceeded) {
+                    break
+                }
+                Start-Sleep -Milliseconds 50
+            } while ([datetime]::UtcNow -lt $deadline)
+        } catch {
+            $operationFailed = $true
+            if (-not $ackObserved) {
+                try {
+                    $shown = Invoke-WinsmuxRaw -Arguments @('show-environment', $ackName) 2>$null
+                    $showExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { $LASTEXITCODE }
+                    $text = ((@($shown) | ForEach-Object { [string]$_ }) -join "`n").Trim()
+                    if ($showExitCode -eq 0 -and $text -ceq $expectedAck) {
+                        $ackObserved = $true
+                    }
+                } catch { }
+            }
+        }
+
+        try {
+            $shown = Invoke-WinsmuxRaw -Arguments @('show-environment', $ackName) 2>$null
+            $showExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { $LASTEXITCODE }
+            $text = ((@($shown) | ForEach-Object { [string]$_ }) -join "`n").Trim()
+            if ($showExitCode -eq 0 -and $text -ceq $expectedAck) {
+                $ackObserved = $true
+                $cleanupOutput = @(Invoke-WinsmuxRaw -Arguments @('set-environment', '-u', $ackName) 2>$null)
+                $cleanupExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { $LASTEXITCODE }
+                $ackCleanupSucceeded = ($cleanupExitCode -eq 0)
+            } else {
+                $ackCleanupSucceeded = $false
+            }
+        } catch {
+            $ackCleanupSucceeded = $false
+        }
+
+        $success = (-not $operationFailed) -and $sourceSucceeded -and $ackObserved -and $ackCleanupSucceeded
+        return [PSCustomObject]@{
+            Success  = $success
+            ExitCode = if ($success) { $sourceExitCode } else { 1 }
         }
     } finally {
         if ($null -ne $stream) {
             try { $stream.Dispose() } catch { }
         }
         $ackValue = $null
+        $expectedAck = $null
+        $sourceOutput = $null
+        $cleanupOutput = $null
         if ($ownedTemp) {
             Remove-Item -LiteralPath $tempConf -Force -ErrorAction SilentlyContinue
         }
@@ -17982,7 +18036,7 @@ function Invoke-VaultInject {
                 $command = 'set-environment ' + [string]$envName + ' ' + $value
                 Assert-WinsmuxTargetRuntimeWriteAllowed -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
                     -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
-                $sourceResult = Invoke-WinsmuxSourceFile -Commands @($command)
+                $sourceResult = Invoke-WinsmuxSourceFile -Commands @($command) -CredentialNames $credentialNames
                 if (-not $sourceResult.Success) {
                     Stop-WithError "winsmux source-file failed while injecting credentials into $paneId (session $sessionName)."
                 }

--- a/tests/Runtime.VaultInject.Tests.ps1
+++ b/tests/Runtime.VaultInject.Tests.ps1
@@ -217,8 +217,13 @@ public static class WinCredDeleteNative {
 
     It 'source-file wait does not treat a stale NAME= as applied' {
         $script:ShowNames = [System.Collections.Generic.List[string]]::new()
+        $script:UnsetNames = [System.Collections.Generic.List[string]]::new()
         $script:AckPolls = 0
         $script:ConfText = ''
+        $script:GeneratedAckName = ''
+        $script:GeneratedAckValue = ''
+        $script:CredentialNames = @('WINSMUX_VAULT_INJECT_ACK', 'ROTATE_ME')
+        $script:SimulatedEnvironment = @{}
         Mock Invoke-WinsmuxCommand {
             if ($Arguments[0] -eq 'source-file') {
                 $script:ConfText = [System.IO.File]::ReadAllText($Arguments[1])
@@ -231,27 +236,44 @@ public static class WinCredDeleteNative {
                 [string]$rules[0].IdentityReference | Should -Be ([string]$sid)
                 $rules[0].AccessControlType | Should -Be ([System.Security.AccessControl.AccessControlType]::Allow)
                 $rules[0].FileSystemRights | Should -Be ([System.Security.AccessControl.FileSystemRights]::FullControl)
+
+                $commandLines = @($script:ConfText -split "`r?`n" | Where-Object { $_ -ne '' })
+                foreach ($line in $commandLines) {
+                    if ($line -notmatch '^set-environment ([A-Za-z0-9_]+) (.+)$') {
+                        throw ('unexpected source-file command: {0}' -f $line)
+                    }
+                    $script:SimulatedEnvironment[$Matches[1]] = $Matches[2]
+                }
+                $ackMatches = [regex]::Matches(
+                    $script:ConfText,
+                    '(?m)^set-environment (WINSMUX_VAULT_INJECT_ACK_[0-9a-f]{32}) ([0-9a-f]{32})\r?$'
+                )
+                $ackMatches.Count | Should -Be 1
+                $script:GeneratedAckName = $ackMatches[0].Groups[1].Value
+                $script:GeneratedAckValue = $ackMatches[0].Groups[2].Value
+                @($script:CredentialNames) -ccontains $script:GeneratedAckName | Should -BeFalse
+                $commandLines[-1] | Should -Be ('set-environment {0} {1}' -f $script:GeneratedAckName, $script:GeneratedAckValue)
                 return [PSCustomObject]@{ Success = $true; ExitCode = 0; Output = '' }
             }
             if ($Arguments[0] -eq 'show-environment') {
                 $asked = [string]$Arguments[1]
                 $script:ShowNames.Add($asked) | Out-Null
-                if ($asked -eq 'ROTATE_ME') {
-                    return [PSCustomObject]@{ Success = $true; ExitCode = 0; Output = 'ROTATE_ME=old-secret' }
+                if ($asked -ceq 'WINSMUX_VAULT_INJECT_ACK') {
+                    return [PSCustomObject]@{ Success = $true; ExitCode = 0; Output = 'WINSMUX_VAULT_INJECT_ACK=staleack' }
                 }
-                if ($asked -eq 'WINSMUX_VAULT_INJECT_ACK') {
+                if ($asked -ceq $script:GeneratedAckName) {
                     $script:AckPolls++
                     if ($script:AckPolls -lt 2) {
-                        return [PSCustomObject]@{ Success = $true; ExitCode = 0; Output = 'WINSMUX_VAULT_INJECT_ACK=staleack' }
+                        return [PSCustomObject]@{
+                            Success  = $true
+                            ExitCode = 0
+                            Output   = ('{0}=staleack' -f $asked)
+                        }
                     }
-                    if ($script:ConfText -notmatch 'set-environment WINSMUX_VAULT_INJECT_ACK ([0-9a-f]{32})') {
-                        throw 'source-file conf missing inject ack'
-                    }
-                    $ack = $Matches[1]
                     return [PSCustomObject]@{
                         Success  = $true
                         ExitCode = 0
-                        Output   = ('WINSMUX_VAULT_INJECT_ACK={0}' -f $ack)
+                        Output   = ('{0}={1}' -f $script:GeneratedAckName, $script:GeneratedAckValue)
                     }
                 }
                 return [PSCustomObject]@{
@@ -260,15 +282,114 @@ public static class WinCredDeleteNative {
                     Output   = ('unknown variable: {0}' -f $asked)
                 }
             }
+            if ($Arguments[0] -eq 'set-environment' -and $Arguments[1] -eq '-u') {
+                $unsetName = [string]$Arguments[2]
+                if ($unsetName -ceq 'WINSMUX_VAULT_INJECT_ACK') {
+                    throw 'legacy fixed credential must not be unset as an ACK marker'
+                }
+                if ($unsetName -cne $script:GeneratedAckName) {
+                    throw ('unexpected ACK cleanup target: {0}' -f $unsetName)
+                }
+                $script:UnsetNames.Add($unsetName) | Out-Null
+                $script:SimulatedEnvironment.Remove($unsetName)
+                return [PSCustomObject]@{ Success = $true; ExitCode = 0; Output = '' }
+            }
             throw ('unexpected winsmux {0}' -f ($Arguments -join ' '))
         }
 
-        $result = Invoke-WinsmuxSourceFile -Commands @('set-environment ROTATE_ME new-secret')
+        $result = Invoke-WinsmuxSourceFile -Commands @(
+            'set-environment WINSMUX_VAULT_INJECT_ACK requested-fixed-secret'
+            'set-environment ROTATE_ME new-secret'
+        ) -CredentialNames $script:CredentialNames
+
         $result.Success | Should -BeTrue
         $script:AckPolls | Should -BeGreaterOrEqual 2
-        $script:ShowNames | Should -Contain 'WINSMUX_VAULT_INJECT_ACK'
+        $script:GeneratedAckName | Should -Match '^WINSMUX_VAULT_INJECT_ACK_[0-9a-f]{32}$'
+        @($script:CredentialNames) -ccontains $script:GeneratedAckName | Should -BeFalse
+        $script:ShowNames | Should -Contain $script:GeneratedAckName
+        $script:ShowNames | Should -Not -Contain 'WINSMUX_VAULT_INJECT_ACK'
         $script:ShowNames | Should -Not -Contain 'ROTATE_ME'
+        @($script:UnsetNames) | Should -Be @($script:GeneratedAckName)
+        $script:SimulatedEnvironment['WINSMUX_VAULT_INJECT_ACK'] | Should -Be 'requested-fixed-secret'
+        $script:SimulatedEnvironment.ContainsKey($script:GeneratedAckName) | Should -BeFalse
+        $script:ConfText | Should -Match 'set-environment WINSMUX_VAULT_INJECT_ACK requested-fixed-secret'
         $script:ConfText | Should -Match 'set-environment ROTATE_ME new-secret'
-        $script:ConfText | Should -Match 'set-environment WINSMUX_VAULT_INJECT_ACK '
+        $script:ConfText | Should -Match 'set-environment WINSMUX_VAULT_INJECT_ACK_[0-9a-f]{32} [0-9a-f]{32}'
+    }
+
+    It 'source-file cleanup does not unset ACK after ownership is lost' {
+        $script:UnsetNames = [System.Collections.Generic.List[string]]::new()
+        $script:AckPolls = 0
+        $script:ConfText = ''
+        $script:GeneratedAckName = ''
+        $script:GeneratedAckValue = ''
+        $script:CredentialNames = @('WINSMUX_VAULT_INJECT_ACK', 'ROTATE_ME')
+        $script:SimulatedEnvironment = @{}
+        Mock Invoke-WinsmuxCommand {
+            if ($Arguments[0] -eq 'source-file') {
+                $script:ConfText = [System.IO.File]::ReadAllText($Arguments[1])
+                $commandLines = @($script:ConfText -split "`r?`n" | Where-Object { $_ -ne '' })
+                foreach ($line in $commandLines) {
+                    if ($line -notmatch '^set-environment ([A-Za-z0-9_]+) (.+)$') {
+                        throw ('unexpected source-file command: {0}' -f $line)
+                    }
+                    $script:SimulatedEnvironment[$Matches[1]] = $Matches[2]
+                }
+                $ackMatches = [regex]::Matches(
+                    $script:ConfText,
+                    '(?m)^set-environment (WINSMUX_VAULT_INJECT_ACK_[0-9a-f]{32}) ([0-9a-f]{32})\r?$'
+                )
+                $ackMatches.Count | Should -Be 1
+                $script:GeneratedAckName = $ackMatches[0].Groups[1].Value
+                $script:GeneratedAckValue = $ackMatches[0].Groups[2].Value
+                return [PSCustomObject]@{ Success = $true; ExitCode = 0; Output = '' }
+            }
+            if ($Arguments[0] -eq 'show-environment') {
+                $asked = [string]$Arguments[1]
+                if ($asked -ceq $script:GeneratedAckName) {
+                    $script:AckPolls++
+                    if ($script:AckPolls -lt 2) {
+                        return [PSCustomObject]@{
+                            Success  = $true
+                            ExitCode = 0
+                            Output   = ('{0}=staleack' -f $asked)
+                        }
+                    }
+                    if ($script:AckPolls -ge 3) {
+                        $script:SimulatedEnvironment[$asked] = 'stolen-value'
+                        return [PSCustomObject]@{
+                            Success  = $true
+                            ExitCode = 0
+                            Output   = ('{0}=stolen-value' -f $asked)
+                        }
+                    }
+                    return [PSCustomObject]@{
+                        Success  = $true
+                        ExitCode = 0
+                        Output   = ('{0}={1}' -f $script:GeneratedAckName, $script:GeneratedAckValue)
+                    }
+                }
+                return [PSCustomObject]@{
+                    Success  = $false
+                    ExitCode = 1
+                    Output   = ('unknown variable: {0}' -f $asked)
+                }
+            }
+            if ($Arguments[0] -eq 'set-environment' -and $Arguments[1] -eq '-u') {
+                $script:UnsetNames.Add([string]$Arguments[2]) | Out-Null
+                throw 'ACK must not be unset after ownership is lost'
+            }
+            throw ('unexpected winsmux {0}' -f ($Arguments -join ' '))
+        }
+
+        $result = Invoke-WinsmuxSourceFile -Commands @(
+            'set-environment WINSMUX_VAULT_INJECT_ACK requested-fixed-secret'
+            'set-environment ROTATE_ME new-secret'
+        ) -CredentialNames $script:CredentialNames
+
+        $result.Success | Should -BeFalse
+        @($script:UnsetNames) | Should -Be @()
+        $script:SimulatedEnvironment['WINSMUX_VAULT_INJECT_ACK'] | Should -Be 'requested-fixed-secret'
+        $script:SimulatedEnvironment[$script:GeneratedAckName] | Should -Be 'stolen-value'
     }
 }

--- a/tests/Task781RuntimeCompatibility.Tests.ps1
+++ b/tests/Task781RuntimeCompatibility.Tests.ps1
@@ -712,6 +712,7 @@ $afterDelete = Test-VaultKeyExists -Key $key
         $vaultInject.Extent.Text | Should -Match '(?s)foreach.*credentialNames'
         $vaultInject.Extent.Text | Should -Match 'Get-WinsmuxVaultCredentialValue'
         $vaultInject.Extent.Text | Should -Match 'Invoke-WinsmuxSourceFile'
+        $vaultInject.Extent.Text | Should -Match '(?s)Invoke-WinsmuxSourceFile\s+-Commands\s+@\(\$command\)\s+-CredentialNames\s+\$credentialNames'
         $vaultInject.Extent.Text | Should -Not -Match 'send-keys'
 
         $prodInject = $bridgeAst.Find({
@@ -720,6 +721,7 @@ $afterDelete = Test-VaultKeyExists -Key $key
                 $node.Name -ceq 'Invoke-VaultInject'
         }, $true)
         $prodInject.Extent.Text | Should -Match 'Invoke-WinsmuxSourceFile'
+        $prodInject.Extent.Text | Should -Match '(?s)Invoke-WinsmuxSourceFile\s+-Commands\s+@\(\$command\)\s+-CredentialNames\s+\$credentialNames'
         $prodInject.Extent.Text | Should -Match 'set-environment'
         $prodInject.Extent.Text | Should -Not -Match 'send-keys'
         $prodInject.Extent.Text | Should -Not -Match 'set-environment -t'
@@ -732,12 +734,22 @@ $afterDelete = Test-VaultKeyExists -Key $key
         $prodSource.Extent.Text | Should -Match 'show-environment'
         $prodSource.Extent.Text | Should -Match 'UTF8Encoding'
         $prodSource.Extent.Text | Should -Match 'WINSMUX_VAULT_INJECT_ACK'
+        $prodSource.Extent.Text | Should -Match '\[string\[\]\]\$CredentialNames'
+        $prodSource.Extent.Text | Should -Not -Match '(?m)^\s*\$ackName\s*=\s*''WINSMUX_VAULT_INJECT_ACK''\s*$'
+        $prodSource.Extent.Text | Should -Match ([regex]::Escape('''WINSMUX_VAULT_INJECT_ACK_'' + [guid]::NewGuid().ToString(''N'')'))
+        $prodSource.Extent.Text | Should -Match '(?s)foreach\s*\(\$credentialName\s+in\s+@\(\$CredentialNames\)\).*?\[string\]\$credentialName\s+-ceq\s+\$candidate'
+        $prodSource.Extent.Text | Should -Match ([regex]::Escape('''set-environment '' + $ackName + '' '' + $ackValue'))
+        $prodSource.Extent.Text | Should -Match ([regex]::Escape('$expectedAck = $ackName + ''='' + $ackValue'))
+        $prodSource.Extent.Text | Should -Match ([regex]::Escape('@(''show-environment'', $ackName)'))
+        $prodSource.Extent.Text | Should -Match ([regex]::Escape('@(''set-environment'', ''-u'', $ackName)'))
+        $prodSource.Extent.Text | Should -Match ([regex]::Escape('@(''source-file'', $tempConf)'))
         $prodSource.Extent.Text | Should -Match '(?s)(FileStream|FileSystemAclExtensions).{0,500}CreateNew.{0,500}FileSecurity'
         $prodSource.Extent.Text | Should -Not -Match 'Set-Content'
         $prodSource.Extent.Text | Should -Not -Match 'GetTempFileName'
         $prodSource.Extent.Text | Should -Not -Match 'WriteAllText'
         $prodSource.Extent.Text | Should -Not -Match 'Set-Acl'
         $prodSource.Extent.Text | Should -Not -Match 'SetAccessControl'
+        $prodSource.Extent.Text | Should -Not -Match '(?i)\bshred\b'
 
         $vaultSource = $vaultAst.Find({
             param($node)
@@ -746,11 +758,21 @@ $afterDelete = Test-VaultKeyExists -Key $key
         }, $true)
         $vaultSource.Extent.Text | Should -Match 'WINSMUX_VAULT_INJECT_ACK'
         $vaultSource.Extent.Text | Should -Match 'show-environment'
+        $vaultSource.Extent.Text | Should -Match '\[string\[\]\]\$CredentialNames'
+        $vaultSource.Extent.Text | Should -Not -Match '(?m)^\s*\$ackName\s*=\s*''WINSMUX_VAULT_INJECT_ACK''\s*$'
+        $vaultSource.Extent.Text | Should -Match ([regex]::Escape('''WINSMUX_VAULT_INJECT_ACK_'' + [guid]::NewGuid().ToString(''N'')'))
+        $vaultSource.Extent.Text | Should -Match '(?s)foreach\s*\(\$credentialName\s+in\s+@\(\$CredentialNames\)\).*?\[string\]\$credentialName\s+-ceq\s+\$candidate'
+        $vaultSource.Extent.Text | Should -Match ([regex]::Escape('''set-environment '' + $ackName + '' '' + $ackValue'))
+        $vaultSource.Extent.Text | Should -Match ([regex]::Escape('$expectedAck = $ackName + ''='' + $ackValue'))
+        $vaultSource.Extent.Text | Should -Match ([regex]::Escape('@(''show-environment'', $ackName)'))
+        $vaultSource.Extent.Text | Should -Match ([regex]::Escape('@(''set-environment'', ''-u'', $ackName)'))
+        $vaultSource.Extent.Text | Should -Match ([regex]::Escape('@(''source-file'', $tempConf)'))
         $vaultSource.Extent.Text | Should -Match '(?s)(FileStream|FileSystemAclExtensions).{0,500}CreateNew.{0,500}FileSecurity'
         $vaultSource.Extent.Text | Should -Not -Match 'GetTempFileName'
         $vaultSource.Extent.Text | Should -Not -Match 'WriteAllText'
         $vaultSource.Extent.Text | Should -Not -Match 'Set-Acl'
         $vaultSource.Extent.Text | Should -Not -Match 'SetAccessControl'
+        $vaultSource.Extent.Text | Should -Not -Match '(?i)\bshred\b'
     }
 }
 

--- a/winsmux-core/scripts/vault.ps1
+++ b/winsmux-core/scripts/vault.ps1
@@ -238,74 +238,127 @@ function Get-WinsmuxSessionNameForPane {
 }
 
 function Invoke-WinsmuxSourceFile {
-    param([Parameter(Mandatory = $true)][string[]]$Commands)
+    param(
+        [Parameter(Mandatory = $true)][string[]]$Commands,
+        [Parameter(Mandatory = $true)][string[]]$CredentialNames
+    )
 
-    $ackName = 'WINSMUX_VAULT_INJECT_ACK'
-    $ackValue = [guid]::NewGuid().ToString('N')
-    $tempConf = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-src-' + [guid]::NewGuid().ToString('N') + '.conf')
-    $stream = $null
-    $ownedTemp = $false
-    try {
-        $FileSecurity = New-Object System.Security.AccessControl.FileSecurity
-        $FileSecurity.SetAccessRuleProtection($true, $false)
-        $FileSecurity.SetAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule(
-            [Security.Principal.WindowsIdentity]::GetCurrent().User,
-            [System.Security.AccessControl.FileSystemRights]::FullControl,
-            [System.Security.AccessControl.AccessControlType]::Allow
-        )))
-        try {
-            $stream = New-Object System.IO.FileStream($tempConf, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None, 4096, [System.IO.FileOptions]::None, $FileSecurity)
-            $ownedTemp = $true
-        } catch {
-            if (Test-Path -LiteralPath $tempConf) {
-                throw
-            }
-            $stream = [System.IO.FileSystemAclExtensions]::Create((New-Object System.IO.FileInfo($tempConf)), [System.IO.FileMode]::CreateNew, [System.Security.AccessControl.FileSystemRights]::FullControl, [System.IO.FileShare]::None, 4096, [System.IO.FileOptions]::None, $FileSecurity)
-            $ownedTemp = $true
-        }
-        $utf8 = New-Object System.Text.UTF8Encoding $false
-        $sourced = @($Commands) + @('set-environment ' + $ackName + ' ' + $ackValue)
-        $bytes = $utf8.GetBytes(($sourced -join [Environment]::NewLine))
-        $stream.Write($bytes, 0, $bytes.Length)
-        $stream.Dispose()
-        $stream = $null
-        $sourceResult = Invoke-WinsmuxCommand -Arguments @('source-file', $tempConf)
-        if ($sourceResult.Success) {
-            $expected = $ackName + '=' + $ackValue
-            $deadline = [datetime]::UtcNow.AddSeconds(5)
-            $applied = $false
-            while ([datetime]::UtcNow -lt $deadline) {
-                $shown = Invoke-WinsmuxCommand -Arguments @('show-environment', $ackName)
-                $text = [string]$shown.Output
-                if ($text.Trim() -ceq $expected) {
-                    $applied = $true
-                    break
-                }
-                Start-Sleep -Milliseconds 50
-            }
-            $shown = $null
-            $text = $null
-            $expected = $null
-            if (-not $applied) {
-                return [PSCustomObject]@{
-                    Success  = $false
-                    ExitCode = 1
-                    Output   = ''
-                }
+    $ackName = $null
+    $ackNameAttemptLimit = 8
+    for ($attempt = 0; $attempt -lt $ackNameAttemptLimit; $attempt++) {
+        $candidate = 'WINSMUX_VAULT_INJECT_ACK_' + [guid]::NewGuid().ToString('N')
+        $collides = $false
+        foreach ($credentialName in @($CredentialNames)) {
+            if ([string]$credentialName -ceq $candidate) {
+                $collides = $true
+                break
             }
         }
-        return $sourceResult
-    } catch {
+        if (-not $collides) {
+            $ackName = $candidate
+            break
+        }
+    }
+    if ([string]::IsNullOrEmpty($ackName)) {
         return [PSCustomObject]@{
             Success  = $false
             ExitCode = 1
             Output   = ''
+        }
+    }
+
+    $ackValue = [guid]::NewGuid().ToString('N')
+    $expectedAck = $ackName + '=' + $ackValue
+    $tempConf = Join-Path ([System.IO.Path]::GetTempPath()) ('winsmux-src-' + [guid]::NewGuid().ToString('N') + '.conf')
+    $stream = $null
+    $ownedTemp = $false
+    $sourceResult = $null
+    $sourceSucceeded = $false
+    $sourceExitCode = 1
+    $ackObserved = $false
+    $ackCleanupSucceeded = $false
+    $operationFailed = $false
+    try {
+        try {
+            $FileSecurity = New-Object System.Security.AccessControl.FileSecurity
+            $FileSecurity.SetAccessRuleProtection($true, $false)
+            $FileSecurity.SetAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule(
+                [Security.Principal.WindowsIdentity]::GetCurrent().User,
+                [System.Security.AccessControl.FileSystemRights]::FullControl,
+                [System.Security.AccessControl.AccessControlType]::Allow
+            )))
+            try {
+                $stream = New-Object System.IO.FileStream($tempConf, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None, 4096, [System.IO.FileOptions]::None, $FileSecurity)
+                $ownedTemp = $true
+            } catch {
+                if (Test-Path -LiteralPath $tempConf) {
+                    throw
+                }
+                $stream = [System.IO.FileSystemAclExtensions]::Create((New-Object System.IO.FileInfo($tempConf)), [System.IO.FileMode]::CreateNew, [System.Security.AccessControl.FileSystemRights]::FullControl, [System.IO.FileShare]::None, 4096, [System.IO.FileOptions]::None, $FileSecurity)
+                $ownedTemp = $true
+            }
+            $utf8 = New-Object System.Text.UTF8Encoding $false
+            $sourced = @($Commands) + @('set-environment ' + $ackName + ' ' + $ackValue)
+            $bytes = $utf8.GetBytes(($sourced -join [Environment]::NewLine))
+            $stream.Write($bytes, 0, $bytes.Length)
+            $stream.Dispose()
+            $stream = $null
+            $sourceResult = Invoke-WinsmuxCommand -Arguments @('source-file', $tempConf)
+            $sourceSucceeded = [bool]$sourceResult.Success
+            $sourceExitCode = if ($null -eq $sourceResult.ExitCode) { 1 } else { [int]$sourceResult.ExitCode }
+
+            $deadline = [datetime]::UtcNow.AddSeconds(5)
+            do {
+                $shown = Invoke-WinsmuxCommand -Arguments @('show-environment', $ackName)
+                $text = [string]$shown.Output
+                if ($shown.Success -and $text.Trim() -ceq $expectedAck) {
+                    $ackObserved = $true
+                    break
+                }
+                if (-not $sourceSucceeded) {
+                    break
+                }
+                Start-Sleep -Milliseconds 50
+            } while ([datetime]::UtcNow -lt $deadline)
+        } catch {
+            $operationFailed = $true
+            if (-not $ackObserved) {
+                try {
+                    $shown = Invoke-WinsmuxCommand -Arguments @('show-environment', $ackName)
+                    $text = [string]$shown.Output
+                    if ($shown.Success -and $text.Trim() -ceq $expectedAck) {
+                        $ackObserved = $true
+                    }
+                } catch { }
+            }
+        }
+
+        try {
+            $shown = Invoke-WinsmuxCommand -Arguments @('show-environment', $ackName)
+            $text = [string]$shown.Output
+            if ($shown.Success -and $text.Trim() -ceq $expectedAck) {
+                $ackObserved = $true
+                $cleanupResult = Invoke-WinsmuxCommand -Arguments @('set-environment', '-u', $ackName)
+                $ackCleanupSucceeded = [bool]$cleanupResult.Success
+            } else {
+                $ackCleanupSucceeded = $false
+            }
+        } catch {
+            $ackCleanupSucceeded = $false
+        }
+
+        $success = (-not $operationFailed) -and $sourceSucceeded -and $ackObserved -and $ackCleanupSucceeded
+        return [PSCustomObject]@{
+            Success  = $success
+            ExitCode = if ($success) { $sourceExitCode } else { 1 }
+            Output   = if ($null -ne $sourceResult) { [string]$sourceResult.Output } else { '' }
         }
     } finally {
         if ($null -ne $stream) {
             try { $stream.Dispose() } catch { }
         }
         $ackValue = $null
+        $expectedAck = $null
         if ($ownedTemp) {
             Remove-Item -LiteralPath $tempConf -Force -ErrorAction SilentlyContinue
         }
@@ -340,7 +393,7 @@ function Invoke-VaultInject {
                 Assert-WinsmuxTargetRuntimeWriteAllowed `
                     -PaneId $paneId -CurrentProjectDir $projectDir -Operation dispatch `
                     -ExpectedGenerationId ([string]$initialRuntime.GenerationId) | Out-Null
-                $sourceResult = Invoke-WinsmuxSourceFile -Commands @($command)
+                $sourceResult = Invoke-WinsmuxSourceFile -Commands @($command) -CredentialNames $credentialNames
                 if (-not $sourceResult.Success) {
                     Stop-WithError "winsmux source-file failed while injecting credentials into $paneId (session $sessionName)."
                 }


### PR DESCRIPTION
## Summary

- Vault inject ACK is now a per-inject `WINSMUX_VAULT_INJECT_ACK_<guid>` name, collision-checked against the credential-name set, then exact-polled.
- Owned cleanup unsets that generated name only after a live `name=value` match. The legacy key `WINSMUX_VAULT_INJECT_ACK` can be a real credential and is not blindly deleted.
- Source-file user-only DACL / exclusive `CreateNew` / BOM-less UTF-8 write are unchanged.

## Surface Classification

- [x] Runtime contract surface
- [x] Contributor/test surface

## Responsibility And Cutover

- Replaced behavior, workflow, config path, or responsibility: fixed ACK env name `WINSMUX_VAULT_INJECT_ACK` in both `Invoke-WinsmuxSourceFile` copies
- Expected outcome: inject ACK cannot overwrite a vault key of that name; the owned marker is removed after success
- Source of truth: TASK-677 unique ACK freeze (per-inject marker, collision check, live ownership unset)
- Old paths preserved, redirected, deprecated, or removed: fixed live assignment removed; leftover session markers named `WINSMUX_VAULT_INJECT_ACK` are left untouched

## Verification

- Focused Pester: Runtime.VaultInject 10, WorkerBroker C19/C40/C35/C44 8, Task781 Vault 2
- Windows PowerShell 5.1: `scripts/winsmux-core.ps1 version` → `winsmux 0.36.34` (UTF-8 BOM restored)
- Independent Sol REQUEST_CHANGES on BOM + stale cleanup; desk increment; Terra APPROVE, P0/P1 none
- `scripts/winsmux-core.ps1` 19466 physical lines (≤ 19989). Zero diff on `control_pipe.rs` / `operator_cli.rs` / `main.ts` / `desktop_backend.rs` / VERSION

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.
