### PR TITLE
feat(cli): add isolated winsmux-remote-helper stdio protocol (TASK-772)

### DIFF
--- a/.githooks/pre-commit-whitelist.ps1
+++ b/.githooks/pre-commit-whitelist.ps1
@@ -24,6 +24,7 @@ $whitelistPatterns = @(
     'core/src/*.rs',
     'core/src/bin/*.rs',
     'core/tests-rs/*.rs',
+    'core/crates/winsmux-remote-helper/**',
     'git-graph/**',
     '.github/workflows/test.yml',
     '.github/ISSUE_TEMPLATE/**',

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1902,6 +1902,15 @@ dependencies = [
  "vt100-winsmux",
  "which",
  "windows-sys",
+ "winsmux-remote-helper",
+]
+
+[[package]]
+name = "winsmux-remote-helper"
+version = "0.36.36"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -135,6 +135,14 @@ windows-sys = { version = "0.61", features = [
 name = "winsmux"
 path = "src/bin/winsmux.rs"
 
+[[bin]]
+name = "winsmux-remote-helper"
+path = "crates/winsmux-remote-helper/src/main.rs"
+
+[[test]]
+name = "remote_helper_protocol"
+path = "crates/winsmux-remote-helper/tests/protocol.rs"
+
 [dependencies]
 ratatui = "0.30"
 crossterm = "0.29"
@@ -152,6 +160,7 @@ sha2 = "0.10"
 regex = "1"
 glob = "0.3"
 rusqlite = { version = "0.32", features = ["bundled"] }
+winsmux-remote-helper = { path = "crates/winsmux-remote-helper" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/core/crates/winsmux-remote-helper/Cargo.toml
+++ b/core/crates/winsmux-remote-helper/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "winsmux-remote-helper"
+version = "0.36.36"
+edition = "2021"
+publish = false
+license = "Apache-2.0 AND MIT"
+description = "stdio remote-helper protocol for winsmux (Hello/Welcome/Reject only)"
+
+[[bin]]
+name = "winsmux-remote-helper"
+path = "src/main.rs"
+
+[dependencies]
+serde = { version = "=1.0.228", features = ["derive"] }
+serde_json = "=1.0.149"

--- a/core/crates/winsmux-remote-helper/src/lib.rs
+++ b/core/crates/winsmux-remote-helper/src/lib.rs
@@ -1,0 +1,331 @@
+//! Length-prefixed stdio protocol for `winsmux-remote-helper`.
+//!
+//! TASK-772 first PR. No SSH, PTY, filesystem, network, or host mutation.
+
+use serde::{Deserialize, Serialize};
+use std::io::{self, Read, Write};
+
+/// Payload-byte ceiling. Pinned by `measured_max_payloads` to the largest
+/// production encoding of a legal Hello, Welcome, or Reject. No extra margin.
+pub const MAX_FRAME_LEN: u32 = 523;
+pub const PROTOCOL_VERSION: u16 = 1;
+pub const PREFIX_LEN: usize = 4;
+pub const MAX_CLIENT_VERSION_BYTES: usize = 64;
+pub const NONCE_LEN: usize = 32;
+pub const NONCE_HEX_LEN: usize = NONCE_LEN * 2;
+pub const MAX_CAPABILITY_LEN: usize = 32;
+pub const MAX_CAPABILITIES: usize = 8;
+pub const MAX_REJECT_DETAIL_BYTES: usize = 128;
+pub const SUPPORTED_CAPABILITIES: [&str; 1] = ["frame-v1"];
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum Message {
+    Hello {
+        protocol_version: u16,
+        client_version: String,
+        nonce: String,
+        capabilities: Vec<String>,
+        peer_frame_limit: u32,
+    },
+    Welcome {
+        protocol_version: u16,
+        nonce: String,
+        capabilities: Vec<String>,
+        peer_frame_limit: u32,
+    },
+    Reject {
+        code: RejectCode,
+        detail: String,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RejectCode {
+    VersionMismatch,
+    UnknownType,
+    Malformed,
+    Oversized,
+    PeerLimit,
+}
+
+#[derive(Debug)]
+pub struct ProtocolError(pub Message);
+
+impl Message {
+    pub fn reject(code: RejectCode, detail: impl Into<String>) -> Self {
+        Message::Reject {
+            code,
+            detail: truncate_detail(detail.into()),
+        }
+    }
+}
+
+pub fn encode_payload(message: &Message) -> Result<Vec<u8>, serde_json::Error> {
+    serde_json::to_vec(message)
+}
+
+pub fn encode_frame(message: &Message) -> io::Result<Vec<u8>> {
+    let payload = encode_payload(message).map_err(|error| {
+        io::Error::new(io::ErrorKind::InvalidData, error)
+    })?;
+    if payload.len() > MAX_FRAME_LEN as usize {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "encoded payload exceeds MAX_FRAME_LEN",
+        ));
+    }
+    let mut frame = Vec::with_capacity(PREFIX_LEN + payload.len());
+    frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    frame.extend_from_slice(&payload);
+    Ok(frame)
+}
+
+pub fn write_frame<W: Write>(writer: &mut W, message: &Message) -> io::Result<()> {
+    writer.write_all(&encode_frame(message)?)?;
+    writer.flush()
+}
+
+/// Read one frame. Oversized prefixes reject without reading or allocating the payload.
+pub fn read_frame<R: Read>(reader: &mut R) -> io::Result<Result<Vec<u8>, Message>> {
+    let mut prefix = [0u8; PREFIX_LEN];
+    match reader.read_exact(&mut prefix) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => {
+            return Err(error);
+        }
+        Err(error) => return Err(error),
+    }
+    let declared = u32::from_be_bytes(prefix);
+    if declared > MAX_FRAME_LEN {
+        return Ok(Err(Message::reject(
+            RejectCode::Oversized,
+            "frame payload larger than MAX_FRAME_LEN",
+        )));
+    }
+    if declared == 0 {
+        return Ok(Err(Message::reject(
+            RejectCode::Malformed,
+            "frame payload length is zero",
+        )));
+    }
+    let mut payload = vec![0u8; declared as usize];
+    if let Err(error) = reader.read_exact(&mut payload) {
+        if error.kind() == io::ErrorKind::UnexpectedEof {
+            return Ok(Err(Message::reject(
+                RejectCode::Malformed,
+                "truncated frame payload",
+            )));
+        }
+        return Err(error);
+    }
+    Ok(Ok(payload))
+}
+
+pub fn decode_payload(payload: &[u8]) -> Result<Message, Message> {
+    let value: serde_json::Value = serde_json::from_slice(payload).map_err(|_| {
+        Message::reject(RejectCode::Malformed, "payload is not JSON")
+    })?;
+    let Some(kind) = value.get("type").and_then(serde_json::Value::as_str) else {
+        return Err(Message::reject(
+            RejectCode::Malformed,
+            "payload type is missing",
+        ));
+    };
+    match kind {
+        "hello" | "welcome" | "reject" => {}
+        _ => {
+            return Err(Message::reject(
+                RejectCode::UnknownType,
+                format!("unknown type '{kind}'"),
+            ));
+        }
+    }
+    serde_json::from_value(value).map_err(|_| {
+        Message::reject(RejectCode::Malformed, "payload fields are invalid")
+    })
+}
+
+pub fn negotiate(hello: &Message) -> Message {
+    let Message::Hello {
+        protocol_version,
+        client_version,
+        nonce,
+        capabilities,
+        peer_frame_limit,
+    } = hello
+    else {
+        return Message::reject(RejectCode::UnknownType, "first frame must be hello");
+    };
+    if *protocol_version != PROTOCOL_VERSION {
+        return Message::reject(
+            RejectCode::VersionMismatch,
+            format!("unsupported protocol_version {protocol_version}"),
+        );
+    }
+    if !client_version_is_legal(client_version) {
+        return Message::reject(RejectCode::Malformed, "client_version is illegal");
+    }
+    if !nonce_is_legal(nonce) {
+        return Message::reject(RejectCode::Malformed, "nonce must be 32-byte hex");
+    }
+    if capabilities.len() > MAX_CAPABILITIES
+        || capabilities
+            .iter()
+            .any(|item| item.is_empty() || item.len() > MAX_CAPABILITY_LEN || !capability_is_legal(item))
+    {
+        return Message::reject(RejectCode::Malformed, "capabilities are illegal");
+    }
+    let selected: Vec<String> = SUPPORTED_CAPABILITIES
+        .iter()
+        .filter(|supported| capabilities.iter().any(|item| item == *supported))
+        .map(|item| (*item).to_string())
+        .collect();
+    let welcome = Message::Welcome {
+        protocol_version: PROTOCOL_VERSION,
+        nonce: nonce.clone(),
+        capabilities: selected,
+        peer_frame_limit: MAX_FRAME_LEN,
+    };
+    let welcome_len = encode_payload(&welcome)
+        .map(|payload| payload.len() as u32)
+        .unwrap_or(u32::MAX);
+    if *peer_frame_limit < welcome_len {
+        return Message::reject(
+            RejectCode::PeerLimit,
+            "peer_frame_limit cannot carry Welcome",
+        );
+    }
+    welcome
+}
+
+pub fn respond_after_negotiation(payload: &[u8]) -> Message {
+    match decode_payload(payload) {
+        Ok(Message::Hello { .. }) => {
+            Message::reject(RejectCode::UnknownType, "hello is not accepted after Welcome")
+        }
+        Ok(Message::Welcome { .. }) => {
+            Message::reject(RejectCode::UnknownType, "welcome is not accepted from the peer")
+        }
+        Ok(Message::Reject { .. }) => Message::reject(
+            RejectCode::UnknownType,
+            "reject is not an accepted follow-on type",
+        ),
+        Err(reject) => reject,
+    }
+}
+
+pub fn serve_stdio<R: Read, W: Write>(mut reader: R, mut writer: W) -> io::Result<()> {
+    let first = match read_frame(&mut reader)? {
+        Ok(payload) => payload,
+        Err(reject) => {
+            write_frame(&mut writer, &reject)?;
+            return Ok(());
+        }
+    };
+    let reply = match decode_payload(&first) {
+        Ok(message) => negotiate(&message),
+        Err(reject) => reject,
+    };
+    write_frame(&mut writer, &reply)?;
+    if !matches!(reply, Message::Welcome { .. }) {
+        return Ok(());
+    }
+    loop {
+        match read_frame(&mut reader) {
+            Ok(Ok(payload)) => {
+                write_frame(&mut writer, &respond_after_negotiation(&payload))?;
+            }
+            Ok(Err(reject)) => {
+                write_frame(&mut writer, &reject)?;
+                if matches!(
+                    reject,
+                    Message::Reject {
+                        code: RejectCode::Oversized,
+                        ..
+                    }
+                ) {
+                    return Ok(());
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(()),
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+pub fn max_legal_hello() -> Message {
+    Message::Hello {
+        protocol_version: PROTOCOL_VERSION,
+        client_version: "c".repeat(MAX_CLIENT_VERSION_BYTES),
+        nonce: "ab".repeat(NONCE_LEN),
+        capabilities: (0..MAX_CAPABILITIES)
+            .map(|index| format!("{:0width$}", index, width = MAX_CAPABILITY_LEN))
+            .collect(),
+        peer_frame_limit: u32::MAX,
+    }
+}
+
+pub fn max_legal_welcome() -> Message {
+    Message::Welcome {
+        protocol_version: PROTOCOL_VERSION,
+        nonce: "cd".repeat(NONCE_LEN),
+        capabilities: SUPPORTED_CAPABILITIES
+            .iter()
+            .map(|item| (*item).to_string())
+            .collect(),
+        peer_frame_limit: MAX_FRAME_LEN,
+    }
+}
+
+pub fn max_legal_reject() -> Message {
+    Message::reject(RejectCode::Malformed, "d".repeat(MAX_REJECT_DETAIL_BYTES))
+}
+
+fn nonce_is_legal(nonce: &str) -> bool {
+    nonce.len() == NONCE_HEX_LEN && nonce.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn capability_is_legal(item: &str) -> bool {
+    item.bytes()
+        .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
+fn client_version_is_legal(client_version: &str) -> bool {
+    let len = client_version.len();
+    len > 0
+        && len <= MAX_CLIENT_VERSION_BYTES
+        && client_version
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+}
+
+fn truncate_detail(detail: String) -> String {
+    if detail.len() <= MAX_REJECT_DETAIL_BYTES {
+        return detail;
+    }
+    let mut end = MAX_REJECT_DETAIL_BYTES;
+    while end > 0 && !detail.is_char_boundary(end) {
+        end -= 1;
+    }
+    detail[..end].to_string()
+}
+
+#[cfg(test)]
+mod measure {
+    use super::*;
+
+    #[test]
+    fn measured_max_payloads() {
+        let hello = encode_payload(&max_legal_hello()).unwrap().len() as u32;
+        let welcome = encode_payload(&max_legal_welcome()).unwrap().len() as u32;
+        let reject = encode_payload(&max_legal_reject()).unwrap().len() as u32;
+        let measured = hello.max(welcome).max(reject);
+        assert_eq!(
+            (hello, welcome, reject, measured, MAX_FRAME_LEN),
+            (hello, welcome, reject, measured, measured),
+            "re-pin MAX_FRAME_LEN to the measured max payload"
+        );
+    }
+}

--- a/core/crates/winsmux-remote-helper/src/main.rs
+++ b/core/crates/winsmux-remote-helper/src/main.rs
@@ -1,0 +1,19 @@
+use std::io::{self, Write};
+use std::process::ExitCode;
+use winsmux_remote_helper::serve_stdio;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.as_slice() != ["serve", "--stdio"] {
+        let _ = writeln!(
+            io::stderr(),
+            "usage: winsmux-remote-helper serve --stdio"
+        );
+        return ExitCode::from(2);
+    }
+    if let Err(error) = serve_stdio(io::stdin().lock(), io::stdout().lock()) {
+        let _ = writeln!(io::stderr(), "{error}");
+        return ExitCode::from(1);
+    }
+    ExitCode::SUCCESS
+}

--- a/core/crates/winsmux-remote-helper/tests/protocol.rs
+++ b/core/crates/winsmux-remote-helper/tests/protocol.rs
@@ -1,0 +1,372 @@
+use std::io::{Cursor, Read};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use winsmux_remote_helper::{
+    decode_payload, encode_frame, encode_payload, max_legal_hello, max_legal_reject,
+    max_legal_welcome, read_frame, respond_after_negotiation, serve_stdio, Message, RejectCode,
+    MAX_FRAME_LEN, PREFIX_LEN, PROTOCOL_VERSION,
+};
+
+struct CountingReader {
+    inner: Cursor<Vec<u8>>,
+    payload_bytes_read: AtomicUsize,
+}
+
+impl CountingReader {
+    fn new(bytes: Vec<u8>) -> Self {
+        Self {
+            inner: Cursor::new(bytes),
+            payload_bytes_read: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl Read for CountingReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        if self.inner.position() > PREFIX_LEN as u64 {
+            self.payload_bytes_read.fetch_add(n, Ordering::SeqCst);
+        }
+        Ok(n)
+    }
+}
+
+fn helper_bin() -> PathBuf {
+    env!("CARGO_BIN_EXE_winsmux-remote-helper").into()
+}
+
+fn nonce() -> String {
+    "aa".repeat(32)
+}
+
+fn hello_with_caps(capabilities: Vec<String>, peer_frame_limit: u32) -> Message {
+    Message::Hello {
+        protocol_version: PROTOCOL_VERSION,
+        client_version: "winsmux-test".to_string(),
+        nonce: nonce(),
+        capabilities,
+        peer_frame_limit,
+    }
+}
+
+fn hello(peer_frame_limit: u32) -> Message {
+    hello_with_caps(vec!["frame-v1".to_string()], peer_frame_limit)
+}
+
+fn frame_with_declared_len(declared: u32, payload: &[u8]) -> Vec<u8> {
+    let mut bytes = Vec::from(declared.to_be_bytes());
+    bytes.extend_from_slice(payload);
+    bytes
+}
+
+#[test]
+fn oversized_after_welcome_stops_without_reading_payload_as_frames() {
+    let mut stream = encode_frame(&hello(MAX_FRAME_LEN)).unwrap();
+    let declared = MAX_FRAME_LEN + 1;
+    stream.extend_from_slice(&declared.to_be_bytes());
+    stream.extend_from_slice(&vec![0u8; declared as usize]);
+    let mut output = Vec::new();
+    serve_stdio(Cursor::new(stream), &mut output).unwrap();
+    let mut cursor = Cursor::new(output);
+    let welcome = read_frame(&mut cursor).unwrap().expect("welcome");
+    assert!(matches!(
+        decode_payload(&welcome).unwrap(),
+        Message::Welcome { .. }
+    ));
+    let reject = read_frame(&mut cursor).unwrap().expect("oversized");
+    match decode_payload(&reject).unwrap() {
+        Message::Reject { code, .. } => assert_eq!(code, RejectCode::Oversized),
+        other => panic!("expected Oversized, got {other:?}"),
+    }
+    let eof = read_frame(&mut cursor);
+    assert!(eof.is_err(), "server must stop after Oversized");
+}
+
+#[test]
+fn unknown_type_detail_does_not_panic_on_multibyte_truncate() {
+    let kind = format!("{}é", "a".repeat(113));
+    let json = format!(r#"{{"type":"{kind}","protocol_version":1}}"#);
+    let mut frame = (json.len() as u32).to_be_bytes().to_vec();
+    frame.extend_from_slice(json.as_bytes());
+    let mut output = Vec::new();
+    serve_stdio(Cursor::new(frame), &mut output).unwrap();
+    let payload = read_frame(&mut Cursor::new(output))
+        .unwrap()
+        .expect("reject frame");
+    match decode_payload(&payload).unwrap() {
+        Message::Reject { code, detail } => {
+            assert_eq!(code, RejectCode::UnknownType);
+            assert!(detail.len() <= 128);
+        }
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+#[test]
+fn nul_client_version_is_malformed_not_a_larger_hello() {
+    let mut hello = hello(MAX_FRAME_LEN);
+    if let Message::Hello {
+        client_version, ..
+    } = &mut hello
+    {
+        *client_version = "win\0mux".to_string();
+    }
+    let mut output = Vec::new();
+    serve_stdio(Cursor::new(encode_frame(&hello).unwrap()), &mut output).unwrap();
+    let payload = read_frame(&mut Cursor::new(output))
+        .unwrap()
+        .expect("reject");
+    match decode_payload(&payload).unwrap() {
+        Message::Reject { code, .. } => assert_eq!(code, RejectCode::Malformed),
+        other => panic!("expected Malformed, got {other:?}"),
+    }
+}
+
+#[test]
+fn argv_without_serve_stdio_exits_2() {
+    let status = Command::new(helper_bin())
+        .arg("serve")
+        .status()
+        .expect("spawn helper");
+    assert_eq!(status.code(), Some(2));
+}
+
+#[test]
+fn argv_extra_token_exits_2() {
+    let status = Command::new(helper_bin())
+        .args(["serve", "--stdio", "extra"])
+        .status()
+        .expect("spawn helper");
+    assert_eq!(status.code(), Some(2));
+}
+
+#[test]
+fn capability_intersection_drops_unknown_tokens() {
+    let mut output = Vec::new();
+    serve_stdio(
+        Cursor::new(
+            encode_frame(&hello_with_caps(
+                vec![
+                    "pty-v1".to_string(),
+                    "frame-v1".to_string(),
+                    "scroll-v1".to_string(),
+                ],
+                MAX_FRAME_LEN,
+            ))
+            .unwrap(),
+        ),
+        &mut output,
+    )
+    .unwrap();
+    let payload = read_frame(&mut Cursor::new(output))
+        .unwrap()
+        .expect("welcome frame");
+    match decode_payload(&payload).unwrap() {
+        Message::Welcome { capabilities, .. } => {
+            assert_eq!(capabilities, vec!["frame-v1".to_string()]);
+        }
+        other => panic!("expected Welcome, got {other:?}"),
+    }
+}
+
+#[test]
+fn legal_hello_roundtrip_welcome() {
+    let mut output = Vec::new();
+    serve_stdio(
+        Cursor::new(encode_frame(&hello(MAX_FRAME_LEN)).unwrap()),
+        &mut output,
+    )
+    .unwrap();
+    let payload = read_frame(&mut Cursor::new(output))
+        .unwrap()
+        .expect("welcome frame");
+    match decode_payload(&payload).unwrap() {
+        Message::Welcome {
+            protocol_version,
+            nonce: echoed,
+            capabilities,
+            peer_frame_limit,
+        } => {
+            assert_eq!(protocol_version, PROTOCOL_VERSION);
+            assert_eq!(echoed, nonce());
+            assert_eq!(capabilities, vec!["frame-v1".to_string()]);
+            assert_eq!(peer_frame_limit, MAX_FRAME_LEN);
+        }
+        other => panic!("expected Welcome, got {other:?}"),
+    }
+}
+
+#[test]
+fn version_mismatch_rejects() {
+    let mut hello = hello(MAX_FRAME_LEN);
+    if let Message::Hello {
+        protocol_version, ..
+    } = &mut hello
+    {
+        *protocol_version = 2;
+    }
+    let mut output = Vec::new();
+    serve_stdio(Cursor::new(encode_frame(&hello).unwrap()), &mut output).unwrap();
+    let payload = read_frame(&mut Cursor::new(output))
+        .unwrap()
+        .expect("reject frame");
+    match decode_payload(&payload).unwrap() {
+        Message::Reject { code, .. } => assert_eq!(code, RejectCode::VersionMismatch),
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+#[test]
+fn unknown_type_rejects() {
+    let json = br#"{"type":"pty-start","protocol_version":1}"#;
+    let mut frame = (json.len() as u32).to_be_bytes().to_vec();
+    frame.extend_from_slice(json);
+    let mut output = Vec::new();
+    serve_stdio(Cursor::new(frame), &mut output).unwrap();
+    let payload = read_frame(&mut Cursor::new(output))
+        .unwrap()
+        .expect("reject frame");
+    match decode_payload(&payload).unwrap() {
+        Message::Reject { code, .. } => assert_eq!(code, RejectCode::UnknownType),
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+#[test]
+fn malformed_json_rejects() {
+    let json = b"{not-json";
+    let mut frame = (json.len() as u32).to_be_bytes().to_vec();
+    frame.extend_from_slice(json);
+    let mut output = Vec::new();
+    serve_stdio(Cursor::new(frame), &mut output).unwrap();
+    let payload = read_frame(&mut Cursor::new(output))
+        .unwrap()
+        .expect("reject frame");
+    match decode_payload(&payload).unwrap() {
+        Message::Reject { code, .. } => assert_eq!(code, RejectCode::Malformed),
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+#[test]
+fn truncated_payload_rejects_malformed() {
+    let mut frame = 16u32.to_be_bytes().to_vec();
+    frame.extend_from_slice(b"short");
+    let mut output = Vec::new();
+    serve_stdio(Cursor::new(frame), &mut output).unwrap();
+    let payload = read_frame(&mut Cursor::new(output))
+        .unwrap()
+        .expect("reject frame");
+    match decode_payload(&payload).unwrap() {
+        Message::Reject { code, .. } => assert_eq!(code, RejectCode::Malformed),
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+#[test]
+fn oversized_prefix_does_not_read_payload() {
+    let declared = MAX_FRAME_LEN + 1;
+    let junk = vec![0u8; 64];
+    let mut reader = CountingReader::new(frame_with_declared_len(declared, &junk));
+    let result = read_frame(&mut reader).unwrap();
+    match result {
+        Err(Message::Reject {
+            code: RejectCode::Oversized,
+            ..
+        }) => {}
+        other => panic!("expected Oversized, got {other:?}"),
+    }
+    assert_eq!(reader.payload_bytes_read.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn size_gate_allows_n_minus_one_and_n() {
+    for declared in [MAX_FRAME_LEN - 1, MAX_FRAME_LEN] {
+        let payload = vec![b'x'; declared as usize];
+        let result = read_frame(&mut Cursor::new(frame_with_declared_len(declared, &payload)))
+            .unwrap();
+        assert!(result.is_ok(), "declared {declared} must pass the size gate");
+    }
+}
+
+#[test]
+fn golden_max_payload_lengths() {
+    let hello = encode_payload(&max_legal_hello()).unwrap().len() as u32;
+    let welcome = encode_payload(&max_legal_welcome()).unwrap().len() as u32;
+    let reject = encode_payload(&max_legal_reject()).unwrap().len() as u32;
+    assert_eq!(hello, 523);
+    assert_eq!(welcome, 165);
+    assert_eq!(reject, 176);
+    assert_eq!(hello.max(welcome).max(reject), MAX_FRAME_LEN);
+}
+
+#[test]
+fn follow_on_unknown_type_rejects_after_welcome() {
+    let mut stream = encode_frame(&hello(MAX_FRAME_LEN)).unwrap();
+    let junk = br#"{"type":"exec","cmd":"id"}"#;
+    stream.extend_from_slice(&(junk.len() as u32).to_be_bytes());
+    stream.extend_from_slice(junk);
+    let mut output = Vec::new();
+    serve_stdio(Cursor::new(stream), &mut output).unwrap();
+    let mut cursor = Cursor::new(output);
+    let welcome = read_frame(&mut cursor).unwrap().expect("welcome");
+    assert!(matches!(
+        decode_payload(&welcome).unwrap(),
+        Message::Welcome { .. }
+    ));
+    let reject = read_frame(&mut cursor).unwrap().expect("reject");
+    match decode_payload(&reject).unwrap() {
+        Message::Reject { code, .. } => assert_eq!(code, RejectCode::UnknownType),
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}
+
+#[test]
+fn peer_limit_too_small_rejects_welcome() {
+    let mut output = Vec::new();
+    serve_stdio(Cursor::new(encode_frame(&hello(1)).unwrap()), &mut output).unwrap();
+    let payload = read_frame(&mut Cursor::new(output))
+        .unwrap()
+        .expect("reject");
+    match decode_payload(&payload).unwrap() {
+        Message::Reject { code, .. } => assert_eq!(code, RejectCode::PeerLimit),
+        other => panic!("expected PeerLimit, got {other:?}"),
+    }
+}
+
+#[test]
+fn black_box_binary_hello_welcome() {
+    let mut child = Command::new(helper_bin())
+        .args(["serve", "--stdio"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn helper");
+    {
+        let mut stdin = child.stdin.take().expect("stdin");
+        use std::io::Write;
+        stdin
+            .write_all(&encode_frame(&hello(MAX_FRAME_LEN)).unwrap())
+            .unwrap();
+    }
+    let output = child.wait_with_output().expect("wait helper");
+    assert!(output.status.success());
+    let payload = read_frame(&mut Cursor::new(output.stdout))
+        .unwrap()
+        .expect("welcome");
+    assert!(matches!(
+        decode_payload(&payload).unwrap(),
+        Message::Welcome { .. }
+    ));
+}
+
+#[test]
+fn respond_after_negotiation_rejects_second_hello() {
+    let payload = encode_payload(&hello(MAX_FRAME_LEN)).unwrap();
+    match respond_after_negotiation(&payload) {
+        Message::Reject { code, .. } => assert_eq!(code, RejectCode::UnknownType),
+        other => panic!("expected Reject, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

- Add isolated `winsmux-remote-helper` binary: argv is only `serve --stdio`.
- Length-prefixed JSON Hello/Welcome/Reject. `MAX_FRAME_LEN` is the measured 523-byte max legal payload (no extra margin). Oversized prefixes reject without consuming the payload.
- Not registered through rust-direct `core/src/main.rs`. No SSH, PTY, signing, or host mutation.

## Surface Classification

- [x] Public product surface
- [ ] Runtime contract surface
- [x] Contributor/test surface
- [ ] Generated/runtime artifact not tracked
- [ ] Not sure; reviewer help requested

Reference: [Repository surface policy](../docs/repo-surface-policy.md)

## Responsibility And Cutover

- Replaced behavior, workflow, config path, or responsibility: none. New helper crate and binary only.
- Expected outcome: a peer can negotiate Hello/Welcome or receive typed Reject. There is no session, PTY, or SSH yet.
- Source of truth: helper wire types and golden tests, including measured `MAX_FRAME_LEN`.
- Old paths preserved, redirected, deprecated, or removed: `worker-artifact`, loopback psmux TCP, HostProfile, and rust-direct CLI stay unchanged.

## Verification

- `cargo test --locked -p winsmux-remote-helper`: 1 lib + 18 protocol passed
- Plan review: mothership Sol `01a02a73` APPROVE
- Product review: mothership Sol REQUEST_CHANGES (oversized loop, NUL Hello, truncate panic)
- Increment review: mothership Terra APPROVE, those P1s closed

## Security And Privacy

- [x] No secrets, credentials, private local paths, browser profile paths, account IDs, customer data, or raw private logs are included.
- [x] Security issues are reported through `SECURITY.md`, not this public pull request.
- [x] Rollback is clear for any configuration, automation, release, or routing change.

Rollback: revert this PR. No installation, migration, persisted state, or existing caller.

tag / npm はこの PR の仕事ではない。
