### PR TITLE
feat(planning): add durable planning-file write primitive (TASK-814)

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -157,6 +157,7 @@ $whitelistPatterns = @(
     'tests/V03618ReleaseHardening.Tests.ps1',
     'tests/V03619RepoAudit.Tests.ps1',
     'tests/Task810PesterRunner.Tests.ps1',
+    'tests/planning-model.Tests.ps1',
     'tests/Task800OperatorShellBoundary.Tests.ps1',
     'tests/PesterGitIsolation.Tests.ps1',
     'tests/Task811OperatorInfraGate.Tests.ps1',

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,6 +258,10 @@ jobs:
             result: packaged-restore-v03628
             timeout_minutes: 12
             paths: tests/V03628PackagedRestoreGate.Tests.ps1
+          - name: planning-model
+            result: planning-model
+            timeout_minutes: 5
+            paths: tests/planning-model.Tests.ps1
     steps:
       - uses: actions/checkout@v6
 

--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ tests/bridge/_helpers/*
 !tests/V03630DesktopDebugGate.Tests.ps1
 !tests/V03630DesktopDebugGateProcess.Tests.ps1
 !tests/Task810PesterRunner.Tests.ps1
+!tests/planning-model.Tests.ps1
 !tests/Task811OperatorInfraGate.Tests.ps1
 !tests/Task800OperatorShellBoundary.Tests.ps1
 !tests/PesterGitIsolation.Tests.ps1

--- a/scripts/assert-pester-shard-coverage.ps1
+++ b/scripts/assert-pester-shard-coverage.ps1
@@ -13,13 +13,13 @@ $modulePath = Join-Path $PSScriptRoot 'winsmux-pester.psm1'
 Import-Module -Name $modulePath -Force -ErrorAction Stop
 
 $registry = @(Get-WinsmuxPesterShardRegistry)
-if ($registry.Count -ne 26) {
-    throw "Expected 26 registry rows, found $($registry.Count)."
+if ($registry.Count -ne 27) {
+    throw "Expected 27 registry rows, found $($registry.Count)."
 }
 
 $matrix = @($registry | Where-Object { [string]$_.job_kind -eq 'matrix' })
 $desktop = @($registry | Where-Object { [string]$_.job_kind -eq 'Desktop' })
-if ($matrix.Count -ne 25) { throw "Expected 25 matrix rows, found $($matrix.Count)." }
+if ($matrix.Count -ne 26) { throw "Expected 26 matrix rows, found $($matrix.Count)." }
 if ($desktop.Count -ne 1) { throw "Expected 1 Desktop row, found $($desktop.Count)." }
 
 $workflowFullPath = if ([IO.Path]::IsPathRooted($WorkflowPath)) { $WorkflowPath } else { Join-Path $repositoryRoot $WorkflowPath }

--- a/scripts/winsmux-pester.psm1
+++ b/scripts/winsmux-pester.psm1
@@ -173,6 +173,9 @@ function Get-WinsmuxPesterShardRegistry {
         (New-WinsmuxPesterDesktopRow -Ordinal 26 -ShardId 'desktop-debug-process' -TestPaths @(
             'tests/V03630DesktopDebugGateProcess.Tests.ps1'
         ) -ResultFile 'test-results-desktop-debug-v03630.xml')
+        (New-WinsmuxPesterMatrixRow -Ordinal 27 -ShardId 'planning-model' -TimeoutMinutes 5 -TestPaths @(
+            'tests/planning-model.Tests.ps1'
+        ) -ResultFile 'test-results-planning-model.xml')
     )
 }
 

--- a/tests/Task810PesterRunner.Tests.ps1
+++ b/tests/Task810PesterRunner.Tests.ps1
@@ -982,7 +982,7 @@ Export-ModuleMember -Function New-PesterConfiguration, Invoke-Pester
             $exports = @($script:Module.ExportedCommands.Keys | Sort-Object)
             $exports | Should -Be ($script:Task810RequiredExports | Sort-Object)
             $reg = @(Get-WinsmuxPesterShardRegistry)
-            $reg.Count | Should -Be 26
+            $reg.Count | Should -Be 27
         }
 
         It 'arbitrary primitive strings' {

--- a/tests/planning-model.Tests.ps1
+++ b/tests/planning-model.Tests.ps1
@@ -1,0 +1,70 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+Describe 'Write-PlanningModelDurably' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..\winsmux-core\scripts\planning-model.ps1')
+        $script:Command = Get-Command -Name 'Write-PlanningModelDurably' -ErrorAction Stop
+    }
+
+    BeforeEach {
+        $script:FixtureRoot = Join-Path ([IO.Path]::GetTempPath()) ('winsmux-planning-model-' + [guid]::NewGuid().ToString('N'))
+        [void][IO.Directory]::CreateDirectory($script:FixtureRoot)
+    }
+
+    AfterEach {
+        if ([IO.Directory]::Exists($script:FixtureRoot)) {
+            [IO.Directory]::Delete($script:FixtureRoot, $true)
+        }
+    }
+
+    It 'exposes Write-PlanningModelDurably from the exact dot-source' {
+        $script:Command.Name | Should -BeExactly 'Write-PlanningModelDurably'
+        $script:Command.Parameters.ContainsKey('LiteralPath') | Should -BeTrue
+        $script:Command.Parameters.ContainsKey('Content') | Should -BeTrue
+    }
+
+    It 'creates a missing destination with the exact requested content' {
+        $dest = Join-Path $script:FixtureRoot 'created.txt'
+        Write-PlanningModelDurably -LiteralPath $dest -Content 'exact-bytes'
+        [IO.File]::ReadAllText($dest, [Text.UTF8Encoding]::new($false)) | Should -BeExactly 'exact-bytes'
+        @(Get-ChildItem -LiteralPath $script:FixtureRoot -Force).Name | Should -BeExactly @('created.txt')
+    }
+
+    It 'replaces an existing destination completely' {
+        $dest = Join-Path $script:FixtureRoot 'replaced.txt'
+        [IO.File]::WriteAllText($dest, 'old-content', [Text.UTF8Encoding]::new($false))
+        Write-PlanningModelDurably -LiteralPath $dest -Content 'new-content'
+        [IO.File]::ReadAllText($dest, [Text.UTF8Encoding]::new($false)) | Should -BeExactly 'new-content'
+        @(Get-ChildItem -LiteralPath $script:FixtureRoot -Force).Name | Should -BeExactly @('replaced.txt')
+    }
+
+    It 'treats wildcard characters in a filename literally' {
+        $dest = Join-Path $script:FixtureRoot 'file[1].txt'
+        Write-PlanningModelDurably -LiteralPath $dest -Content 'literal-brackets'
+        Test-Path -LiteralPath $dest -PathType Leaf | Should -BeTrue
+        @(Get-ChildItem -LiteralPath $script:FixtureRoot -Force).Name | Should -BeExactly @('file[1].txt')
+        [IO.File]::ReadAllText($dest, [Text.UTF8Encoding]::new($false)) | Should -BeExactly 'literal-brackets'
+    }
+
+    It 'writes UTF-8 without BOM and does not add a newline' {
+        $dest = Join-Path $script:FixtureRoot 'utf8.txt'
+        Write-PlanningModelDurably -LiteralPath $dest -Content 'a'
+        $bytes = [IO.File]::ReadAllBytes($dest)
+        $bytes.Length | Should -Be 1
+        $bytes[0] | Should -Be 97
+    }
+
+    It 'preserves the previous destination when publication fails and removes the staging file' {
+        $dest = Join-Path $script:FixtureRoot 'locked.txt'
+        [IO.File]::WriteAllText($dest, 'keep-me', [Text.UTF8Encoding]::new($false))
+        $lock = [IO.File]::Open($dest, [IO.FileMode]::Open, [IO.FileAccess]::Read, [IO.FileShare]::None)
+        try {
+            { Write-PlanningModelDurably -LiteralPath $dest -Content 'should-not-land' } | Should -Throw
+        } finally {
+            $lock.Dispose()
+        }
+        [IO.File]::ReadAllText($dest, [Text.UTF8Encoding]::new($false)) | Should -BeExactly 'keep-me'
+        @(Get-ChildItem -LiteralPath $script:FixtureRoot -Force).Name | Should -BeExactly @('locked.txt')
+    }
+}

--- a/winsmux-core/scripts/planning-model.ps1
+++ b/winsmux-core/scripts/planning-model.ps1
@@ -1,0 +1,63 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-PlanningModelDurably {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $LiteralPath,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string] $Content
+    )
+
+    if ([string]::IsNullOrWhiteSpace($LiteralPath)) {
+        throw 'LiteralPath is empty.'
+    }
+    if ($LiteralPath.IndexOf([char]0) -ge 0) {
+        throw 'LiteralPath contains a NUL character.'
+    }
+
+    $directory = [IO.Path]::GetDirectoryName($LiteralPath)
+    if ([string]::IsNullOrWhiteSpace($directory)) {
+        throw "LiteralPath has no directory: $LiteralPath"
+    }
+    if (-not [IO.Directory]::Exists($directory)) {
+        $null = [IO.Directory]::CreateDirectory($directory)
+    }
+
+    $stagingName = [guid]::NewGuid().ToString('N') + '.planning-model.tmp'
+    $stagingPath = [IO.Path]::Combine($directory, $stagingName)
+    $utf8 = [Text.UTF8Encoding]::new($false)
+    $bytes = $utf8.GetBytes($Content)
+    $stream = $null
+    $published = $false
+    try {
+        $stream = [IO.File]::Open(
+            $stagingPath,
+            [IO.FileMode]::CreateNew,
+            [IO.FileAccess]::Write,
+            [IO.FileShare]::None
+        )
+        $stream.Write($bytes, 0, $bytes.Length)
+        $stream.Flush($true)
+        $stream.Dispose()
+        $stream = $null
+
+        if ([IO.File]::Exists($LiteralPath)) {
+            [IO.File]::Move($stagingPath, $LiteralPath, $true)
+        } else {
+            [IO.File]::Move($stagingPath, $LiteralPath)
+        }
+        $published = $true
+    } catch {
+        throw
+    } finally {
+        if ($null -ne $stream) {
+            try { $stream.Dispose() } catch { }
+        }
+        if (-not $published -and [IO.File]::Exists($stagingPath)) {
+            try { [IO.File]::Delete($stagingPath) } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Write-PlanningModelDurably` as a Windows-safe planning-file write primitive (`winsmux-core/scripts/planning-model.ps1`).
- First shipped caller is `tests/planning-model.Tests.ps1`, wired through the live Pester shard registry, coverage pins, `.gitignore` un-ignore, and pre-commit whitelist.
- Live `run-sync.ps1` and the ROADMAP renderer stay disconnected. VERSION stays `0.36.35`.

## Test plan
- [x] `pwsh -NoProfile -File scripts/run-pester-shard.ps1 -ShardId planning-model` — 6/6
- [x] `pwsh -NoProfile -File scripts/assert-pester-shard-coverage.ps1` — 27 registry / 26 matrix
- [ ] CI Tests + Merge Gate on this head
