### PR TITLE
test(ci): fail-closed Tests-workflow candidate VERSION pin (TASK-683)

### DIFF
--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -532,4 +532,18 @@ Describe 'Public surface policy' {
         $gitleaksScript | Should -Match '-UpdateBaseline'
         $baseline.Trim() | Should -Match '^[0-9a-f]{40}$'
     }
+
+    It 'keeps Tests-workflow candidate identity on the live VERSION file' {
+        $workflow = Get-Content (Join-Path $repoRoot '.github/workflows/test.yml') -Raw
+        $version = (Get-Content -LiteralPath (Join-Path $repoRoot 'VERSION') -Raw -Encoding UTF8).Trim()
+        $candidatePinClass = '\$version\s+-cne\s+[''"]\d+\.\d+\.\d+[''"]'
+        $pinFixture = "`$version -cne '$version'"
+
+        $version | Should -Match '^\d+\.\d+\.\d+'
+        $workflow | Should -Match ([Regex]::Escape("Get-Content -LiteralPath 'VERSION'"))
+        $workflow | Should -Match ([Regex]::Escape("priorVersion = '0.36.33'"))
+        $pinFixture | Should -Match $candidatePinClass
+        $workflow | Should -Not -Match $candidatePinClass
+        $workflow | Should -Not -Match ('\$version\s+-cne\s+[''"]' + [Regex]::Escape($version) + '[''"]')
+    }
 }


### PR DESCRIPTION
## Summary
- Add one fail-closed PublicSurfacePolicy assertion: Tests-workflow candidate identity must come from root VERSION, not a literal `$version -cne` plus a frozen semver.
- Preserve Ubuntu Common Contract Drift Gate (`test.yml:111-149`) byte-for-byte. Do not edit `test.yml`.
- Preserve live VERSION at `test.yml:786` and prior-installer `v0.36.33` at `:787-789` by semantic role. Size pins and generated-edit stay skipped (no independent oracle / named owner).

## Surface Classification
- [x] Contributor/test surface

## Responsibility And Cutover
- Replaced behavior: none. Closes the TASK-680 recurrence class that deleted a candidate VERSION freeze from desktop-nsis-lifecycle.
- Expected outcome: reintroducing `$version -cne` plus the live VERSION string as candidate identity fails `release-public`.
- Source of truth: `tests/PublicSurfacePolicy.Tests.ps1`. Workflow identity still comes from root VERSION.
- Old paths: preserved. Ubuntu npm jobs stay. `public-smoke-recovery.yml` `0.36.30` literals are not absorbed.

## Verification
- [x] `git diff --name-only origin/main...HEAD` is exactly `tests/PublicSurfacePolicy.Tests.ps1`
- [x] `git diff --check` clean
- [x] Local Pester: `It 'keeps Tests-workflow candidate identity on the live VERSION file'` 1/1
- [x] Independent Sol max review `01a0274e` APPROVE

## Security And Privacy
- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is revert of this one test file.
