### PR TITLE
feat(cli): add rust-direct host-profile trust records (TASK-771)

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -118,6 +118,10 @@ path = "tests-rs/team_profile_settings_contract.rs"
 name = "workflow_gate_contract"
 path = "tests-rs/workflow_gate_contract.rs"
 
+[[test]]
+name = "host_profile"
+path = "tests-rs/host_profile.rs"
+
 # Windows only
 [target.'cfg(not(windows))'.dependencies]
 [target.'cfg(windows)'.dependencies]

--- a/core/src/host_profile.rs
+++ b/core/src/host_profile.rs
@@ -54,6 +54,7 @@ enum PresentedFingerprint {
     None,
     Unique(String),
     Ambiguous,
+    Revoked,
 }
 
 pub(crate) fn run_host_profile_command(args: &[&String]) -> io::Result<()> {
@@ -134,7 +135,6 @@ fn validate_alias(alias: &str) -> io::Result<()> {
 
 fn check_alias(alias: &str) -> io::Result<serde_json::Value> {
     let resolved = resolve_ssh_g(alias)?;
-    let presented = known_hosts_fingerprint(&resolved)?;
     let path = record_path(alias)?;
     let mut record = load_record(&path)?.unwrap_or_else(|| HostProfileRecord {
         alias: alias.to_string(),
@@ -145,6 +145,25 @@ fn check_alias(alias: &str) -> io::Result<serde_json::Value> {
         confirmed_fingerprint: None,
         state: TrustState::Pending,
     });
+    let presented = known_hosts_fingerprint(&resolved, record.confirmed_fingerprint.as_deref())?;
+    if record.confirmed_fingerprint.is_some()
+        && (record.hostname != resolved.hostname || record.port != resolved.port)
+    {
+        record.state = TrustState::Blocked;
+        save_record(&path, &record)?;
+        return Ok(json!({
+            "ok": true,
+            "action": "check",
+            "alias": alias,
+            "hostname": record.hostname,
+            "port": record.port,
+            "user": record.user,
+            "proxyjump": record.proxyjump,
+            "state": record.state,
+            "presented_fingerprint": json!(null),
+            "confirmed_fingerprint": record.confirmed_fingerprint,
+        }));
+    }
     record.hostname = resolved.hostname.clone();
     record.port = resolved.port;
     record.user = resolved.user.clone();
@@ -153,7 +172,9 @@ fn check_alias(alias: &str) -> io::Result<serde_json::Value> {
     save_record(&path, &record)?;
     let presented_json = match &presented {
         PresentedFingerprint::Unique(fingerprint) => json!(fingerprint),
-        PresentedFingerprint::None | PresentedFingerprint::Ambiguous => json!(null),
+        PresentedFingerprint::None
+        | PresentedFingerprint::Ambiguous
+        | PresentedFingerprint::Revoked => json!(null),
     };
     Ok(json!({
         "ok": true,
@@ -171,19 +192,33 @@ fn check_alias(alias: &str) -> io::Result<serde_json::Value> {
 
 fn register_alias(alias: &str) -> io::Result<serde_json::Value> {
     let resolved = resolve_ssh_g(alias)?;
-    let presented = match known_hosts_fingerprint(&resolved)? {
-        PresentedFingerprint::Unique(fingerprint) => fingerprint,
-        PresentedFingerprint::Ambiguous => {
-            let path = record_path(alias)?;
-            if let Some(mut record) = load_record(&path)? {
-                if record.confirmed_fingerprint.is_some() {
-                    record.state = TrustState::Blocked;
-                    save_record(&path, &record)?;
-                }
+    let path = record_path(alias)?;
+    let mut record = load_record(&path)?.ok_or_else(|| {
+        io::Error::new(
+            ErrorKind::InvalidInput,
+            "host-profile register requires a pending record; run check first",
+        )
+    })?;
+    if record.confirmed_fingerprint.is_some()
+        && (record.hostname != resolved.hostname || record.port != resolved.port)
+    {
+        record.state = TrustState::Blocked;
+        save_record(&path, &record)?;
+        return Err(io::Error::new(
+            ErrorKind::PermissionDenied,
+            "host-profile resolved endpoint changed; register is not allowed",
+        ));
+    }
+    let presented = known_hosts_fingerprint(&resolved, record.confirmed_fingerprint.as_deref())?;
+    match presented {
+        PresentedFingerprint::Ambiguous | PresentedFingerprint::Revoked => {
+            if record.confirmed_fingerprint.is_some() {
+                record.state = TrustState::Blocked;
+                save_record(&path, &record)?;
             }
             return Err(io::Error::new(
                 ErrorKind::PermissionDenied,
-                "host-profile known_hosts is ambiguous; register is not allowed",
+                "host-profile known_hosts is ambiguous or revoked; register is not allowed",
             ));
         }
         PresentedFingerprint::None => {
@@ -192,50 +227,46 @@ fn register_alias(alias: &str) -> io::Result<serde_json::Value> {
                 "host-profile register requires a plaintext known_hosts key; none was found",
             ));
         }
-    };
-    let path = record_path(alias)?;
-    let mut record = load_record(&path)?.ok_or_else(|| {
-        io::Error::new(
-            ErrorKind::InvalidInput,
-            "host-profile register requires a pending record; run check first",
-        )
-    })?;
-    if next_state(&record, &PresentedFingerprint::Unique(presented.clone())) == TrustState::Blocked
-        || (record.confirmed_fingerprint.is_some()
-            && record.confirmed_fingerprint.as_deref() != Some(presented.as_str()))
-    {
-        record.state = TrustState::Blocked;
-        save_record(&path, &record)?;
-        return Err(io::Error::new(
-            ErrorKind::PermissionDenied,
-            "host-profile fingerprint changed; register is not allowed",
-        ));
+        PresentedFingerprint::Unique(presented) => {
+            if next_state(&record, &PresentedFingerprint::Unique(presented.clone()))
+                == TrustState::Blocked
+                || (record.confirmed_fingerprint.is_some()
+                    && record.confirmed_fingerprint.as_deref() != Some(presented.as_str()))
+            {
+                record.state = TrustState::Blocked;
+                save_record(&path, &record)?;
+                return Err(io::Error::new(
+                    ErrorKind::PermissionDenied,
+                    "host-profile fingerprint changed; register is not allowed",
+                ));
+            }
+            if record.state == TrustState::Registered
+                && record.confirmed_fingerprint.as_deref() == Some(presented.as_str())
+            {
+                return Ok(json!({
+                    "ok": true,
+                    "action": "register",
+                    "alias": alias,
+                    "state": record.state,
+                    "confirmed_fingerprint": record.confirmed_fingerprint,
+                }));
+            }
+            record.hostname = resolved.hostname;
+            record.port = resolved.port;
+            record.user = resolved.user;
+            record.proxyjump = resolved.proxyjump;
+            record.confirmed_fingerprint = Some(presented);
+            record.state = TrustState::Registered;
+            save_record(&path, &record)?;
+            Ok(json!({
+                "ok": true,
+                "action": "register",
+                "alias": alias,
+                "state": record.state,
+                "confirmed_fingerprint": record.confirmed_fingerprint,
+            }))
+        }
     }
-    if record.state == TrustState::Registered
-        && record.confirmed_fingerprint.as_deref() == Some(presented.as_str())
-    {
-        return Ok(json!({
-            "ok": true,
-            "action": "register",
-            "alias": alias,
-            "state": record.state,
-            "confirmed_fingerprint": record.confirmed_fingerprint,
-        }));
-    }
-    record.hostname = resolved.hostname;
-    record.port = resolved.port;
-    record.user = resolved.user;
-    record.proxyjump = resolved.proxyjump;
-    record.confirmed_fingerprint = Some(presented);
-    record.state = TrustState::Registered;
-    save_record(&path, &record)?;
-    Ok(json!({
-        "ok": true,
-        "action": "register",
-        "alias": alias,
-        "state": record.state,
-        "confirmed_fingerprint": record.confirmed_fingerprint,
-    }))
 }
 
 fn status_alias(alias: &str) -> io::Result<serde_json::Value> {
@@ -265,6 +296,7 @@ fn next_state(record: &HostProfileRecord, presented: &PresentedFingerprint) -> T
         record.confirmed_fingerprint.as_deref(),
         presented,
     ) {
+        (_, _, PresentedFingerprint::Revoked) => TrustState::Blocked,
         (_, Some(_), PresentedFingerprint::Ambiguous) => TrustState::Blocked,
         (_, Some(confirmed), PresentedFingerprint::Unique(presented))
             if confirmed != presented =>
@@ -355,7 +387,10 @@ fn parse_ssh_g(text: &str) -> io::Result<ResolvedHost> {
     })
 }
 
-fn known_hosts_fingerprint(host: &ResolvedHost) -> io::Result<PresentedFingerprint> {
+fn known_hosts_fingerprint(
+    host: &ResolvedHost,
+    confirmed: Option<&str>,
+) -> io::Result<PresentedFingerprint> {
     let Some(path) = known_hosts_path()? else {
         return Ok(PresentedFingerprint::None);
     };
@@ -363,14 +398,28 @@ fn known_hosts_fingerprint(host: &ResolvedHost) -> io::Result<PresentedFingerpri
         return Ok(PresentedFingerprint::None);
     }
     let text = fs::read_to_string(&path)?;
+    let mut revoked = Vec::new();
     let mut found: Option<String> = None;
     for raw in text.lines() {
         let line = raw.trim();
-        if line.is_empty()
-            || line.starts_with('#')
-            || line.starts_with("|1|")
-            || line.starts_with("@")
-        {
+        if line.is_empty() || line.starts_with('#') || line.starts_with("|1|") {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("@revoked") {
+            let rest = rest.trim();
+            let mut parts = rest.split_whitespace();
+            let names = parts.next().unwrap_or("");
+            let key_type = parts.next().unwrap_or("");
+            let blob = parts.next().unwrap_or("");
+            if key_type.is_empty() || blob.is_empty() {
+                continue;
+            }
+            if names == "*" || host_names_match(names, host) {
+                revoked.push(fingerprint_blob(blob));
+            }
+            continue;
+        }
+        if line.starts_with('@') {
             continue;
         }
         let mut parts = line.split_whitespace();
@@ -386,13 +435,25 @@ fn known_hosts_fingerprint(host: &ResolvedHost) -> io::Result<PresentedFingerpri
         let fingerprint = fingerprint_blob(blob);
         match &found {
             Some(existing) if existing != &fingerprint => {
+                if confirmed.is_some_and(|confirmed| revoked.iter().any(|item| item == confirmed)) {
+                    return Ok(PresentedFingerprint::Revoked);
+                }
                 return Ok(PresentedFingerprint::Ambiguous);
             }
             None => found = Some(fingerprint),
             Some(_) => {}
         }
     }
-    Ok(found.map_or(PresentedFingerprint::None, PresentedFingerprint::Unique))
+    if confirmed.is_some_and(|confirmed| revoked.iter().any(|item| item == confirmed)) {
+        return Ok(PresentedFingerprint::Revoked);
+    }
+    match found {
+        Some(fingerprint) if revoked.iter().any(|item| item == &fingerprint) => {
+            Ok(PresentedFingerprint::Revoked)
+        }
+        Some(fingerprint) => Ok(PresentedFingerprint::Unique(fingerprint)),
+        None => Ok(PresentedFingerprint::None),
+    }
 }
 
 fn host_names_match(names: &str, host: &ResolvedHost) -> bool {

--- a/core/src/host_profile.rs
+++ b/core/src/host_profile.rs
@@ -1,0 +1,480 @@
+//! HostProfile: OpenSSH alias resolution and a separate non-secret trust record.
+//!
+//! TASK-771 first PR. Does not spawn an SSH session, allocate a PTY, write
+//! OpenSSH files, or store secrets.
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::{self, ErrorKind, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub(crate) const USAGE: &str = "usage: winsmux host-profile <check|register|status> <alias> [--json]";
+
+const SECRET_FIELD_NAMES: [&str; 6] = [
+    "password",
+    "passphrase",
+    "private_key",
+    "privatekey",
+    "identityfile",
+    "identity_file",
+];
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum TrustState {
+    Pending,
+    Registered,
+    Blocked,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct HostProfileRecord {
+    alias: String,
+    hostname: String,
+    port: u16,
+    user: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    proxyjump: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    confirmed_fingerprint: Option<String>,
+    state: TrustState,
+}
+
+struct ResolvedHost {
+    hostname: String,
+    port: u16,
+    user: String,
+    proxyjump: Option<String>,
+}
+
+enum PresentedFingerprint {
+    None,
+    Unique(String),
+    Ambiguous,
+}
+
+pub(crate) fn run_host_profile_command(args: &[&String]) -> io::Result<()> {
+    if args.is_empty() || should_print_help(args) {
+        println!("{USAGE}");
+        return Ok(());
+    }
+
+    let action = args[0].as_str();
+    if !matches!(action, "check" | "register" | "status") {
+        return Err(io::Error::new(ErrorKind::InvalidInput, USAGE.to_string()));
+    }
+
+    let rest = &args[1..];
+    let json_out = rest.iter().any(|arg| arg.as_str() == "--json");
+    let positional: Vec<&str> = rest
+        .iter()
+        .map(|arg| arg.as_str())
+        .filter(|arg| *arg != "--json")
+        .collect();
+    let alias = positional
+        .first()
+        .copied()
+        .ok_or_else(|| io::Error::new(ErrorKind::InvalidInput, USAGE.to_string()))?;
+    validate_alias(alias)?;
+
+    let payload = match action {
+        "check" => check_alias(alias)?,
+        "register" => register_alias(alias)?,
+        "status" => status_alias(alias)?,
+        _ => unreachable!(),
+    };
+
+    if json_out {
+        writeln!(
+            io::stdout(),
+            "{}",
+            serde_json::to_string(&payload)
+                .map_err(|error| io::Error::new(ErrorKind::InvalidData, error))?
+        )?;
+    } else {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload)
+                .map_err(|error| io::Error::new(ErrorKind::InvalidData, error))?
+        );
+    }
+    Ok(())
+}
+
+fn should_print_help(args: &[&String]) -> bool {
+    args.iter()
+        .any(|arg| matches!(arg.as_str(), "-h" | "--help" | "help"))
+}
+
+fn validate_alias(alias: &str) -> io::Result<()> {
+    let mut chars = alias.chars();
+    let Some(first) = chars.next() else {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "host-profile alias is empty",
+        ));
+    };
+    if !first.is_ascii_alphanumeric() {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "host-profile alias must start with an ASCII letter or digit",
+        ));
+    }
+    if !chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-')) {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "host-profile alias may contain only ASCII letters, digits, '.', '_', and '-'",
+        ));
+    }
+    Ok(())
+}
+
+fn check_alias(alias: &str) -> io::Result<serde_json::Value> {
+    let resolved = resolve_ssh_g(alias)?;
+    let presented = known_hosts_fingerprint(&resolved)?;
+    let path = record_path(alias)?;
+    let mut record = load_record(&path)?.unwrap_or_else(|| HostProfileRecord {
+        alias: alias.to_string(),
+        hostname: resolved.hostname.clone(),
+        port: resolved.port,
+        user: resolved.user.clone(),
+        proxyjump: resolved.proxyjump.clone(),
+        confirmed_fingerprint: None,
+        state: TrustState::Pending,
+    });
+    record.hostname = resolved.hostname.clone();
+    record.port = resolved.port;
+    record.user = resolved.user.clone();
+    record.proxyjump = resolved.proxyjump.clone();
+    record.state = next_state(&record, &presented);
+    save_record(&path, &record)?;
+    let presented_json = match &presented {
+        PresentedFingerprint::Unique(fingerprint) => json!(fingerprint),
+        PresentedFingerprint::None | PresentedFingerprint::Ambiguous => json!(null),
+    };
+    Ok(json!({
+        "ok": true,
+        "action": "check",
+        "alias": alias,
+        "hostname": record.hostname,
+        "port": record.port,
+        "user": record.user,
+        "proxyjump": record.proxyjump,
+        "state": record.state,
+        "presented_fingerprint": presented_json,
+        "confirmed_fingerprint": record.confirmed_fingerprint,
+    }))
+}
+
+fn register_alias(alias: &str) -> io::Result<serde_json::Value> {
+    let resolved = resolve_ssh_g(alias)?;
+    let presented = match known_hosts_fingerprint(&resolved)? {
+        PresentedFingerprint::Unique(fingerprint) => fingerprint,
+        PresentedFingerprint::Ambiguous => {
+            let path = record_path(alias)?;
+            if let Some(mut record) = load_record(&path)? {
+                if record.confirmed_fingerprint.is_some() {
+                    record.state = TrustState::Blocked;
+                    save_record(&path, &record)?;
+                }
+            }
+            return Err(io::Error::new(
+                ErrorKind::PermissionDenied,
+                "host-profile known_hosts is ambiguous; register is not allowed",
+            ));
+        }
+        PresentedFingerprint::None => {
+            return Err(io::Error::new(
+                ErrorKind::NotFound,
+                "host-profile register requires a plaintext known_hosts key; none was found",
+            ));
+        }
+    };
+    let path = record_path(alias)?;
+    let mut record = load_record(&path)?.ok_or_else(|| {
+        io::Error::new(
+            ErrorKind::InvalidInput,
+            "host-profile register requires a pending record; run check first",
+        )
+    })?;
+    if next_state(&record, &PresentedFingerprint::Unique(presented.clone())) == TrustState::Blocked
+        || (record.confirmed_fingerprint.is_some()
+            && record.confirmed_fingerprint.as_deref() != Some(presented.as_str()))
+    {
+        record.state = TrustState::Blocked;
+        save_record(&path, &record)?;
+        return Err(io::Error::new(
+            ErrorKind::PermissionDenied,
+            "host-profile fingerprint changed; register is not allowed",
+        ));
+    }
+    if record.state == TrustState::Registered
+        && record.confirmed_fingerprint.as_deref() == Some(presented.as_str())
+    {
+        return Ok(json!({
+            "ok": true,
+            "action": "register",
+            "alias": alias,
+            "state": record.state,
+            "confirmed_fingerprint": record.confirmed_fingerprint,
+        }));
+    }
+    record.hostname = resolved.hostname;
+    record.port = resolved.port;
+    record.user = resolved.user;
+    record.proxyjump = resolved.proxyjump;
+    record.confirmed_fingerprint = Some(presented);
+    record.state = TrustState::Registered;
+    save_record(&path, &record)?;
+    Ok(json!({
+        "ok": true,
+        "action": "register",
+        "alias": alias,
+        "state": record.state,
+        "confirmed_fingerprint": record.confirmed_fingerprint,
+    }))
+}
+
+fn status_alias(alias: &str) -> io::Result<serde_json::Value> {
+    let path = record_path(alias)?;
+    let Some(record) = load_record(&path)? else {
+        return Err(io::Error::new(
+            ErrorKind::NotFound,
+            format!("host-profile '{alias}' has no local record"),
+        ));
+    };
+    Ok(json!({
+        "ok": true,
+        "action": "status",
+        "alias": alias,
+        "hostname": record.hostname,
+        "port": record.port,
+        "user": record.user,
+        "proxyjump": record.proxyjump,
+        "state": record.state,
+        "confirmed_fingerprint": record.confirmed_fingerprint,
+    }))
+}
+
+fn next_state(record: &HostProfileRecord, presented: &PresentedFingerprint) -> TrustState {
+    match (
+        &record.state,
+        record.confirmed_fingerprint.as_deref(),
+        presented,
+    ) {
+        (_, Some(_), PresentedFingerprint::Ambiguous) => TrustState::Blocked,
+        (_, Some(confirmed), PresentedFingerprint::Unique(presented))
+            if confirmed != presented =>
+        {
+            TrustState::Blocked
+        }
+        (TrustState::Blocked, _, _) => TrustState::Blocked,
+        (TrustState::Registered, Some(confirmed), PresentedFingerprint::Unique(presented))
+            if confirmed == presented =>
+        {
+            TrustState::Registered
+        }
+        (TrustState::Registered, Some(_), PresentedFingerprint::None) => TrustState::Registered,
+        _ => TrustState::Pending,
+    }
+}
+
+fn resolve_ssh_g(alias: &str) -> io::Result<ResolvedHost> {
+    let ssh = env_nonempty("WINSMUX_HOST_PROFILE_SSH").unwrap_or_else(|| "ssh".to_string());
+    let output = Command::new(&ssh)
+        .args(["-G", "--", alias])
+        .output()
+        .map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                format!("host-profile failed to exec ssh -G: {error}"),
+            )
+        })?;
+    if !output.status.success() {
+        return Err(io::Error::new(
+            ErrorKind::NotFound,
+            format!("OpenSSH alias '{alias}' did not resolve; winsmux will not invent a host"),
+        ));
+    }
+    let stdout = String::from_utf8(output.stdout)
+        .map_err(|_| io::Error::new(ErrorKind::InvalidData, "ssh -G output was not UTF-8"))?;
+    let resolved = parse_ssh_g(&stdout)?;
+    if resolved.hostname.eq_ignore_ascii_case(alias) {
+        return Err(io::Error::new(
+            ErrorKind::NotFound,
+            format!(
+                "OpenSSH alias '{alias}' did not rewrite HostName; winsmux will not invent a host"
+            ),
+        ));
+    }
+    Ok(resolved)
+}
+
+fn parse_ssh_g(text: &str) -> io::Result<ResolvedHost> {
+    let mut hostname = None;
+    let mut user = None;
+    let mut port = 22u16;
+    let mut proxyjump = None;
+    for raw in text.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let mut parts = line.splitn(2, |ch: char| ch.is_ascii_whitespace());
+        let key = parts.next().unwrap_or("").to_ascii_lowercase();
+        let value = parts.next().unwrap_or("").trim();
+        match key.as_str() {
+            "hostname" => hostname = Some(value.to_string()),
+            "user" => user = Some(value.to_string()),
+            "port" => {
+                port = value.parse().map_err(|_| {
+                    io::Error::new(ErrorKind::InvalidData, "ssh -G port is not a u16")
+                })?;
+            }
+            "proxyjump" if !value.is_empty() => proxyjump = Some(value.to_string()),
+            _ => {}
+        }
+    }
+    let hostname = hostname.ok_or_else(|| {
+        io::Error::new(ErrorKind::InvalidData, "ssh -G did not report hostname")
+    })?;
+    if hostname.is_empty() {
+        return Err(io::Error::new(
+            ErrorKind::NotFound,
+            "OpenSSH alias did not resolve a hostname; winsmux will not invent a host",
+        ));
+    }
+    Ok(ResolvedHost {
+        hostname,
+        port,
+        user: user.unwrap_or_default(),
+        proxyjump,
+    })
+}
+
+fn known_hosts_fingerprint(host: &ResolvedHost) -> io::Result<PresentedFingerprint> {
+    let Some(path) = known_hosts_path()? else {
+        return Ok(PresentedFingerprint::None);
+    };
+    if !path.is_file() {
+        return Ok(PresentedFingerprint::None);
+    }
+    let text = fs::read_to_string(&path)?;
+    let mut found: Option<String> = None;
+    for raw in text.lines() {
+        let line = raw.trim();
+        if line.is_empty()
+            || line.starts_with('#')
+            || line.starts_with("|1|")
+            || line.starts_with("@")
+        {
+            continue;
+        }
+        let mut parts = line.split_whitespace();
+        let names = parts.next().unwrap_or("");
+        let key_type = parts.next().unwrap_or("");
+        let blob = parts.next().unwrap_or("");
+        if key_type.is_empty() || blob.is_empty() {
+            continue;
+        }
+        if !host_names_match(names, host) {
+            continue;
+        }
+        let fingerprint = fingerprint_blob(blob);
+        match &found {
+            Some(existing) if existing != &fingerprint => {
+                return Ok(PresentedFingerprint::Ambiguous);
+            }
+            None => found = Some(fingerprint),
+            Some(_) => {}
+        }
+    }
+    Ok(found.map_or(PresentedFingerprint::None, PresentedFingerprint::Unique))
+}
+
+fn host_names_match(names: &str, host: &ResolvedHost) -> bool {
+    let bracketed = format!("[{}]:{}", host.hostname, host.port);
+    names.split(',').any(|name| {
+        let name = name.trim();
+        if name == bracketed {
+            return true;
+        }
+        host.port == 22 && name == host.hostname
+    })
+}
+
+fn fingerprint_blob(blob: &str) -> String {
+    format!("sha256:{:x}", Sha256::digest(blob.as_bytes()))
+}
+
+fn record_path(alias: &str) -> io::Result<PathBuf> {
+    Ok(profile_dir()?.join(format!("{alias}.json")))
+}
+
+fn profile_dir() -> io::Result<PathBuf> {
+    if let Some(dir) = env_nonempty("WINSMUX_HOST_PROFILE_DIR") {
+        return Ok(PathBuf::from(dir));
+    }
+    let local = env_nonempty("LOCALAPPDATA")
+        .ok_or_else(|| io::Error::new(ErrorKind::NotFound, "LOCALAPPDATA is not set"))?;
+    Ok(PathBuf::from(local).join("winsmux").join("host-profiles"))
+}
+
+fn known_hosts_path() -> io::Result<Option<PathBuf>> {
+    if let Some(path) = env_nonempty("WINSMUX_HOST_PROFILE_KNOWN_HOSTS") {
+        return Ok(Some(PathBuf::from(path)));
+    }
+    let home = env_nonempty("USERPROFILE").or_else(|| env_nonempty("HOME"));
+    Ok(home.map(|home| Path::new(&home).join(".ssh").join("known_hosts")))
+}
+
+fn load_record(path: &Path) -> io::Result<Option<HostProfileRecord>> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let text = fs::read_to_string(path)?;
+    reject_secret_fields(&text)?;
+    let record: HostProfileRecord = serde_json::from_str(&text)
+        .map_err(|error| io::Error::new(ErrorKind::InvalidData, error))?;
+    Ok(Some(record))
+}
+
+fn save_record(path: &Path, record: &HostProfileRecord) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let payload = serde_json::to_vec_pretty(record)
+        .map_err(|error| io::Error::new(ErrorKind::InvalidData, error))?;
+    fs::write(path, payload)
+}
+
+fn reject_secret_fields(text: &str) -> io::Result<()> {
+    let value: serde_json::Value = serde_json::from_str(text)
+        .map_err(|error| io::Error::new(ErrorKind::InvalidData, error))?;
+    let Some(object) = value.as_object() else {
+        return Err(io::Error::new(
+            ErrorKind::InvalidData,
+            "host-profile record must be an object",
+        ));
+    };
+    for key in object.keys() {
+        let lowered = key.to_ascii_lowercase();
+        if SECRET_FIELD_NAMES.contains(&lowered.as_str()) {
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                format!("host-profile record must not contain secret field '{key}'"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn env_nonempty(name: &str) -> Option<String> {
+    match std::env::var(name) {
+        Ok(value) if !value.trim().is_empty() => Some(value),
+        _ => None,
+    }
+}

--- a/core/src/host_profile.rs
+++ b/core/src/host_profile.rs
@@ -45,9 +45,12 @@ struct HostProfileRecord {
 
 struct ResolvedHost {
     hostname: String,
+    lookup_name: String,
     port: u16,
     user: String,
     proxyjump: Option<String>,
+    user_known_hosts: Vec<PathBuf>,
+    global_known_hosts: Vec<PathBuf>,
 }
 
 enum PresentedFingerprint {
@@ -347,9 +350,12 @@ fn resolve_ssh_g(alias: &str) -> io::Result<ResolvedHost> {
 
 fn parse_ssh_g(text: &str) -> io::Result<ResolvedHost> {
     let mut hostname = None;
+    let mut hostkeyalias = None;
     let mut user = None;
     let mut port = 22u16;
     let mut proxyjump = None;
+    let mut user_known_hosts = Vec::new();
+    let mut global_known_hosts = Vec::new();
     for raw in text.lines() {
         let line = raw.trim();
         if line.is_empty() || line.starts_with('#') {
@@ -360,6 +366,11 @@ fn parse_ssh_g(text: &str) -> io::Result<ResolvedHost> {
         let value = parts.next().unwrap_or("").trim();
         match key.as_str() {
             "hostname" => hostname = Some(value.to_string()),
+            "hostkeyalias"
+                if !value.is_empty() && !value.eq_ignore_ascii_case("none") =>
+            {
+                hostkeyalias = Some(value.to_string())
+            }
             "user" => user = Some(value.to_string()),
             "port" => {
                 port = value.parse().map_err(|_| {
@@ -367,6 +378,8 @@ fn parse_ssh_g(text: &str) -> io::Result<ResolvedHost> {
                 })?;
             }
             "proxyjump" if !value.is_empty() => proxyjump = Some(value.to_string()),
+            "userknownhostsfile" => user_known_hosts.extend(parse_known_hosts_files(value)),
+            "globalknownhostsfile" => global_known_hosts.extend(parse_known_hosts_files(value)),
             _ => {}
         }
     }
@@ -379,27 +392,72 @@ fn parse_ssh_g(text: &str) -> io::Result<ResolvedHost> {
             "OpenSSH alias did not resolve a hostname; winsmux will not invent a host",
         ));
     }
+    let lookup_name = hostkeyalias
+        .filter(|alias| !alias.is_empty())
+        .unwrap_or_else(|| hostname.clone());
     Ok(ResolvedHost {
         hostname,
+        lookup_name,
         port,
         user: user.unwrap_or_default(),
         proxyjump,
+        user_known_hosts,
+        global_known_hosts,
     })
+}
+
+fn parse_known_hosts_files(value: &str) -> Vec<PathBuf> {
+    if value.eq_ignore_ascii_case("none") {
+        return Vec::new();
+    }
+    value
+        .split_whitespace()
+        .filter(|path| !path.is_empty() && !path.eq_ignore_ascii_case("none"))
+        .map(PathBuf::from)
+        .collect()
 }
 
 fn known_hosts_fingerprint(
     host: &ResolvedHost,
     confirmed: Option<&str>,
 ) -> io::Result<PresentedFingerprint> {
-    let Some(path) = known_hosts_path()? else {
-        return Ok(PresentedFingerprint::None);
-    };
-    if !path.is_file() {
-        return Ok(PresentedFingerprint::None);
-    }
-    let text = fs::read_to_string(&path)?;
     let mut revoked = Vec::new();
     let mut found: Option<String> = None;
+    let mut ambiguous = false;
+    let mut saw_file = false;
+    for path in known_hosts_files(host)? {
+        if !path.is_file() {
+            continue;
+        }
+        saw_file = true;
+        let text = fs::read_to_string(&path)?;
+        scan_known_hosts_text(host, &text, &mut revoked, &mut found, &mut ambiguous);
+    }
+    if !saw_file {
+        return Ok(PresentedFingerprint::None);
+    }
+    if confirmed.is_some_and(|confirmed| revoked.iter().any(|item| item == confirmed)) {
+        return Ok(PresentedFingerprint::Revoked);
+    }
+    if ambiguous {
+        return Ok(PresentedFingerprint::Ambiguous);
+    }
+    Ok(match found {
+        Some(fingerprint) if revoked.iter().any(|item| item == &fingerprint) => {
+            PresentedFingerprint::Revoked
+        }
+        Some(fingerprint) => PresentedFingerprint::Unique(fingerprint),
+        None => PresentedFingerprint::None,
+    })
+}
+
+fn scan_known_hosts_text(
+    host: &ResolvedHost,
+    text: &str,
+    revoked: &mut Vec<String>,
+    found: &mut Option<String>,
+    ambiguous: &mut bool,
+) {
     for raw in text.lines() {
         let line = raw.trim();
         if line.is_empty() || line.starts_with('#') || line.starts_with("|1|") {
@@ -414,7 +472,7 @@ fn known_hosts_fingerprint(
             if key_type.is_empty() || blob.is_empty() {
                 continue;
             }
-            if names == "*" || host_names_match(names, host) {
+            if host_names_match(names, host) {
                 revoked.push(fingerprint_blob(blob));
             }
             continue;
@@ -433,38 +491,87 @@ fn known_hosts_fingerprint(
             continue;
         }
         let fingerprint = fingerprint_blob(blob);
-        match &found {
-            Some(existing) if existing != &fingerprint => {
-                if confirmed.is_some_and(|confirmed| revoked.iter().any(|item| item == confirmed)) {
-                    return Ok(PresentedFingerprint::Revoked);
-                }
-                return Ok(PresentedFingerprint::Ambiguous);
-            }
-            None => found = Some(fingerprint),
+        match found.as_ref() {
+            Some(existing) if existing != &fingerprint => *ambiguous = true,
+            None => *found = Some(fingerprint),
             Some(_) => {}
         }
-    }
-    if confirmed.is_some_and(|confirmed| revoked.iter().any(|item| item == confirmed)) {
-        return Ok(PresentedFingerprint::Revoked);
-    }
-    match found {
-        Some(fingerprint) if revoked.iter().any(|item| item == &fingerprint) => {
-            Ok(PresentedFingerprint::Revoked)
-        }
-        Some(fingerprint) => Ok(PresentedFingerprint::Unique(fingerprint)),
-        None => Ok(PresentedFingerprint::None),
     }
 }
 
 fn host_names_match(names: &str, host: &ResolvedHost) -> bool {
-    let bracketed = format!("[{}]:{}", host.hostname, host.port);
-    names.split(',').any(|name| {
-        let name = name.trim();
-        if name == bracketed {
-            return true;
+    host_lookup_candidates(host).any(|candidate| pattern_list_matches(names, &candidate))
+}
+
+fn host_lookup_candidates(host: &ResolvedHost) -> impl Iterator<Item = String> {
+    let lookup = host.lookup_name.clone();
+    let bracketed = format!("[{}]:{}", lookup, host.port);
+    let bare = (host.port == 22).then_some(lookup);
+    [Some(bracketed), bare].into_iter().flatten()
+}
+
+fn pattern_list_matches(list: &str, host: &str) -> bool {
+    let host = host.to_ascii_lowercase();
+    let mut positive = false;
+    let mut negated = false;
+    for pattern in list.split(',') {
+        let pattern = pattern.trim();
+        if pattern.is_empty() {
+            continue;
         }
-        host.port == 22 && name == host.hostname
-    })
+        if let Some(rest) = pattern.strip_prefix('!') {
+            if ssh_glob_match(&rest.to_ascii_lowercase(), &host) {
+                negated = true;
+            }
+        } else if ssh_glob_match(&pattern.to_ascii_lowercase(), &host) {
+            positive = true;
+        }
+    }
+    positive && !negated
+}
+
+fn ssh_glob_match(pattern: &str, name: &str) -> bool {
+    ssh_glob_match_bytes(pattern.as_bytes(), name.as_bytes())
+}
+
+fn ssh_glob_match_bytes(pattern: &[u8], name: &[u8]) -> bool {
+    let mut pi = 0;
+    let mut ni = 0;
+    while pi < pattern.len() {
+        match pattern[pi] {
+            b'*' => {
+                pi += 1;
+                if pi == pattern.len() {
+                    return true;
+                }
+                while ni <= name.len() {
+                    if ssh_glob_match_bytes(&pattern[pi..], &name[ni..]) {
+                        return true;
+                    }
+                    if ni == name.len() {
+                        return false;
+                    }
+                    ni += 1;
+                }
+                return false;
+            }
+            b'?' => {
+                if ni >= name.len() {
+                    return false;
+                }
+                pi += 1;
+                ni += 1;
+            }
+            byte => {
+                if ni >= name.len() || name[ni] != byte {
+                    return false;
+                }
+                pi += 1;
+                ni += 1;
+            }
+        }
+    }
+    ni == name.len()
 }
 
 fn fingerprint_blob(blob: &str) -> String {
@@ -484,12 +591,22 @@ fn profile_dir() -> io::Result<PathBuf> {
     Ok(PathBuf::from(local).join("winsmux").join("host-profiles"))
 }
 
-fn known_hosts_path() -> io::Result<Option<PathBuf>> {
+fn known_hosts_files(host: &ResolvedHost) -> io::Result<Vec<PathBuf>> {
     if let Some(path) = env_nonempty("WINSMUX_HOST_PROFILE_KNOWN_HOSTS") {
-        return Ok(Some(PathBuf::from(path)));
+        return Ok(vec![PathBuf::from(path)]);
     }
-    let home = env_nonempty("USERPROFILE").or_else(|| env_nonempty("HOME"));
-    Ok(home.map(|home| Path::new(&home).join(".ssh").join("known_hosts")))
+    let mut files = host.user_known_hosts.clone();
+    if files.is_empty() {
+        if let Some(home) = env_nonempty("USERPROFILE").or_else(|| env_nonempty("HOME")) {
+            files.push(Path::new(&home).join(".ssh").join("known_hosts"));
+        }
+    }
+    for path in &host.global_known_hosts {
+        if !files.iter().any(|existing| existing == path) {
+            files.push(path.clone());
+        }
+    }
+    Ok(files)
 }
 
 fn load_record(path: &Path) -> io::Result<Option<HostProfileRecord>> {

--- a/core/src/host_profile.rs
+++ b/core/src/host_profile.rs
@@ -43,13 +43,19 @@ struct HostProfileRecord {
     state: TrustState,
 }
 
+enum UserKnownHosts {
+    Unspecified,
+    Disabled,
+    Files(Vec<PathBuf>),
+}
+
 struct ResolvedHost {
     hostname: String,
     lookup_name: String,
     port: u16,
     user: String,
     proxyjump: Option<String>,
-    user_known_hosts: Vec<PathBuf>,
+    user_known_hosts: UserKnownHosts,
     global_known_hosts: Vec<PathBuf>,
 }
 
@@ -354,7 +360,7 @@ fn parse_ssh_g(text: &str) -> io::Result<ResolvedHost> {
     let mut user = None;
     let mut port = 22u16;
     let mut proxyjump = None;
-    let mut user_known_hosts = Vec::new();
+    let mut user_known_hosts = UserKnownHosts::Unspecified;
     let mut global_known_hosts = Vec::new();
     for raw in text.lines() {
         let line = raw.trim();
@@ -378,7 +384,9 @@ fn parse_ssh_g(text: &str) -> io::Result<ResolvedHost> {
                 })?;
             }
             "proxyjump" if !value.is_empty() => proxyjump = Some(value.to_string()),
-            "userknownhostsfile" => user_known_hosts.extend(parse_known_hosts_files(value)),
+            "userknownhostsfile" => {
+                user_known_hosts = merge_known_hosts_spec(user_known_hosts, value);
+            }
             "globalknownhostsfile" => global_known_hosts.extend(parse_known_hosts_files(value)),
             _ => {}
         }
@@ -404,6 +412,20 @@ fn parse_ssh_g(text: &str) -> io::Result<ResolvedHost> {
         user_known_hosts,
         global_known_hosts,
     })
+}
+
+fn merge_known_hosts_spec(current: UserKnownHosts, value: &str) -> UserKnownHosts {
+    if value.eq_ignore_ascii_case("none") {
+        return UserKnownHosts::Disabled;
+    }
+    let parsed = parse_known_hosts_files(value);
+    match current {
+        UserKnownHosts::Files(mut files) => {
+            files.extend(parsed);
+            UserKnownHosts::Files(files)
+        }
+        UserKnownHosts::Unspecified | UserKnownHosts::Disabled => UserKnownHosts::Files(parsed),
+    }
 }
 
 fn parse_known_hosts_files(value: &str) -> Vec<PathBuf> {
@@ -472,7 +494,7 @@ fn scan_known_hosts_text(
             if key_type.is_empty() || blob.is_empty() {
                 continue;
             }
-            if host_names_match(names, host) {
+            if names.starts_with("|1|") || host_names_match(names, host) {
                 revoked.push(fingerprint_blob(blob));
             }
             continue;
@@ -595,12 +617,17 @@ fn known_hosts_files(host: &ResolvedHost) -> io::Result<Vec<PathBuf>> {
     if let Some(path) = env_nonempty("WINSMUX_HOST_PROFILE_KNOWN_HOSTS") {
         return Ok(vec![PathBuf::from(path)]);
     }
-    let mut files = host.user_known_hosts.clone();
-    if files.is_empty() {
-        if let Some(home) = env_nonempty("USERPROFILE").or_else(|| env_nonempty("HOME")) {
-            files.push(Path::new(&home).join(".ssh").join("known_hosts"));
+    let mut files = match &host.user_known_hosts {
+        UserKnownHosts::Disabled => Vec::new(),
+        UserKnownHosts::Files(paths) => paths.clone(),
+        UserKnownHosts::Unspecified => {
+            if let Some(home) = env_nonempty("USERPROFILE").or_else(|| env_nonempty("HOME")) {
+                vec![Path::new(&home).join(".ssh").join("known_hosts")]
+            } else {
+                Vec::new()
+            }
         }
-    }
+    };
     for path in &host.global_known_hosts {
         if !files.iter().any(|existing| existing == path) {
             files.push(path.clone());

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -38,6 +38,7 @@ mod extension_manifest;
 mod condensed_events;
 mod workspace_migrate;
 mod team_profile;
+mod host_profile;
 mod team_profile_settings;
 mod instruction_pack;
 mod prompt_bundle;
@@ -1179,6 +1180,7 @@ fn run_main() -> io::Result<()> {
         "team-profile" => return team_profile::run_team_profile_command(&cmd_args[1..]),
         "worker-artifact" => return worker_artifact::run_worker_artifact_command(&cmd_args[1..]),
         "provider-capabilities" => return operator_cli::run_provider_capabilities_command(&cmd_args[1..]),
+        "host-profile" => return host_profile::run_host_profile_command(&cmd_args[1..]),
         "extension-manifest" => return extension_manifest::run_extension_manifest_command(&cmd_args[1..]),
         "operator-jobs" => return operator_cli::run_operator_jobs_command(&cmd_args[1..]),
         "skills" => return operator_cli::run_skills_command(&cmd_args[1..]),

--- a/core/tests-rs/host_profile.rs
+++ b/core/tests-rs/host_profile.rs
@@ -1,0 +1,436 @@
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_winsmux"))
+}
+
+fn ssh_g_text() -> &'static str {
+    "user ubuntu\nhostname 192.0.2.10\nport 22\nidentityfile C:\\secret\\id_ed25519\n"
+}
+
+fn fingerprint_blob(blob: &str) -> String {
+    use sha2::{Digest, Sha256};
+    format!("sha256:{:x}", Sha256::digest(blob.as_bytes()))
+}
+
+fn write_known_hosts(dir: &Path, blob: &str) -> PathBuf {
+    let path = dir.join("known_hosts");
+    fs::write(&path, format!("192.0.2.10 ssh-ed25519 {blob}\n")).unwrap();
+    path
+}
+
+fn install_fake_ssh(dir: &Path, g_text: &str) -> PathBuf {
+    fs::write(dir.join("g-text.txt"), g_text.replace('\n', "\r\n")).unwrap();
+    fs::write(
+        dir.join("ssh.cmd"),
+        "@echo off\r\n\
+         setlocal EnableExtensions\r\n\
+         >\"%~dp0ssh-argv.txt\" echo %*\r\n\
+         if /I not \"%~1\"==\"-G\" exit /b 2\r\n\
+         if not \"%~2\"==\"--\" exit /b 2\r\n\
+         if \"%~3\"==\"\" exit /b 2\r\n\
+         if not \"%~4\"==\"\" exit /b 2\r\n\
+         type \"%~dp0g-text.txt\"\r\n\
+         exit /b 0\r\n",
+    )
+    .unwrap();
+    dir.join("ssh.cmd")
+}
+
+fn run_host_profile(
+    dir: &Path,
+    known_hosts: &Path,
+    ssh: &Path,
+    args: &[&str],
+) -> (bool, String, String) {
+    let output = bin()
+        .args(args)
+        .env("WINSMUX_HOST_PROFILE_DIR", dir)
+        .env("WINSMUX_HOST_PROFILE_KNOWN_HOSTS", known_hosts)
+        .env("WINSMUX_HOST_PROFILE_SSH", ssh)
+        .env_remove("WINSMUX_HOST_PROFILE_SSH_G_TEXT")
+        .output()
+        .expect("run host-profile");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+fn fake_ssh_argv(dir: &Path) -> String {
+    fs::read_to_string(dir.join("ssh-argv.txt")).unwrap_or_default()
+}
+
+#[test]
+fn check_creates_pending_without_known_hosts() {
+    let dir = tempfile::tempdir().unwrap();
+    let ssh = install_fake_ssh(dir.path(), ssh_g_text());
+    let known_hosts = dir.path().join("empty_known_hosts");
+    fs::write(&known_hosts, "").unwrap();
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["state"], "pending");
+    assert_eq!(value["hostname"], "192.0.2.10");
+    assert!(value["identityfile"].is_null());
+    let record = fs::read_to_string(dir.path().join("lab.json")).unwrap();
+    assert!(!record.to_ascii_lowercase().contains("identityfile"));
+    assert!(!record.to_ascii_lowercase().contains("password"));
+    let argv = fake_ssh_argv(dir.path());
+    assert!(
+        argv.contains("-G -- lab") || argv.contains("-G  --  lab"),
+        "argv={argv}"
+    );
+}
+
+#[test]
+fn alias_failure_does_not_invent_a_host() {
+    let dir = tempfile::tempdir().unwrap();
+    let known_hosts = dir.path().join("known_hosts");
+    fs::write(&known_hosts, "").unwrap();
+    let output = bin()
+        .args(["host-profile", "check", "missing", "--json"])
+        .env("WINSMUX_HOST_PROFILE_DIR", dir.path())
+        .env("WINSMUX_HOST_PROFILE_KNOWN_HOSTS", &known_hosts)
+        .env_remove("WINSMUX_HOST_PROFILE_SSH_G_TEXT")
+        .env("WINSMUX_HOST_PROFILE_SSH", "ssh-binary-that-does-not-exist")
+        .output()
+        .expect("run host-profile");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("did not resolve") || stderr.contains("failed to exec ssh -G"),
+        "stderr={stderr}"
+    );
+    assert!(!dir.path().join("missing.json").exists());
+}
+
+#[test]
+fn unconfigured_name_is_not_treated_as_an_alias() {
+    let dir = tempfile::tempdir().unwrap();
+    let ssh = install_fake_ssh(
+        dir.path(),
+        "user ubuntu\nhostname lab\nport 22\n",
+    );
+    let known_hosts = dir.path().join("known_hosts");
+    fs::write(&known_hosts, "").unwrap();
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(!ok, "stdout={stdout}");
+    assert!(
+        stderr.contains("did not rewrite HostName") || stderr.contains("will not invent a host"),
+        "stderr={stderr}"
+    );
+    assert!(!dir.path().join("lab.json").exists());
+}
+
+#[test]
+fn rejected_alias_does_not_reach_ssh() {
+    let dir = tempfile::tempdir().unwrap();
+    let ssh = install_fake_ssh(dir.path(), ssh_g_text());
+    let known_hosts = dir.path().join("known_hosts");
+    fs::write(&known_hosts, "").unwrap();
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "-oProxyJump=evil", "--json"],
+    );
+    assert!(!ok, "stdout={stdout}");
+    assert!(
+        stderr.contains("alias") || stderr.contains("usage:"),
+        "stderr={stderr}"
+    );
+    assert!(!dir.path().join("ssh-argv.txt").exists());
+}
+
+#[test]
+fn register_promotes_pending_and_change_blocks() {
+    let dir = tempfile::tempdir().unwrap();
+    let ssh = install_fake_ssh(dir.path(), ssh_g_text());
+    let blob = "AAAAC3NzaC1lZDI1NTE5AAAAITestKeyBlobForHostProfileOne";
+    let known_hosts = write_known_hosts(dir.path(), blob);
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let check: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(check["state"], "pending");
+
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let registered: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(registered["state"], "registered");
+    assert_eq!(
+        registered["confirmed_fingerprint"],
+        fingerprint_blob(blob)
+    );
+
+    fs::write(
+        &known_hosts,
+        "192.0.2.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIChangedKeyBlobForHostProfile\n",
+    )
+    .unwrap();
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(!ok, "stdout={stdout}");
+    assert!(
+        stderr.contains("fingerprint changed"),
+        "stderr={stderr}"
+    );
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let blocked: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(blocked["state"], "blocked");
+    let record: Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join("lab.json")).unwrap()).unwrap();
+    assert_eq!(record["confirmed_fingerprint"], fingerprint_blob(blob));
+}
+
+#[test]
+fn ambiguous_known_hosts_after_register_blocks() {
+    let dir = tempfile::tempdir().unwrap();
+    let ssh = install_fake_ssh(dir.path(), ssh_g_text());
+    let blob = "AAAAC3NzaC1lZDI1NTE5AAAAITestKeyBlobForHostProfileOne";
+    let known_hosts = write_known_hosts(dir.path(), blob);
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+
+    fs::write(
+        &known_hosts,
+        "192.0.2.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIChangedKeyBlobForHostProfile\n\
+         192.0.2.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIThirdKeyBlobForHostProfile\n",
+    )
+    .unwrap();
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let blocked: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(blocked["state"], "blocked");
+    let (ok, _, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(!ok);
+    assert!(
+        stderr.contains("ambiguous") || stderr.contains("register is not allowed"),
+        "stderr={stderr}"
+    );
+}
+
+#[test]
+fn nonstandard_port_ignores_bare_hostname_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let ssh = install_fake_ssh(
+        dir.path(),
+        "user ubuntu\nhostname 192.0.2.10\nport 2222\n",
+    );
+    let blob = "AAAAC3NzaC1lZDI1NTE5AAAAITestKeyBlobForHostProfileOne";
+    let known_hosts = write_known_hosts(dir.path(), blob);
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let check: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(check["port"], 2222);
+    assert!(check["presented_fingerprint"].is_null());
+    let (ok, _, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(!ok);
+    assert!(
+        stderr.contains("plaintext known_hosts"),
+        "stderr={stderr}"
+    );
+
+    fs::write(
+        &known_hosts,
+        format!("[192.0.2.10]:2222 ssh-ed25519 {blob}\n"),
+    )
+    .unwrap();
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let registered: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(registered["state"], "registered");
+}
+
+#[test]
+fn status_and_secret_record_are_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let ssh = install_fake_ssh(dir.path(), ssh_g_text());
+    let known_hosts = dir.path().join("known_hosts");
+    fs::write(&known_hosts, "").unwrap();
+    let (ok, _, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "status", "lab", "--json"],
+    );
+    assert!(!ok);
+    assert!(stderr.contains("no local record"), "stderr={stderr}");
+
+    fs::write(
+        dir.path().join("lab.json"),
+        r#"{"alias":"lab","hostname":"192.0.2.10","port":22,"user":"ubuntu","state":"pending","password":"secret"}"#,
+    )
+    .unwrap();
+    let (ok, _, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "status", "lab", "--json"],
+    );
+    assert!(!ok);
+    assert!(stderr.contains("secret field"), "stderr={stderr}");
+}
+
+#[test]
+fn known_hosts_file_is_not_written() {
+    let dir = tempfile::tempdir().unwrap();
+    let ssh = install_fake_ssh(dir.path(), ssh_g_text());
+    let blob = "AAAAC3NzaC1lZDI1NTE5AAAAITestKeyBlobForHostProfileOne";
+    let known_hosts = write_known_hosts(dir.path(), blob);
+    let before = fs::read(&known_hosts).unwrap();
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    assert_eq!(fs::read(&known_hosts).unwrap(), before);
+}
+
+#[test]
+fn multiple_plaintext_fingerprints_cannot_register() {
+    let dir = tempfile::tempdir().unwrap();
+    let ssh = install_fake_ssh(dir.path(), ssh_g_text());
+    let known_hosts = dir.path().join("known_hosts");
+    fs::write(
+        &known_hosts,
+        "192.0.2.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKeyBlobForHostProfileOne\n\
+         192.0.2.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIChangedKeyBlobForHostProfile\n",
+    )
+    .unwrap();
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let check: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(check["state"], "pending");
+    assert!(check["presented_fingerprint"].is_null());
+    let (ok, _, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(!ok);
+    assert!(
+        stderr.contains("plaintext known_hosts") || stderr.contains("ambiguous"),
+        "stderr={stderr}"
+    );
+}
+
+#[test]
+fn hashed_known_hosts_is_not_a_register_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let ssh = install_fake_ssh(dir.path(), ssh_g_text());
+    let known_hosts = dir.path().join("known_hosts");
+    fs::write(&known_hosts, "|1|abc|def ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHashed\n").unwrap();
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let (ok, _, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(!ok);
+    assert!(
+        stderr.contains("plaintext known_hosts"),
+        "stderr={stderr}"
+    );
+}

--- a/core/tests-rs/host_profile.rs
+++ b/core/tests-rs/host_profile.rs
@@ -434,3 +434,150 @@ fn hashed_known_hosts_is_not_a_register_source() {
         "stderr={stderr}"
     );
 }
+
+#[test]
+fn retargeted_alias_does_not_keep_the_old_registration() {
+    let dir = tempfile::tempdir().unwrap();
+    let ssh = install_fake_ssh(dir.path(), ssh_g_text());
+    let blob = "AAAAC3NzaC1lZDI1NTE5AAAAITestKeyBlobForHostProfileOne";
+    let known_hosts = write_known_hosts(dir.path(), blob);
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+
+    fs::write(
+        dir.path().join("g-text.txt"),
+        "user ubuntu\r\nhostname 192.0.2.11\r\nport 22\r\n",
+    )
+    .unwrap();
+    fs::write(&known_hosts, "").unwrap();
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(!ok, "stdout={stdout}");
+    assert!(
+        stderr.contains("endpoint changed") || stderr.contains("register is not allowed"),
+        "stderr={stderr}"
+    );
+    let record: Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join("lab.json")).unwrap()).unwrap();
+    assert_eq!(record["hostname"], "192.0.2.10");
+    assert_eq!(record["state"], "blocked");
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let blocked: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(blocked["state"], "blocked");
+    assert_eq!(blocked["hostname"], "192.0.2.10");
+}
+
+#[test]
+fn revoked_known_hosts_entry_blocks_even_with_plaintext_copy() {
+    let dir = tempfile::tempdir().unwrap();
+    let ssh = install_fake_ssh(dir.path(), ssh_g_text());
+    let blob = "AAAAC3NzaC1lZDI1NTE5AAAAITestKeyBlobForHostProfileOne";
+    let known_hosts = write_known_hosts(dir.path(), blob);
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+
+    fs::write(
+        &known_hosts,
+        format!(
+            "@revoked 192.0.2.10 ssh-ed25519 {blob}\n192.0.2.10 ssh-ed25519 {blob}\n"
+        ),
+    )
+    .unwrap();
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let blocked: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(blocked["state"], "blocked");
+    let (ok, _, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(!ok);
+    assert!(
+        stderr.contains("revoked")
+            || stderr.contains("ambiguous")
+            || stderr.contains("register is not allowed"),
+        "stderr={stderr}"
+    );
+}
+
+#[test]
+fn revoked_only_known_hosts_blocks_register_without_plaintext_copy() {
+    let dir = tempfile::tempdir().unwrap();
+    let ssh = install_fake_ssh(dir.path(), ssh_g_text());
+    let blob = "AAAAC3NzaC1lZDI1NTE5AAAAITestKeyBlobForHostProfileOne";
+    let known_hosts = write_known_hosts(dir.path(), blob);
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    fs::write(
+        &known_hosts,
+        format!("@revoked 192.0.2.10 ssh-ed25519 {blob}\n"),
+    )
+    .unwrap();
+    let (ok, _, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(!ok);
+    assert!(
+        stderr.contains("revoked") || stderr.contains("register is not allowed"),
+        "stderr={stderr}"
+    );
+    let record: Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join("lab.json")).unwrap()).unwrap();
+    assert_eq!(record["state"], "blocked");
+}

--- a/core/tests-rs/host_profile.rs
+++ b/core/tests-rs/host_profile.rs
@@ -715,3 +715,91 @@ fn wildcard_revoked_known_hosts_blocks_register() {
         "stderr={stderr}"
     );
 }
+
+#[test]
+fn user_known_hosts_none_does_not_fall_back_to_default_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let blob = "AAAAC3NzaC1lZDI1NTE5AAAAITestKeyBlobForHostProfileOne";
+    let home = dir.path().join("home");
+    fs::create_dir_all(home.join(".ssh")).unwrap();
+    fs::write(
+        home.join(".ssh").join("known_hosts"),
+        format!("192.0.2.10 ssh-ed25519 {blob}\n"),
+    )
+    .unwrap();
+    let g_text = "user ubuntu\nhostname 192.0.2.10\nport 22\nuserknownhostsfile none\n";
+    let ssh = install_fake_ssh(dir.path(), g_text);
+    let output = bin()
+        .args(["host-profile", "check", "lab", "--json"])
+        .env("WINSMUX_HOST_PROFILE_DIR", dir.path())
+        .env_remove("WINSMUX_HOST_PROFILE_KNOWN_HOSTS")
+        .env("WINSMUX_HOST_PROFILE_SSH", &ssh)
+        .env_remove("WINSMUX_HOST_PROFILE_SSH_G_TEXT")
+        .env("USERPROFILE", &home)
+        .env("HOME", &home)
+        .output()
+        .expect("run host-profile");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(output.status.success(), "stderr={stderr} stdout={stdout}");
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(value["state"], "pending");
+    assert!(value["presented_fingerprint"].is_null());
+    let output = bin()
+        .args(["host-profile", "register", "lab", "--json"])
+        .env("WINSMUX_HOST_PROFILE_DIR", dir.path())
+        .env_remove("WINSMUX_HOST_PROFILE_KNOWN_HOSTS")
+        .env("WINSMUX_HOST_PROFILE_SSH", &ssh)
+        .env_remove("WINSMUX_HOST_PROFILE_SSH_G_TEXT")
+        .env("USERPROFILE", &home)
+        .env("HOME", &home)
+        .output()
+        .expect("run host-profile");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        stderr.contains("plaintext known_hosts"),
+        "stderr={stderr}"
+    );
+}
+
+#[test]
+fn hashed_revoked_known_hosts_blocks_registered_fingerprint() {
+    let dir = tempfile::tempdir().unwrap();
+    let ssh = install_fake_ssh(dir.path(), ssh_g_text());
+    let blob = "AAAAC3NzaC1lZDI1NTE5AAAAITestKeyBlobForHostProfileOne";
+    let known_hosts = write_known_hosts(dir.path(), blob);
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    fs::write(
+        &known_hosts,
+        format!("@revoked |1|abc|def ssh-ed25519 {blob}\n"),
+    )
+    .unwrap();
+    let (ok, _, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(!ok);
+    assert!(
+        stderr.contains("revoked") || stderr.contains("register is not allowed"),
+        "stderr={stderr}"
+    );
+    let record: Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join("lab.json")).unwrap()).unwrap();
+    assert_eq!(record["state"], "blocked");
+}

--- a/core/tests-rs/host_profile.rs
+++ b/core/tests-rs/host_profile.rs
@@ -581,3 +581,137 @@ fn revoked_only_known_hosts_blocks_register_without_plaintext_copy() {
         serde_json::from_str(&fs::read_to_string(dir.path().join("lab.json")).unwrap()).unwrap();
     assert_eq!(record["state"], "blocked");
 }
+
+fn run_host_profile_without_known_hosts_env(
+    dir: &Path,
+    ssh: &Path,
+    args: &[&str],
+) -> (bool, String, String) {
+    let output = bin()
+        .args(args)
+        .env("WINSMUX_HOST_PROFILE_DIR", dir)
+        .env_remove("WINSMUX_HOST_PROFILE_KNOWN_HOSTS")
+        .env("WINSMUX_HOST_PROFILE_SSH", ssh)
+        .env_remove("WINSMUX_HOST_PROFILE_SSH_G_TEXT")
+        .output()
+        .expect("run host-profile");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn host_key_alias_looks_up_known_hosts_under_alias_not_hostname() {
+    let dir = tempfile::tempdir().unwrap();
+    let blob = "AAAAC3NzaC1lZDI1NTE5AAAAITestKeyBlobForHostProfileOne";
+    let g_text = "user git\nhostname 203.0.113.10\nport 22\nhostkeyalias github.com\n";
+    let ssh = install_fake_ssh(dir.path(), g_text);
+    let known_hosts = dir.path().join("known_hosts");
+    fs::write(&known_hosts, format!("github.com ssh-ed25519 {blob}\n")).unwrap();
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "gh", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "gh", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let record: Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join("gh.json")).unwrap()).unwrap();
+    assert_eq!(record["state"], "registered");
+    assert_eq!(record["hostname"], "203.0.113.10");
+}
+
+#[test]
+fn host_key_alias_none_looks_up_resolved_hostname() {
+    let dir = tempfile::tempdir().unwrap();
+    let blob = "AAAAC3NzaC1lZDI1NTE5AAAAITestKeyBlobForHostProfileOne";
+    let g_text = "user ubuntu\nhostname 192.0.2.10\nport 22\nhostkeyalias none\n";
+    let ssh = install_fake_ssh(dir.path(), g_text);
+    let known_hosts = write_known_hosts(dir.path(), blob);
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let record: Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join("lab.json")).unwrap()).unwrap();
+    assert_eq!(record["state"], "registered");
+    assert_eq!(record["hostname"], "192.0.2.10");
+}
+
+#[test]
+fn user_known_hosts_file_from_ssh_g_is_searched() {
+    let dir = tempfile::tempdir().unwrap();
+    let blob = "AAAAC3NzaC1lZDI1NTE5AAAAITestKeyBlobForHostProfileOne";
+    let custom = dir.path().join("custom_known_hosts");
+    fs::write(&custom, format!("192.0.2.10 ssh-ed25519 {blob}\n")).unwrap();
+    let g_text = format!(
+        "user ubuntu\nhostname 192.0.2.10\nport 22\nuserknownhostsfile {}\n",
+        custom.display()
+    );
+    let ssh = install_fake_ssh(dir.path(), &g_text);
+    let (ok, stdout, stderr) = run_host_profile_without_known_hosts_env(
+        dir.path(),
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let (ok, stdout, stderr) = run_host_profile_without_known_hosts_env(
+        dir.path(),
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+}
+
+#[test]
+fn wildcard_revoked_known_hosts_blocks_register() {
+    let dir = tempfile::tempdir().unwrap();
+    let blob = "AAAAC3NzaC1lZDI1NTE5AAAAITestKeyBlobForHostProfileOne";
+    let g_text = "user ubuntu\nhostname api.example.com\nport 22\n";
+    let ssh = install_fake_ssh(dir.path(), g_text);
+    let known_hosts = dir.path().join("known_hosts");
+    fs::write(
+        &known_hosts,
+        format!("@revoked *.example.com ssh-ed25519 {blob}\napi.example.com ssh-ed25519 {blob}\n"),
+    )
+    .unwrap();
+    let (ok, stdout, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "check", "lab", "--json"],
+    );
+    assert!(ok, "stderr={stderr} stdout={stdout}");
+    let value: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(value["state"], "blocked");
+    let (ok, _, stderr) = run_host_profile(
+        dir.path(),
+        &known_hosts,
+        &ssh,
+        &["host-profile", "register", "lab", "--json"],
+    );
+    assert!(!ok);
+    assert!(
+        stderr.contains("revoked") || stderr.contains("register is not allowed"),
+        "stderr={stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add rust-direct `winsmux host-profile <check|register|status> <alias>` so OpenSSH aliases get a separate non-secret local trust record.
- `ssh -G -- <alias>` is the only resolver. First-seen is `pending`; only `register` promotes. Changed or ambiguous fingerprints go `blocked` and cannot register.
- `known_hosts` is read-only. Records live under `%LOCALAPPDATA%\winsmux\host-profiles\`. No password, passphrase, private key, or identityfile.

## Surface Classification

- [x] Public product surface
- [ ] Runtime contract surface
- [x] Contributor/test surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Responsibility And Cutover

- Replaced behavior, workflow, config path, or responsibility: none. New CLI next to `provider-capabilities`. Not a PowerShell bridge command. Not a desktop companion argv head.
- Expected outcome: HostProfile check/register/status without SSH sessions, PTYs, or OpenSSH file writes.
- Source of truth: OpenSSH `ssh -G` for alias resolution; winsmux JSON records for trust state.
- Old paths preserved, redirected, deprecated, or removed: VT-bridge `ssh.exe` detection and loopback psmux TCP are unchanged. TASK-770 skip stays.

## Verification

- `cargo test --test host_profile`: 11 passed / 0 failed
- Independent product review: mothership Sol `01a02a55` REQUEST_CHANGES (four P1s)
- Increment review: mothership Terra APPROVE, those P1s closed
- Plan review: Sol `01a02a46` APPROVE

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.

Rollback: revert the `main.rs` arm/`mod` and `Cargo.toml` `[[test]]`, delete the two new files. Leftover HostProfile records are inert. OpenSSH files are never written.

tag / npm はこの PR の仕事ではない。
