### PR TITLE
docs: add ADR recording protocol for durable decisions (TASK-684)

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -59,6 +59,7 @@ $whitelistPatterns = @(
     'docs/external-control-plane.ja.md',
     'docs/control-plane-contract.v2.json',
     'docs/repo-surface-policy.md',
+    'docs/adr/README.md',
     'docs/incidents/**',
     'docs/project/ARCHITECTURE.md',
     'docs/project/DETAILED_DESIGN.md',

--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -59,7 +59,7 @@ $whitelistPatterns = @(
     'docs/external-control-plane.ja.md',
     'docs/control-plane-contract.v2.json',
     'docs/repo-surface-policy.md',
-    'docs/adr/README.md',
+    'docs/adr/**',
     'docs/incidents/**',
     'docs/project/ARCHITECTURE.md',
     'docs/project/DETAILED_DESIGN.md',

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,81 @@
+# Architecture decision records
+
+This file is the recorded method for durable architecture decisions.
+It does not own domain maps or repository surfaces.
+
+- Domain ownership: [Component map](../project/component-map.md)
+- Surface classification: [Repository surface policy](../repo-surface-policy.md)
+- Contribution workflow: [CONTRIBUTING](../../CONTRIBUTING.md)
+
+[v0.36.24 Design Freeze Gate](../project/design-freeze-gate.md) is a historical snapshot. Do not treat it as the current decision log.
+
+## When a record is required
+
+Write a record before a change that is durable and cross-domain: it assigns or moves ownership, changes a process or contract boundary, or removes a named compatibility path. Do not write a record for a single-file bug fix, a test-only pin, or a VERSION synchronization.
+
+## Who does what
+
+A coding agent may draft the record and attach evidence. A human maintainer accepts or rejects it. An agent does not mark a record accepted.
+
+## Status
+
+| Status | Meaning |
+| --- | --- |
+| `proposed` | Draft. Not yet accepted. |
+| `accepted` | A human maintainer accepted the decision. |
+| `superseded` | Replaced by a later record. Name that record. |
+| `rejected` | A human maintainer rejected the proposal. Keep the file. |
+
+Status moves only `proposed` → `accepted` or `proposed` → `rejected`, and `accepted` → `superseded`. Do not skip `proposed`.
+
+## Naming
+
+Store each record as `docs/adr/YYYY-MM-DD-slug.md` next to this file. The date is the proposal date. The slug is lowercase hyphenated English. Do not number records.
+
+## Template
+
+Copy this block into a new file. Fill every heading. Link authority. Do not paste ownership tables, PR-budget rules, or another task's decision.
+
+```markdown
+# <title>
+
+- Status: proposed
+- Date: YYYY-MM-DD
+- Authors: <human maintainer; agent drafts named as drafts>
+
+## Context
+
+Why a decision is needed now.
+
+## Decision
+
+The choice, in one paragraph.
+
+## Alternatives
+
+What was considered and why it was not chosen.
+
+## Affected domains
+
+Name domains from the component map. Do not copy that table.
+
+## Authority
+
+Which existing contract remains source of truth (component map, surface policy, CONTRIBUTING, or a named runtime contract). This record must not replace that contract.
+
+## Evidence
+
+Commands, file:line, or review sessions that support the decision.
+
+## Cutover
+
+What changes after acceptance, and what stays unchanged.
+
+## Rollback
+
+How to undo the decision.
+
+## Supersession
+
+`none`, or the later record that replaces this one.
+```


### PR DESCRIPTION
## Summary
- Add `docs/adr/README.md` as the recorded method for durable architecture decisions (when required, human vs agent, status, date-and-slug, copyable template).
- Whitelist that one file in `.githooks/pre-commit-whitelist.ps1`. Domain ownership stays `docs/project/component-map.md`. Surfaces stay `docs/repo-surface-policy.md`. `design-freeze-gate.md` stays historical.
- No numbered ADR. TASK-788 writes the first real record later. No CONTRIBUTING rewrite. VERSION stays `0.36.35`.

## Surface Classification
- [x] Contributor/test surface

## Responsibility And Cutover
- Replaced behavior: none. Adds the missing decision-recording method.
- Expected outcome: TASK-788 and later cross-domain changes use this protocol instead of inventing a second log.
- Source of truth: `docs/adr/README.md` for the method. Existing ownership and surface docs stay canonical.
- Old paths: preserved. No caller-link edit in CONTRIBUTING.

## Verification
- [x] `git diff --name-only origin/main...HEAD` is exactly `docs/adr/README.md` and `.githooks/pre-commit-whitelist.ps1`
- [x] `git diff --check` clean
- [x] Relative links resolve to component-map, repo-surface-policy, CONTRIBUTING, and design-freeze-gate
- [x] Independent Sol max review `01a02760` APPROVE

## Security And Privacy
- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is revert of these two files and the empty `docs/adr/` directory.
