### PR TITLE
docs: encode PR budget and VERSION-only publication rule (TASK-682)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,20 @@ private vulnerability reporting flow described in [SECURITY.md](SECURITY.md).
 
 Keep pull requests narrow and reviewable.
 
+Planning tasks are planning units, not pull-request boundaries. A task may
+split across pull requests. Multiple tasks may share a pull request only when
+they are inseparable within the declared size and coupling budget.
+
+Each pull request delivers one reviewable and independently reversible release
+outcome. A VERSION-only change is not a publication outcome.
+`scripts/bump-version.ps1 -SyncOnly` remains the allowed non-publication way to
+synchronize VERSION files. Tag, GitHub Release, and npm stay a separate
+maintainer publication step.
+
+A planned version with many tasks still uses this budget. It does not require
+one pull request per task, and it does not allow bundling an unrelated product
+change with publication.
+
 1. Classify changed files using [Repository surface policy](docs/repo-surface-policy.md).
 2. Explain the behavior or responsibility being replaced.
 3. Describe the user-visible or maintainer-visible outcome.


### PR DESCRIPTION
## Summary
- Encode the public PR budget in `CONTRIBUTING.md` only: tasks are planning units, not PR boundaries; each PR has one independently reversible release outcome.
- A VERSION-only change is not publication. `scripts/bump-version.ps1 -SyncOnly` stays allowed. Tag, GitHub Release, and npm stay a separate maintainer step.
- No CI, no `bump-version.ps1` edit, no TASK-814/686 absorption. VERSION stays `0.36.35`.

## Surface Classification
- [x] Contributor/test surface

## Responsibility And Cutover
- Replaced behavior: none. Adds the missing public contract beside "keep PRs narrow".
- Expected outcome: contributors and release planners slice by outcome and budget, not 1:1 with backlog tasks.
- Source of truth: `CONTRIBUTING.md`. `docs/project/design-freeze-gate.md` size table stays historical precedent.
- Old paths: preserved. No CI gate added (TASK-683). Publication stays TASK-686.

## Verification
- [x] `git diff --name-only origin/main...HEAD` is exactly `CONTRIBUTING.md`
- [x] `git diff --check` clean
- [x] Independent Sol max review `01a02730` APPROVE. Four policy assertions present at `CONTRIBUTING.md:38-45`.

## Security And Privacy
- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is revert of this one documentation file.
