### PR TITLE
ci: raise Pester integration shard timeout to 30 minutes (TASK-685)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,7 +212,7 @@ jobs:
             paths: tests/bridge/ArtifactsRuntime.Tests.ps1;tests/bridge/ArtifactsRuntime.Operator.Tests.ps1
           - name: integration
             result: integration
-            timeout_minutes: 25
+            timeout_minutes: 30
             paths: tests/Integration.GateEnforcement.Tests.ps1;tests/Integration.MultiAgent.Tests.ps1;tests/Integration.PaneMonitorHook.Tests.ps1;tests/Integration.PluginHookLoader.Tests.ps1;tests/Integration.WorktreeHook.Tests.ps1;tests/Task839WorktreeReviewState.Tests.ps1;tests/V03630DesktopDebugGate.Tests.ps1;tests/DeclarativeWorkflow.Tests.ps1;tests/Task810PesterRunner.Tests.ps1;tests/Task800OperatorShellBoundary.Tests.ps1;tests/PesterGitIsolation.Tests.ps1;tests/Task811OperatorInfraGate.Tests.ps1
           - name: worker-benchmark
             result: worker-benchmark

--- a/scripts/run-tests.ps1
+++ b/scripts/run-tests.ps1
@@ -21,8 +21,8 @@ param(
 
     [Parameter(DontShow = $true)]
     [ValidateRange(1, 7200)]
-    # The integration CI shard owns a 25-minute budget. Keep the local aggregate
-    # runner above that boundary because concurrent bridge workers add contention.
+    # The integration CI shard owns a 30-minute outer budget. The local aggregate
+    # runner stays at 1800 seconds (equal to that budget). Do not raise this watchdog.
     [int]$WorkerTimeoutSeconds = 1800,
 
     [Parameter(DontShow = $true)]

--- a/scripts/winsmux-pester.psm1
+++ b/scripts/winsmux-pester.psm1
@@ -106,7 +106,7 @@ function Get-WinsmuxPesterShardRegistry {
             'tests/bridge/ArtifactsRuntime.Tests.ps1'
             'tests/bridge/ArtifactsRuntime.Operator.Tests.ps1'
         ) -ResultFile 'test-results-bridge-artifacts-runtime.xml')
-        (New-WinsmuxPesterMatrixRow -Ordinal 14 -ShardId 'integration' -TimeoutMinutes 25 -TestPaths @(
+        (New-WinsmuxPesterMatrixRow -Ordinal 14 -ShardId 'integration' -TimeoutMinutes 30 -TestPaths @(
             'tests/Integration.GateEnforcement.Tests.ps1'
             'tests/Integration.MultiAgent.Tests.ps1'
             'tests/Integration.PaneMonitorHook.Tests.ps1'

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -533,6 +533,18 @@ Describe 'Public surface policy' {
         $baseline.Trim() | Should -Match '^[0-9a-f]{40}$'
     }
 
+    It 'keeps the Pester integration shard on a 30-minute outer budget' {
+        $workflow = Get-Content (Join-Path $repoRoot '.github/workflows/test.yml') -Raw
+        $registry = Get-Content (Join-Path $repoRoot 'scripts/winsmux-pester.psm1') -Raw
+        $matrix = [regex]::Match($workflow, '(?ms)^          - name: integration\r?\n.*?timeout_minutes:\s*(\d+)')
+        $row = [regex]::Match($registry, "(?ms)New-WinsmuxPesterMatrixRow -Ordinal 14 -ShardId 'integration' -TimeoutMinutes (\d+)")
+
+        $matrix.Success | Should -BeTrue
+        $row.Success | Should -BeTrue
+        $matrix.Groups[1].Value | Should -Be '30'
+        $row.Groups[1].Value | Should -Be '30'
+    }
+
     It 'keeps Tests-workflow candidate identity on the live VERSION file' {
         $workflow = Get-Content (Join-Path $repoRoot '.github/workflows/test.yml') -Raw
         $version = (Get-Content -LiteralPath (Join-Path $repoRoot 'VERSION') -Raw -Encoding UTF8).Trim()

--- a/tests/PublicSurfacePolicy.Tests.ps1
+++ b/tests/PublicSurfacePolicy.Tests.ps1
@@ -536,8 +536,8 @@ Describe 'Public surface policy' {
     It 'keeps the Pester integration shard on a 30-minute outer budget' {
         $workflow = Get-Content (Join-Path $repoRoot '.github/workflows/test.yml') -Raw
         $registry = Get-Content (Join-Path $repoRoot 'scripts/winsmux-pester.psm1') -Raw
-        $matrix = [regex]::Match($workflow, '(?ms)^          - name: integration\r?\n.*?timeout_minutes:\s*(\d+)')
-        $row = [regex]::Match($registry, "(?ms)New-WinsmuxPesterMatrixRow -Ordinal 14 -ShardId 'integration' -TimeoutMinutes (\d+)")
+        $matrix = [regex]::Match($workflow, '(?m)^          - name: integration\r?\n            result: integration\r?\n            timeout_minutes:\s*(\d+)')
+        $row = [regex]::Match($registry, "(?m)^        \(New-WinsmuxPesterMatrixRow -Ordinal 14 -ShardId 'integration' -TimeoutMinutes (\d+)")
 
         $matrix.Success | Should -BeTrue
         $row.Success | Should -BeTrue


### PR DESCRIPTION
## Summary

- TASK-685 second PR (deferred from `#1321`): raise only the Pester integration shard outer budget from 25 to 30 minutes.
- Five of six recent Attempts cancelled at 1505–1507s. The only success used 1489/1500s (11s margin).
- Keep the 12 integration paths, Merge Gate topology, and local `WorkerTimeoutSeconds = 1800`. Do not split the shard. Do not edit `#1321` in this PR.

## Surface Classification

- [x] Contributor/test surface
- [ ] Public product surface
- [ ] Runtime contract surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Responsibility And Cutover

- Replaced behavior: GitHub Actions `Pester Tests (integration)` job timeout (`test.yml` matrix `timeout_minutes`) and the matching canonical registry row (`scripts/winsmux-pester.psm1` ordinal 14).
- Expected outcome: integration may finish under 1800s instead of cancelling at 1500s. A later 30-minute boundary cancel needs a new inventory, not another automatic raise.
- Source of truth: `.github/workflows/test.yml` integration row + `scripts/winsmux-pester.psm1` ordinal 14.
- Old paths preserved: `#1321` `ci-health-report` (rebase increment after this lands), local worker watchdog 1800s, shard split (not this PR).

## Verification

- `Invoke-Pester -Path tests/PublicSurfacePolicy.Tests.ps1` → 30 passed / 0 failed on this head.
- `scripts/assert-pester-shard-coverage.ps1` → `status: covered`.
- `git diff --check` clean. `test.yml` remains LF-only. The three PowerShell files remain CRLF-only.
- Inventory Sol `01a0294b` yes. Plan Sol `01a0295a` APPROVE. Product Sol `01a02967` REQUEST_CHANGES (regex). Terra `e6c82799` APPROVE.

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.

## Must not (this PR)

VERSION / tag / npm. Split the integration row. Raise `WorkerTimeoutSeconds`. Product-patch TASK810 / NSIS ENOTFOUND / empty-stdout / T826. Edit `#1317` / `#1321` / `#1322` writer branches. 769. 770..779. Second `--failed` rerun as evidence.
